### PR TITLE
Check for user being empty in context

### DIFF
--- a/kubespawner/utils.py
+++ b/kubespawner/utils.py
@@ -74,7 +74,7 @@ def request_maker_kubeconfig():
 
     context = [c for c in config['contexts'] if c['name'] == current_context][0]['context']
     cluster = [c for c in config['clusters'] if c['name'] == context['cluster']][0]['cluster']
-    if 'user' in context:  # Since user accounts aren't strictly required
+    if 'user' in context and context['user']:  # Since user accounts aren't strictly required
         user = [u for u in config['users'] if u['name'] == context['user']][0]['user']
     else:
         user = {}


### PR DESCRIPTION
The `kubectl` command puts in an empty user in the context causing the kubespawner to fail:
```bash
kubectl config set-context default-context --cluster=default-cluster
```

kubepsawner log:
```
    Traceback (most recent call last):
      File "/usr/lib/python3.4/site-packages/jupyterhub/app.py", line 1524, in launch_instance_async
        yield self.initialize(argv)
      File "/usr/lib/python3.4/site-packages/jupyterhub/app.py", line 1315, in initialize
        yield self.init_spawners()
      File "/usr/lib/python3.4/site-packages/jupyterhub/app.py", line 1084, in init_spawners
        self.users[orm_user.id] = user = User(orm_user, self.tornado_settings)
      File "/usr/lib/python3.4/site-packages/jupyterhub/user.py", line 128, in __init__
        config=self.settings.get('config'),
      File "/usr/lib/python3.4/site-packages/kubespawner/spawner.py", line 32, in __init__
        self.request = request_maker()
      File "/usr/lib/python3.4/site-packages/kubespawner/utils.py", line 18, in request_maker
        return request_maker_kubeconfig()
      File "/usr/lib/python3.4/site-packages/kubespawner/utils.py", line 79, in request_maker_kubeconfig
        user = [u for u in config['users'] if u['name'] == context['user']][0]['user']
    IndexError: list index out of range
```

~/.kube/config:
```yaml
apiVersion: v1
clusters:
- cluster:
    server: http://127.0.0.1:8080
  name: default-cluster
contexts:
- context:
    cluster: default-cluster
    user: ""
  name: default-context
current-context: default-context
kind: Config
preferences: {}
users: []
```