### PR TITLE
Make singleuser_uid more configurable

### DIFF
--- a/kubespawner/utils.py
+++ b/kubespawner/utils.py
@@ -5,6 +5,7 @@ import os
 import yaml
 
 from tornado.httpclient import HTTPRequest
+from traitlets import TraitType
 
 
 def request_maker():
@@ -122,3 +123,20 @@ def k8s_url(namespace, kind, name=None):
     if name is not None:
         url_parts.append(name)
     return '/' + '/'.join(url_parts)
+
+
+class Callable(TraitType):
+    """
+    A trait which is callable.
+
+    Classes are callable, as are instances
+    with a __call__() method.
+    """
+
+    info_text = 'a callable'
+
+    def validate(self, obj, value):
+        if callable(value):
+           return value
+        else:
+            self.error(obj, value)


### PR DESCRIPTION
Fixes #26 

With this, and a theoretical authenticator that sets user.id to be a POSIX uid of the user, you can use the following line in your jupyterhub_config.py to run users as their uids (important for NFS file access, mostly):

```python
c.KubeSpawner.singleuser_uid = lambda spawner: spawner.user.id
```

The callable can also be a coroutine, so you can actually perform a remote call (to LDAP or whatever) to find the uid as which the user should be running, and just return that.
