### PR TITLE
Support lifecycle hooks when spawning single-user Notebook server.

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -36,6 +36,7 @@ def make_pod_spec(
     cpu_guarantee,
     mem_limit,
     mem_guarantee,
+    lifecycle_hooks,
 ):
     """
     Make a k8s pod specification for running a user notebook.
@@ -94,6 +95,8 @@ def make_pod_spec(
         String specifying the max amount of RAM the user's pod is guaranteed
         to have access to. String ins loat/int since common suffixes
         are allowed
+      - lifecycle_hooks:
+        Dictionary of lifecycle hooks
     """
     api_client = ApiClient()
 
@@ -133,6 +136,7 @@ def make_pod_spec(
     notebook_container.env = [V1EnvVar(k, v) for k, v in env.items()]
     notebook_container.args = cmd
     notebook_container.image_pull_policy = image_pull_policy
+    notebook_container.lifecycle = lifecycle_hooks
     notebook_container.resources = V1ResourceRequirements()
 
     notebook_container.resources.requests = {}

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -444,6 +444,31 @@ class KubeSpawner(Spawner):
         """
     )
 
+    singleuser_lifecycle_hooks = Dict(
+        {},
+        config=True,
+        help="""
+        Kubernetes lifecycle hooks to set on the spawned single-user pods.
+
+        The keys is name of hooks and there are only two hooks, postStart and preStop.
+        The values are handler of hook which executes by Kubernetes management system when hook is called.
+
+        Below are a sample copied from Kubernetes doc 
+        https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
+
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+          preStop:
+            exec:
+              command: ["/usr/sbin/nginx","-s","quit"]
+
+        See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ for more
+        info on what lifecycle hooks are and why you might want to use them!
+        """
+    )
+
     httpclient_class = Type(
         None,
         config=True,
@@ -526,6 +551,7 @@ class KubeSpawner(Spawner):
             cpu_guarantee=self.cpu_guarantee,
             mem_limit=self.mem_limit,
             mem_guarantee=self.mem_guarantee,
+            lifecycle_hooks=self.singleuser_lifecycle_hooks,
         )
 
     def get_pvc_manifest(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -25,7 +25,8 @@ def test_make_simplest_pod():
         fs_gid=None,
         image_pull_policy='IfNotPresent',
         image_pull_secret=None,
-        labels={}
+        labels={},
+        lifecycle_hooks=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -78,7 +79,8 @@ def test_make_labeled_pod():
         fs_gid=None,
         image_pull_policy='IfNotPresent',
         image_pull_secret=None,
-        labels={"test": "true"}
+        labels={"test": "true"},
+        lifecycle_hooks=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -131,7 +133,8 @@ def test_make_pod_with_image_pull_secrets():
         fs_gid=None,
         image_pull_policy='IfNotPresent',
         image_pull_secret='super-sekrit',
-        labels={}
+        labels={},
+        lifecycle_hooks=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -188,7 +191,8 @@ def test_set_pod_uid_fs_gid():
         fs_gid=1000,
         image_pull_policy='IfNotPresent',
         image_pull_secret=None,
-        labels={}
+        labels={},
+        lifecycle_hooks=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -245,7 +249,8 @@ def test_make_pod_resources_all():
         image_pull_secret="myregistrykey",
         run_as_uid=None,
         fs_gid=None,
-        labels={}
+        labels={},
+        lifecycle_hooks=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -309,6 +314,7 @@ def test_make_pod_with_env():
         run_as_uid=None,
         fs_gid=None,
         labels={},
+        lifecycle_hooks=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -332,6 +338,75 @@ def test_make_pod_with_env():
                         "limits": {
                         },
                         "requests": {
+                        }
+                    }
+                }
+            ],
+            'volumes': [],
+        },
+        "kind": "Pod",
+        "apiVersion": "v1"
+    }
+
+def test_make_pod_with_lifecycle():
+    """
+    Test specification of a pod with lifecycle
+    """
+    assert make_pod_spec(
+        name='test',
+        image_spec='jupyter/singleuser:latest',
+        env={},
+        volumes=[],
+        volume_mounts=[],
+        cmd=['jupyterhub-singleuser'],
+        working_dir=None,
+        port=8888,
+        cpu_limit=None,
+        cpu_guarantee=None,
+        mem_limit=None,
+        mem_guarantee=None,
+        image_pull_policy='IfNotPresent',
+        image_pull_secret=None,
+        run_as_uid=None,
+        fs_gid=None,
+        labels={},
+        lifecycle_hooks={
+            'preStop': {
+                'exec': {
+                    'command': ['/bin/sh', 'test']
+                }
+            }
+        },
+    ) == {
+        "metadata": {
+            "name": "test",
+            "labels": {},
+        },
+        "spec": {
+            "securityContext": {},
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{
+                        "name": "notebook-port",
+                        "containerPort": 8888
+                    }],
+                    'volumeMounts': [],
+                    "resources": {
+                        "limits": {
+                        },
+                        "requests": {
+                        }
+                    },
+                    "lifecycle": {
+                        "preStop": {
+                            "exec": {
+                                "command": ["/bin/sh", "test"]
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Lifecycle hook can be used to preparing or cleanup some resources (e.g. OAuth token, service accounts).