### PR TITLE
Don't specify 0 for requests / limits when not set

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -104,7 +104,7 @@ def make_pod_spec(
     pod.metadata = V1ObjectMeta()
     pod.metadata.name = name
     pod.metadata.labels = labels.copy()
-    
+
     pod.spec = V1PodSpec()
 
     security_context = V1PodSecurityContext()
@@ -134,8 +134,19 @@ def make_pod_spec(
     notebook_container.args = cmd
     notebook_container.image_pull_policy = image_pull_policy
     notebook_container.resources = V1ResourceRequirements()
-    notebook_container.resources.requests = {"cpu": cpu_guarantee, "memory": mem_guarantee}
-    notebook_container.resources.limits = {"cpu": cpu_limit, "memory": mem_limit}
+
+    notebook_container.resources.requests = {}
+
+    if cpu_guarantee:
+        notebook_container.resources.requests['cpu'] = cpu_guarantee
+    if mem_guarantee:
+        notebook_container.resources.requests['memory'] = mem_guarantee
+
+    notebook_container.resources.limits = {}
+    if cpu_limit:
+        notebook_container.resources.limits['cpu'] = cpu_limit
+    if mem_limit:
+        notebook_container.resources.limits['memory'] = mem_limit
     notebook_container.volume_mounts = volume_mounts
     pod.spec.containers.append(notebook_container)
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -46,14 +46,8 @@ def test_make_simplest_pod():
                     }],
                     'volumeMounts': [],
                     "resources": {
-                        "limits": {
-                            "cpu": None,
-                            "memory": None
-                        },
-                        "requests": {
-                            "cpu": None,
-                            "memory": None
-                        }
+                        "limits": {},
+                        "requests": {}
                     }
                 }
             ],
@@ -105,14 +99,8 @@ def test_make_labeled_pod():
                     }],
                     'volumeMounts': [],
                     "resources": {
-                        "limits": {
-                            "cpu": None,
-                            "memory": None
-                        },
-                        "requests": {
-                            "cpu": None,
-                            "memory": None
-                        }
+                        "limits": {},
+                        "requests": {}
                     }
                 }
             ],
@@ -167,14 +155,8 @@ def test_make_pod_with_image_pull_secrets():
                     }],
                     'volumeMounts': [],
                     "resources": {
-                        "limits": {
-                            "cpu": None,
-                            "memory": None
-                        },
-                        "requests": {
-                            "cpu": None,
-                            "memory": None
-                        }
+                        "limits": {},
+                        "requests": {}
                     }
                 }
             ],
@@ -230,14 +212,8 @@ def test_set_pod_uid_fs_gid():
                     }],
                     'volumeMounts': [],
                     "resources": {
-                        "limits": {
-                            "cpu": None,
-                            "memory": None
-                        },
-                        "requests": {
-                            "cpu": None,
-                            "memory": None
-                        }
+                        "limits": {},
+                        "requests": {}
                     }
                 }
             ],
@@ -354,12 +330,8 @@ def test_make_pod_with_env():
                     'volumeMounts': [],
                     "resources": {
                         "limits": {
-                            "cpu": None,
-                            "memory": None
                         },
                         "requests": {
-                            "cpu": None,
-                            "memory": None
                         }
                     }
                 }


### PR DESCRIPTION
Currently, we seem to set limits / requests to 0 (which is what
None seems to translate to) when they aren't set. This causes problems
when you want to set guarantee but not limit (since limit is now smaller
than guarantee!)