### PR TITLE
Add ability to specify extra labels to set on single-user servers

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -13,6 +13,7 @@ def make_pod_spec(
     env,
     volumes,
     volume_mounts,
+    labels,
     cpu_limit,
     cpu_guarantee,
     mem_limit,
@@ -58,6 +59,8 @@ def make_pod_spec(
         List of dictionaries mapping paths in the container and the volume(
         specified in volumes) that should be mounted on them. See the k8s
         documentaiton for more details
+      - labels:
+        Labels to add to the spawned pod.
       - cpu_limit:
         Float specifying the max number of CPU cores the user's pod is
         allowed to use.
@@ -85,6 +88,7 @@ def make_pod_spec(
         'kind': 'Pod',
         'metadata': {
             'name': name,
+            'labels': labels,
         },
         'spec': {
             'securityContext': pod_security_context,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse, urlunparse
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient
 from tornado.httpclient import HTTPError
-from traitlets import Unicode, List, Integer, Union
+from traitlets import Unicode, List, Integer, Union, Dict
 from jupyterhub.spawner import Spawner
 
 from kubespawner.utils import request_maker, k8s_url, Callable
@@ -162,6 +162,21 @@ class KubeSpawner(Spawner):
         some amount of port mapping is happening.
         """
         return self.hub.server.port
+
+    singleuser_extra_labels = Dict(
+        {},
+        config=True,
+        help="""
+        Extra kubernetes labels to set on the spawned single-user pods.
+
+        The keys and values specified here would be set as labels on the spawned single-user
+        kubernetes pods. The keys and values must both be strings that match the kubernetes
+        label key / value constraints.
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more
+        info on what labels are and why you might want to use them!
+        """
+    )
 
     singleuser_image_spec = Unicode(
         'jupyter/singleuser:latest',
@@ -453,6 +468,7 @@ class KubeSpawner(Spawner):
             self.get_env(),
             self._expand_all(self.volumes) + hack_volumes,
             self._expand_all(self.volume_mounts) + hack_volume_mounts,
+            self.singleuser_extra_labels,
             self.cpu_limit,
             self.cpu_guarantee,
             self.mem_limit,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -23,10 +23,12 @@ def test_make_simplest_pod():
         run_as_uid=None,
         fs_gid=None,
         image_pull_policy='IfNotPresent',
-        image_pull_secret=None
+        image_pull_secret=None,
+        labels={}
     ) == {
         "metadata": {
-            "name": "test"
+            "name": "test",
+            "labels": {},
         },
         "spec": {
             "securityContext": {},
@@ -60,6 +62,63 @@ def test_make_simplest_pod():
         "apiVersion": "v1"
     }
 
+def test_make_labeled_pod():
+    """
+    Test specification of the simplest possible pod specification with labels
+    """
+    assert make_pod_spec(
+        name='test',
+        image_spec='jupyter/singleuser:latest',
+        env={},
+        volumes=[],
+        volume_mounts=[],
+        cmd=['jupyterhub-singleuser'],
+        port=8888,
+        cpu_limit=None,
+        cpu_guarantee=None,
+        mem_limit=None,
+        mem_guarantee=None,
+        run_as_uid=None,
+        fs_gid=None,
+        image_pull_policy='IfNotPresent',
+        image_pull_secret=None,
+        labels={"test": "true"}
+    ) == {
+        "metadata": {
+            "name": "test",
+            "labels": {"test": "true"},
+        },
+        "spec": {
+            "securityContext": {},
+            "imagePullSecrets": [],
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "command": ["jupyterhub-singleuser"],
+                    "ports": [{
+                        "containerPort": 8888
+                    }],
+                    "volumeMounts": [],
+                    "resources": {
+                        "limits": {
+                            "cpu": None,
+                            "memory": None
+                        },
+                        "requests": {
+                            "cpu": None,
+                            "memory": None
+                        }
+                    }
+                }
+            ],
+            "volumes": []
+        },
+        "kind": "Pod",
+        "apiVersion": "v1"
+    }
 
 def test_make_pod_with_image_pull_secrets():
     """
@@ -80,10 +139,12 @@ def test_make_pod_with_image_pull_secrets():
         run_as_uid=None,
         fs_gid=None,
         image_pull_policy='IfNotPresent',
-        image_pull_secret='super-sekrit'
+        image_pull_secret='super-sekrit',
+        labels={}
     ) == {
         "metadata": {
-            "name": "test"
+            "name": "test",
+            "labels": {},
         },
         "spec": {
             "securityContext": {},
@@ -139,10 +200,12 @@ def test_set_pod_uid_fs_gid():
         run_as_uid=1000,
         fs_gid=1000,
         image_pull_policy='IfNotPresent',
-        image_pull_secret=None
+        image_pull_secret=None,
+        labels={}
     ) == {
         "metadata": {
-            "name": "test"
+            "name": "test",
+            "labels": {},
         },
         "spec": {
             "securityContext": {
@@ -200,9 +263,11 @@ def test_make_pod_resources_all():
         image_pull_secret=None,
         run_as_uid=None,
         fs_gid=None,
+        labels={}
     ) == {
         "metadata": {
-            "name": "test"
+            "name": "test",
+            "labels": {},
         },
         "spec": {
             "securityContext": {},
@@ -259,9 +324,11 @@ def test_make_pod_with_env():
         image_pull_secret=None,
         run_as_uid=None,
         fs_gid=None,
+        labels={},
     ) == {
         "metadata": {
-            "name": "test"
+            "name": "test",
+            "labels": {},
         },
         "spec": {
             "securityContext": {},


### PR DESCRIPTION
Useful for accounting and other purposes (such as autoscaling) when
other tools want to identify jupyterhub spawned pods easily