### PR TITLE
Use official Kubernetes python client

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -104,7 +104,7 @@ host machine.
 
 This will give you a running JupyterHub that spawns nodes inside the minikube VM! It'll be setup with [DummyAuthenticator](http://github.com/yuvipanda/jupyterhub-dummy-authenticator), so any user + password combo will allow you to log in. You can make changes to the spawner and restart jupyterhub, and rapidly iterate :)
 
-Note for MacOS/OS X: There is some known issues with Curl on MacOS (https://github.com/curl/curl/issues/283)so you might need to set the HttpClient in the `jupyterhub_config.py` like this:
+Note for MacOS/OS X: There is some known issues with Curl on MacOS (https://github.com/curl/curl/issues/283) so you might need to set the HttpClient in the `jupyterhub_config.py` like this:
 
 ```python
 from tornado.simple_httpclient import SimpleAsyncHTTPClient

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -134,12 +134,7 @@ def make_pod_spec(
     port_.name = "notebook-port"
     port_.container_port = port
     notebook_container.ports.append(port_)
-    notebook_container.env = []
-    for key, value in env.items():
-        env_ = V1EnvVar()
-        env_.name = key
-        env_.value = value
-        notebook_container.env.append(env_)
+    notebook_container.env = [V1EnvVar(k, v) for k, v in env.items()]
     notebook_container.args = cmd
     notebook_container.image_pull_policy = image_pull_policy
     notebook_container.resources = V1ResourceRequirements()

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -1,6 +1,28 @@
 """
 Helper methods for generating k8s API objects.
 """
+
+from kubernetes.client import ApiClient
+from kubernetes.client.models.v1_pod import V1Pod
+from kubernetes.client.models.v1_pod_spec import V1PodSpec
+from kubernetes.client.models.v1_object_meta import V1ObjectMeta
+from kubernetes.client.models.v1_pod_security_context import V1PodSecurityContext
+from kubernetes.client.models.v1_local_object_reference import V1LocalObjectReference
+
+from kubernetes.client.models.v1_container import V1Container
+from kubernetes.client.models.v1_container_port import V1ContainerPort
+from kubernetes.client.models.v1_env_var import V1EnvVar
+from kubernetes.client.models.v1_resource_requirements import V1ResourceRequirements
+from kubernetes.client.models.v1_volume import V1Volume
+from kubernetes.client.models.v1_volume_mount import V1VolumeMount
+# from kubernetes.client.models.v1_probe import V1Probe
+# from kubernetes.client.models.v1_http_get_action import V1HTTPGetAction
+
+from kubernetes.client.models.v1_persistent_volume_claim import V1PersistentVolumeClaim
+from kubernetes.client.models.v1_persistent_volume_claim_spec import V1PersistentVolumeClaimSpec
+from kubernetes.client.models.unversioned_label_selector import UnversionedLabelSelector
+
+
 def make_pod_spec(
     name,
     image_spec,
@@ -11,13 +33,15 @@ def make_pod_spec(
     run_as_uid,
     fs_gid,
     env,
+    node_selector,
     volumes,
     volume_mounts,
+    working_dir,
     labels,
     cpu_limit,
     cpu_guarantee,
     mem_limit,
-    mem_guarantee
+    mem_guarantee,
 ):
     """
     Make a k8s pod specification for running a user notebook.
@@ -51,6 +75,8 @@ def make_pod_spec(
         read / write to the volumes mounted.
       - env:
         Dictionary of environment variables.
+      - node_selector:
+        Dictionary to match nodes where to launch the Pods
       - volumes:
         List of dictionaries containing the volumes of various types this pod
         will be using. See k8s documentation about volumes on how to specify
@@ -59,6 +85,8 @@ def make_pod_spec(
         List of dictionaries mapping paths in the container and the volume(
         specified in volumes) that should be mounted on them. See the k8s
         documentaiton for more details
+      - working_dir:
+        String specifying the working directory for the notebook container
       - labels:
         Labels to add to the spawned pod.
       - cpu_limit:
@@ -75,63 +103,98 @@ def make_pod_spec(
         to have access to. String ins loat/int since common suffixes
         are allowed
     """
-    pod_security_context = {}
-    if run_as_uid is not None:
-        pod_security_context['runAsUser'] = int(run_as_uid)
+    api_client = ApiClient()
+
+    pod = V1Pod()
+    pod.kind = "Pod"
+    pod.api_version = "v1"
+
+    pod.metadata = V1ObjectMeta()
+    pod.metadata.name = name
+    pod.metadata.labels = {}
+    pod.metadata.labels.update({"name": name})
+    for key, value in labels.items():
+        pod.metadata.labels.update({key: value})
+    
+
+    pod.spec = V1PodSpec()
+
+    security_context = V1PodSecurityContext()
     if fs_gid is not None:
-        pod_security_context['fsGroup'] = int(fs_gid)
-    image_secret = []
+        security_context.fs_group = int(fs_gid)
+    if run_as_uid is not None:
+        security_context.run_as_user = int(run_as_uid)
+    pod.spec.security_context = security_context
+
     if image_pull_secret is not None:
-        image_secret = [{"name": image_pull_secret}]
-    return {
-        'apiVersion': 'v1',
-        'kind': 'Pod',
-        'metadata': {
-            'name': name,
-            'labels': labels,
-        },
-        'spec': {
-            'securityContext': pod_security_context,
-            "imagePullSecrets": image_secret,
-            'containers': [
-                {
-                    'name': 'notebook',
-                    'image': image_spec,
-                    'args': cmd,
-                    'imagePullPolicy': image_pull_policy,
-                    'ports': [{
-                        'containerPort': port,
-                    }],
-                    'resources': {
-                        'requests': {
-                            # If these are None, it's ok. the k8s API
-                            # seems to interpret that as 'no limit',
-                            # which is what we want.
-                            'memory': mem_guarantee,
-                            'cpu': cpu_guarantee,
-                        },
-                        'limits': {
-                            'memory': mem_limit,
-                            'cpu': cpu_limit,
-                        }
-                    },
-                    'env': [
-                        {'name': k, 'value': v}
-                        for k, v in env.items()
-                    ],
-                    'volumeMounts': volume_mounts
-                }
-            ],
-            'volumes': volumes
-        }
-    }
+        pod.spec.image_pull_secrets = []
+        image_secret = V1LocalObjectReference()
+        image_secret.name = image_pull_secret
+        pod.spec.image_pull_secrets.append(image_secret)
+      
+    if node_selector:
+        pod.spec.node_selector = node_selector
+
+    pod.spec.containers = []
+
+    notebook_container = V1Container()
+    notebook_container.name = "notebook"
+    notebook_container.image = image_spec
+    notebook_container.working_dir = working_dir
+    notebook_container.ports = []
+    port_ = V1ContainerPort()
+    port_.name = "notebook-port"
+    port_.container_port = port
+    notebook_container.ports.append(port_)
+    notebook_container.env = []
+    for key, value in env.items():
+        env_ = V1EnvVar()
+        env_.name = key
+        env_.value = value
+        notebook_container.env.append(env_)
+    notebook_container.args = cmd
+    notebook_container.image_pull_policy = image_pull_policy
+    notebook_container.resources = V1ResourceRequirements()
+    notebook_container.resources.requests = {"cpu": cpu_guarantee, "memory": mem_guarantee}
+    notebook_container.resources.limits = {"cpu": cpu_limit, "memory": mem_limit}
+    # notebook_container.liveness_probe = V1Probe()
+    # notebook_container.liveness_probe.http_get = V1HTTPGetAction()
+    # notebook_container.liveness_probe.http_get.host = "localhost"
+    # notebook_container.liveness_probe.http_get.path = env["JPY_BASE_URL"]
+    # notebook_container.liveness_probe.http_get.port = port
+
+    # Add a hack to ensure that no service accounts are mounted in spawned pods
+    # This makes sure that we don"t accidentally give access to the whole
+    # kubernetes API to the users in the spawned pods.
+    # See https://github.com/kubernetes/kubernetes/issues/16779#issuecomment-157460294
+    hack_volume = V1Volume()
+    hack_volume.name =  "no-api-access-please"
+    hack_volume.empty_dir = {}
+
+    hack_volume_mount = V1VolumeMount()
+    hack_volume_mount.name = "no-api-access-please"
+    hack_volume_mount.mount_path = "/var/run/secrets/kubernetes.io/serviceaccount"
+    hack_volume_mount.read_only = True
+
+    notebook_container.volume_mounts = [hack_volume_mount]
+    for volume_mount in volume_mounts:
+        notebook_container.volume_mounts.append(volume_mount)
+
+    pod.spec.containers.append(notebook_container)
+
+    pod.spec.volumes = [hack_volume]
+    for volume in volumes:
+        pod.spec.volumes.append(volume)
+
+    return api_client.sanitize_for_serialization(pod)
 
 
 def make_pvc_spec(
     name,
     storage_class,
     access_modes,
-    storage
+    storage,
+    volume_match_labels
 ):
     """
     Make a k8s pvc specification for running a user notebook.
@@ -147,21 +210,23 @@ def make_pvc_spec(
       - storage
       The ammount of storage needed for the pvc
     """
-    return {
-        'kind': 'PersistentVolumeClaim',
-        'apiVersion': 'v1',
-        'metadata': {
-            'name': name,
-            'annotations': {
-                'volume.beta.kubernetes.io/storage-class': storage_class
-            }
-        },
-        'spec': {
-            'accessModes': access_modes,
-            'resources': {
-                'requests': {
-                    'storage': storage
-                }
-            }
-        }
-    }
+    api_client = ApiClient()
+
+    pvc = V1PersistentVolumeClaim()
+    pvc.kind = "PersistentVolumeClaim"
+    pvc.api_version = "v1"
+    pvc.metadata = V1ObjectMeta()
+    pvc.metadata.name = name
+    pvc.metadata.annotations = {}
+    if storage_class:
+        pvc.metadata.annotations.update({"volume.beta.kubernetes.io/storage-class": storage_class})
+    pvc.spec = V1PersistentVolumeClaimSpec()
+    pvc.spec.access_modes = access_modes
+    pvc.spec.resources = V1ResourceRequirements()
+    pvc.spec.resources.requests = {"storage": storage}
+    if volume_match_labels:
+        pvc.spec.selector = UnversionedLabelSelector()
+        pvc.spec.selector.match_labels = volume_match_labels
+    
+    return api_client.sanitize_for_serialization(pvc)
+

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -16,7 +16,6 @@ from kubernetes.client.models.v1_resource_requirements import V1ResourceRequirem
 
 from kubernetes.client.models.v1_persistent_volume_claim import V1PersistentVolumeClaim
 from kubernetes.client.models.v1_persistent_volume_claim_spec import V1PersistentVolumeClaimSpec
-from kubernetes.client.models.unversioned_label_selector import UnversionedLabelSelector
 
 
 def make_pod_spec(
@@ -148,9 +147,7 @@ def make_pvc_spec(
     name,
     storage_class,
     access_modes,
-    storage,
-    volume_match_labels
-):
+    storage):
     """
     Make a k8s pvc specification for running a user notebook.
 
@@ -179,9 +176,6 @@ def make_pvc_spec(
     pvc.spec.access_modes = access_modes
     pvc.spec.resources = V1ResourceRequirements()
     pvc.spec.resources.requests = {"storage": storage}
-    if volume_match_labels:
-        pvc.spec.selector = UnversionedLabelSelector()
-        pvc.spec.selector.match_labels = volume_match_labels
     
     return api_client.sanitize_for_serialization(pvc)
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -109,6 +109,8 @@ class KubeSpawner(Spawner):
     ).tag(config=True)
 
     singleuser_working_dir = Unicode(
+        None,
+        allow_none=True,
         help="""
         The working directory were the Notebook server will be started inside the container.
         Defaults to `None` so the working directory will be the one defined in the Dockerfile.

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -109,7 +109,6 @@ class KubeSpawner(Spawner):
     ).tag(config=True)
 
     singleuser_working_dir = Unicode(
-        None,
         help="""
         The working directory were the Notebook server will be started inside the container.
         Defaults to `None` so the working directory will be the one defined in the Dockerfile.

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -444,15 +444,6 @@ class KubeSpawner(Spawner):
         """
     )
 
-    user_storage_match_labels = Dict(
-        help="""
-        The labels used to match the PVC that will be mounted to the user.
-        
-        For example to match the PVC to an existing NFS Persistent Volume use:
-            `{"volume": "jupyter-nfs"}`
-        """
-    )
-
     httpclient_class = Type(
         None,
         config=True,
@@ -545,8 +536,7 @@ class KubeSpawner(Spawner):
             name=self.pvc_name,
             storage_class=self.user_storage_class,
             access_modes=self.user_storage_access_modes,
-            storage=self.user_storage_capacity,
-            volume_match_labels=self.user_storage_match_labels
+            storage=self.user_storage_capacity
         )
 
     @gen.coroutine

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -108,7 +108,7 @@ class KubeSpawner(Spawner):
         """
     ).tag(config=True)
 
-    working_dir = Unicode(
+    singleuser_working_dir = Unicode(
         None,
         help="""
         The working directory were the Notebook server will be started inside the container.
@@ -513,7 +513,7 @@ class KubeSpawner(Spawner):
             env=self.get_env(),
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),
-            working_dir=self.working_dir,
+            working_dir=self.singleuser_working_dir,
             labels=self.singleuser_extra_labels,
             cpu_limit=self.cpu_limit,
             cpu_guarantee=self.cpu_guarantee,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -22,7 +22,6 @@ from kubespawner.objects import make_pod_spec, make_pvc_spec
 class KubeSpawner(Spawner):
     """
     Implement a JupyterHub spawner to spawn pods in a Kubernetes Cluster.
-
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -106,6 +105,26 @@ class KubeSpawner(Spawner):
         Most, including the default, do not. Consult the documentation for your spawner to verify!
 
         If set to None, Kubernetes will start the CMD that is specified in the Docker image being started.
+        """
+    ).tag(config=True)
+
+
+    node_selector = Dict(
+        help="""
+        Thes labels used to match the Nodes where Pods will be launched.
+
+        Default is None and means it will be launched in any available Node.
+        
+        For example to match the Nodes that have a label of `disktype: ssd` use:
+            `{"disktype": "ssd"}`
+        """
+    )
+
+    working_dir = Unicode(
+        "/home",
+        help="""
+        The working directory were the Notebook server will be started inside the container.
+        Defaults to `/home`
         """
     ).tag(config=True)
 
@@ -322,6 +341,7 @@ class KubeSpawner(Spawner):
         for more details.
         """
     )
+
     volumes = List(
         [],
         config=True,
@@ -433,6 +453,15 @@ class KubeSpawner(Spawner):
         """
     )
 
+    user_storage_match_labels = Dict(
+        help="""
+        The labels used to match the PVC that will be mounted to the user.
+        
+        For example to match the PVC to an existing NFS Persistent Volume use:
+            `{"volume": "jupyter-nfs"}`
+        """
+    )
+
     httpclient_class = Type(
         None,
         config=True,
@@ -469,19 +498,6 @@ class KubeSpawner(Spawner):
         """
         Make a pod manifest that will spawn current user's notebook pod.
         """
-        # Add a hack to ensure that no service accounts are mounted in spawned pods
-        # This makes sure that we don't accidentally give access to the whole
-        # kubernetes API to the users in the spawned pods.
-        # See https://github.com/kubernetes/kubernetes/issues/16779#issuecomment-157460294
-        hack_volumes = [{
-            'name': 'no-api-access-please',
-            'emptyDir': {}
-        }]
-        hack_volume_mounts = [{
-            'name': 'no-api-access-please',
-            'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
-            'readOnly': True
-        }]
         if callable(self.singleuser_uid):
             singleuser_uid = yield gen.maybe_future(self.singleuser_uid(self))
         else:
@@ -496,24 +512,26 @@ class KubeSpawner(Spawner):
             real_cmd = self.cmd + self.get_args()
         else:
             real_cmd = None
-
+        
         return make_pod_spec(
-            self.pod_name,
-            self.singleuser_image_spec,
-            self.singleuser_image_pull_policy,
-            self.singleuser_image_pull_secrets,
-            self.port,
-            real_cmd,
-            singleuser_uid,
-            singleuser_fs_gid,
-            self.get_env(),
-            self._expand_all(self.volumes) + hack_volumes,
-            self._expand_all(self.volume_mounts) + hack_volume_mounts,
-            self.singleuser_extra_labels,
-            self.cpu_limit,
-            self.cpu_guarantee,
-            self.mem_limit,
-            self.mem_guarantee,
+            name=self.pod_name,
+            image_spec=self.singleuser_image_spec,
+            image_pull_policy=self.singleuser_image_pull_policy,
+            image_pull_secret=self.singleuser_image_pull_secrets,
+            port=self.port,
+            cmd=real_cmd,
+            run_as_uid=singleuser_uid,
+            fs_gid=singleuser_fs_gid,
+            env=self.get_env(),
+            node_selector=self.node_selector,
+            volumes=self._expand_all(self.volumes),
+            volume_mounts=self._expand_all(self.volume_mounts),
+            working_dir=self.working_dir,
+            labels=self.singleuser_extra_labels,
+            cpu_limit=self.cpu_limit,
+            cpu_guarantee=self.cpu_guarantee,
+            mem_limit=self.mem_limit,
+            mem_guarantee=self.mem_guarantee,
         )
 
     def get_pvc_manifest(self):
@@ -521,12 +539,12 @@ class KubeSpawner(Spawner):
         Make a pvc manifest that will spawn current user's pvc.
         """
         return make_pvc_spec(
-            self.pvc_name,
-            self.user_storage_class,
-            self.user_storage_access_modes,
-            self.user_storage_capacity
+            name=self.pvc_name,
+            storage_class=self.user_storage_class,
+            access_modes=self.user_storage_access_modes,
+            storage=self.user_storage_capacity,
+            volume_match_labels=self.user_storage_match_labels
         )
-
 
     @gen.coroutine
     def get_pod_info(self, pod_name):
@@ -633,7 +651,7 @@ class KubeSpawner(Spawner):
                     headers={'Content-Type': 'application/json'}
                 ))
             except:
-                self.log.info("Pvc " + self.pvc_name + " already exists, so did not create new pvc.")
+                self.log.info("PVC " + self.pvc_name + " already exists, so did not create new pvc.")
 
         # If we run into a 409 Conflict error, it means a pod with the
         # same name already exists. We stop it, wait for it to stop, and
@@ -673,7 +691,7 @@ class KubeSpawner(Spawner):
     @gen.coroutine
     def stop(self, now=False):
         body = {
-            'kind': "DeleteOptions",
+            'kind': 'DeleteOptions',
             'apiVersion': 'v1',
             'gracePeriodSeconds': 0
         }

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -108,23 +108,11 @@ class KubeSpawner(Spawner):
         """
     ).tag(config=True)
 
-
-    node_selector = Dict(
-        help="""
-        Thes labels used to match the Nodes where Pods will be launched.
-
-        Default is None and means it will be launched in any available Node.
-        
-        For example to match the Nodes that have a label of `disktype: ssd` use:
-            `{"disktype": "ssd"}`
-        """
-    )
-
     working_dir = Unicode(
-        "/home",
+        None,
         help="""
         The working directory were the Notebook server will be started inside the container.
-        Defaults to `/home`
+        Defaults to `None` so the working directory will be the one defined in the Dockerfile.
         """
     ).tag(config=True)
 
@@ -523,7 +511,6 @@ class KubeSpawner(Spawner):
             run_as_uid=singleuser_uid,
             fs_gid=singleuser_fs_gid,
             env=self.get_env(),
-            node_selector=self.node_selector,
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),
             working_dir=self.working_dir,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ setup(
     install_requires=[
         'jupyterhub',
         'pyyaml',
-        'pycurl'
+        'pycurl',
+        'kubernetes'
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
         'jupyterhub',
         'pyyaml',
         'pycurl',
-        'kubernetes==1.0.0'
+        'kubernetes==1.*'
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
         'jupyterhub',
         'pyyaml',
         'pycurl',
-        'kubernetes'
+        'kubernetes==1.0.0'
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -379,8 +379,7 @@ def test_make_pvc_simple():
         name='test',
         storage_class='',
         access_modes=[],
-        storage=None,
-        volume_match_labels={"volume": "my-pv"}
+        storage=None
     ) == {
         'kind': 'PersistentVolumeClaim',
         'apiVersion': 'v1',
@@ -395,8 +394,7 @@ def test_make_pvc_simple():
                 'requests': {
                     'storage': None
                 }
-            },
-            'selector': {'matchLabels': {'volume': 'my-pv'} }
+            }
         }
     }
 
@@ -409,8 +407,7 @@ def test_make_resources_all():
         name='test',
         storage_class='gce-standard-storage',
         access_modes=['ReadWriteOnce'],
-        storage='10Gi',
-        volume_match_labels={"volume": "my-pv"}
+        storage='10Gi'
     ) == {
         'kind': 'PersistentVolumeClaim',
         'apiVersion': 'v1',
@@ -426,7 +423,6 @@ def test_make_resources_all():
                 'requests': {
                     'storage': '10Gi'
                 }
-            },
-            'selector': {'matchLabels': {'volume': 'my-pv'} }
+            }
         }
     }

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -44,9 +44,7 @@ def test_make_simplest_pod():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
-                                      'name': 'no-api-access-please',
-                                      'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -59,7 +57,7 @@ def test_make_simplest_pod():
                     }
                 }
             ],
-            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -105,9 +103,7 @@ def test_make_labeled_pod():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
-                                      'name': 'no-api-access-please',
-                                      'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -120,7 +116,7 @@ def test_make_labeled_pod():
                     }
                 }
             ],
-            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -169,9 +165,7 @@ def test_make_pod_with_image_pull_secrets():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
-                                      'name': 'no-api-access-please',
-                                      'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -184,7 +178,7 @@ def test_make_pod_with_image_pull_secrets():
                     }
                 }
             ],
-            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -234,9 +228,7 @@ def test_set_pod_uid_fs_gid():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
-                                      'name': 'no-api-access-please',
-                                      'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -249,7 +241,7 @@ def test_set_pod_uid_fs_gid():
                     }
                 }
             ],
-            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -297,9 +289,7 @@ def test_make_pod_resources_all():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
-                                      'name': 'no-api-access-please',
-                                      'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": 2,
@@ -312,7 +302,7 @@ def test_make_pod_resources_all():
                     }
                 }
             ],
-            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -361,9 +351,7 @@ def test_make_pod_with_env():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
-                                      'name': 'no-api-access-please',
-                                      'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -376,7 +364,7 @@ def test_make_pod_with_env():
                     }
                 }
             ],
-            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -15,6 +15,7 @@ def test_make_simplest_pod():
         volumes=[],
         volume_mounts=[],
         cmd=['jupyterhub-singleuser'],
+        working_dir=None,
         port=8888,
         cpu_limit=None,
         cpu_guarantee=None,
@@ -32,7 +33,6 @@ def test_make_simplest_pod():
         },
         "spec": {
             "securityContext": {},
-            "imagePullSecrets": [],
             "containers": [
                 {
                     "env": [],
@@ -41,9 +41,12 @@ def test_make_simplest_pod():
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
                     "ports": [{
+                        "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    "volumeMounts": [],
+                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
+                                      'name': 'no-api-access-please',
+                                      'readOnly': True}],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -56,7 +59,7 @@ def test_make_simplest_pod():
                     }
                 }
             ],
-            "volumes": []
+            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -73,6 +76,7 @@ def test_make_labeled_pod():
         volumes=[],
         volume_mounts=[],
         cmd=['jupyterhub-singleuser'],
+        working_dir=None,
         port=8888,
         cpu_limit=None,
         cpu_guarantee=None,
@@ -90,7 +94,6 @@ def test_make_labeled_pod():
         },
         "spec": {
             "securityContext": {},
-            "imagePullSecrets": [],
             "containers": [
                 {
                     "env": [],
@@ -99,9 +102,12 @@ def test_make_labeled_pod():
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
                     "ports": [{
+                        "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    "volumeMounts": [],
+                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
+                                      'name': 'no-api-access-please',
+                                      'readOnly': True}],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -114,7 +120,7 @@ def test_make_labeled_pod():
                     }
                 }
             ],
-            "volumes": []
+            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -131,6 +137,7 @@ def test_make_pod_with_image_pull_secrets():
         volumes=[],
         volume_mounts=[],
         cmd=['jupyterhub-singleuser'],
+        working_dir=None,
         port=8888,
         cpu_limit=None,
         cpu_guarantee=None,
@@ -159,9 +166,12 @@ def test_make_pod_with_image_pull_secrets():
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
                     "ports": [{
+                        "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    "volumeMounts": [],
+                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
+                                      'name': 'no-api-access-please',
+                                      'readOnly': True}],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -174,7 +184,7 @@ def test_make_pod_with_image_pull_secrets():
                     }
                 }
             ],
-            "volumes": []
+            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -192,6 +202,7 @@ def test_set_pod_uid_fs_gid():
         volumes=[],
         volume_mounts=[],
         cmd=['jupyterhub-singleuser'],
+        working_dir=None,
         port=8888,
         cpu_limit=None,
         cpu_guarantee=None,
@@ -212,7 +223,6 @@ def test_set_pod_uid_fs_gid():
                 "runAsUser": 1000,
                 "fsGroup": 1000
             },
-            "imagePullSecrets": [],
             "containers": [
                 {
                     "env": [],
@@ -221,9 +231,12 @@ def test_set_pod_uid_fs_gid():
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
                     "ports": [{
+                        "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    "volumeMounts": [],
+                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
+                                      'name': 'no-api-access-please',
+                                      'readOnly': True}],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -236,7 +249,7 @@ def test_set_pod_uid_fs_gid():
                     }
                 }
             ],
-            "volumes": []
+            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -256,11 +269,12 @@ def test_make_pod_resources_all():
         cpu_limit=2,
         cpu_guarantee=1,
         cmd=['jupyterhub-singleuser'],
+        working_dir=None,
         port=8888,
         mem_limit='1Gi',
         mem_guarantee='512Mi',
         image_pull_policy='IfNotPresent',
-        image_pull_secret=None,
+        image_pull_secret="myregistrykey",
         run_as_uid=None,
         fs_gid=None,
         labels={}
@@ -271,7 +285,7 @@ def test_make_pod_resources_all():
         },
         "spec": {
             "securityContext": {},
-            "imagePullSecrets": [],
+            "imagePullSecrets": [{"name": "myregistrykey"}],
             "containers": [
                 {
                     "env": [],
@@ -280,9 +294,12 @@ def test_make_pod_resources_all():
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
                     "ports": [{
+                        "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    "volumeMounts": [],
+                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
+                                      'name': 'no-api-access-please',
+                                      'readOnly': True}],
                     "resources": {
                         "limits": {
                             "cpu": 2,
@@ -295,7 +312,7 @@ def test_make_pod_resources_all():
                     }
                 }
             ],
-            "volumes": []
+            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -315,6 +332,7 @@ def test_make_pod_with_env():
         volumes=[],
         volume_mounts=[],
         cmd=['jupyterhub-singleuser'],
+        working_dir=None,
         port=8888,
         cpu_limit=None,
         cpu_guarantee=None,
@@ -332,7 +350,6 @@ def test_make_pod_with_env():
         },
         "spec": {
             "securityContext": {},
-            "imagePullSecrets": [],
             "containers": [
                 {
                     "env": [{'name': 'TEST_KEY', 'value': 'TEST_VALUE'}],
@@ -341,9 +358,12 @@ def test_make_pod_with_env():
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
                     "ports": [{
+                        "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    "volumeMounts": [],
+                    'volumeMounts': [{'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
+                                      'name': 'no-api-access-please',
+                                      'readOnly': True}],
                     "resources": {
                         "limits": {
                             "cpu": None,
@@ -356,7 +376,7 @@ def test_make_pod_with_env():
                     }
                 }
             ],
-            "volumes": []
+            'volumes': [{'emptyDir': {}, 'name': 'no-api-access-please'}],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -371,14 +391,14 @@ def test_make_pvc_simple():
         name='test',
         storage_class='',
         access_modes=[],
-        storage=None
+        storage=None,
+        volume_match_labels={"volume": "my-pv"}
     ) == {
         'kind': 'PersistentVolumeClaim',
         'apiVersion': 'v1',
         'metadata': {
             'name': 'test',
             'annotations': {
-                'volume.beta.kubernetes.io/storage-class': ''
             }
         },
         'spec': {
@@ -387,7 +407,8 @@ def test_make_pvc_simple():
                 'requests': {
                     'storage': None
                 }
-            }
+            },
+            'selector': {'matchLabels': {'volume': 'my-pv'} }
         }
     }
 
@@ -400,7 +421,8 @@ def test_make_resources_all():
         name='test',
         storage_class='gce-standard-storage',
         access_modes=['ReadWriteOnce'],
-        storage='10Gi'
+        storage='10Gi',
+        volume_match_labels={"volume": "my-pv"}
     ) == {
         'kind': 'PersistentVolumeClaim',
         'apiVersion': 'v1',
@@ -416,6 +438,7 @@ def test_make_resources_all():
                 'requests': {
                     'storage': '10Gi'
                 }
-            }
+            },
+            'selector': {'matchLabels': {'volume': 'my-pv'} }
         }
     }


### PR DESCRIPTION
This PR changes the `objects.py`to use the official [python kubernetes client](https://github.com/kubernetes-incubator/client-python). Hopefully this makes k8s specs creation a little easier by adding a pure python dependency.

This also solves https://github.com/jupyterhub/kubespawner/issues/6 by adding a simple `nodeSelector` to the Pod spec.

I also tried to solve https://github.com/jupyterhub/kubespawner/issues/1 but using `/user/{userid}` as a path for liveliness return a 404 because of Hub redirects or something (not 100% sure) any other ideas on how to check status of the Notebook server?