### PR TITLE
specifying command should set args, not command

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -97,7 +97,7 @@ def make_pod_spec(
                 {
                     'name': 'notebook',
                     'image': image_spec,
-                    'command': cmd,
+                    'args': cmd,
                     'imagePullPolicy': image_pull_policy,
                     'ports': [{
                         'containerPort': port,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -39,7 +39,7 @@ def test_make_simplest_pod():
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
-                    "command": ["jupyterhub-singleuser"],
+                    "args": ["jupyterhub-singleuser"],
                     "ports": [{
                         "containerPort": 8888
                     }],
@@ -97,7 +97,7 @@ def test_make_labeled_pod():
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
-                    "command": ["jupyterhub-singleuser"],
+                    "args": ["jupyterhub-singleuser"],
                     "ports": [{
                         "containerPort": 8888
                     }],
@@ -157,7 +157,7 @@ def test_make_pod_with_image_pull_secrets():
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
-                    "command": ["jupyterhub-singleuser"],
+                    "args": ["jupyterhub-singleuser"],
                     "ports": [{
                         "containerPort": 8888
                     }],
@@ -219,7 +219,7 @@ def test_set_pod_uid_fs_gid():
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
-                    "command": ["jupyterhub-singleuser"],
+                    "args": ["jupyterhub-singleuser"],
                     "ports": [{
                         "containerPort": 8888
                     }],
@@ -278,7 +278,7 @@ def test_make_pod_resources_all():
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
-                    "command": ["jupyterhub-singleuser"],
+                    "args": ["jupyterhub-singleuser"],
                     "ports": [{
                         "containerPort": 8888
                     }],
@@ -339,7 +339,7 @@ def test_make_pod_with_env():
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
-                    "command": ["jupyterhub-singleuser"],
+                    "args": ["jupyterhub-singleuser"],
                     "ports": [{
                         "containerPort": 8888
                     }],


### PR DESCRIPTION
- `command` in pod spec sets ENTRYPOINT
- `args` in pod spec sets CMD

we want to set the equivalent of CMD, not ENTRYPOINT

closes #31