### PR TITLE
support initContainers

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -37,6 +37,7 @@ def make_pod_spec(
     mem_limit,
     mem_guarantee,
     lifecycle_hooks,
+    init_containers,
 ):
     """
     Make a k8s pod specification for running a user notebook.
@@ -97,6 +98,8 @@ def make_pod_spec(
         are allowed
       - lifecycle_hooks:
         Dictionary of lifecycle hooks
+      - init_containers:
+        List of initialization containers belonging to the pod.
     """
     api_client = ApiClient()
 
@@ -154,6 +157,7 @@ def make_pod_spec(
     notebook_container.volume_mounts = volume_mounts
     pod.spec.containers.append(notebook_container)
 
+    pod.spec.init_containers = init_containers
     pod.spec.volumes = volumes
     return api_client.sanitize_for_serialization(pod)
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -469,6 +469,33 @@ class KubeSpawner(Spawner):
         """
     )
 
+    singleuser_init_containers = List(
+        None,
+        config=True,
+        help="""
+        List of initialization containers belonging to the pod.
+
+        This list will be directly added under `initContainers` in the kubernetes pod spec,
+        so you should use the same structure. Each item in the list is container configuration
+        which follows spec at https://kubernetes.io/docs/api-reference/v1.6/#container-v1-core.
+         
+        One usage is disabling access to metadata service from single-user notebook server with configuration below:
+        initContainers:
+        - name: init-iptables
+          image: <image with iptables installed>
+          command: ["iptables", "-A", "OUTPUT", "-p", "tcp", "--dport", "80", "-d", "169.254.169.254", "-j", "DROP"]
+          securityContext:
+            capabilities:
+              add:
+              - NET_ADMIN         
+
+        See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ for more
+        info on what init containers are and why you might want to use them!
+        
+        To user this feature, Kubernetes version must greater than 1.6.
+        """
+    )
+
     httpclient_class = Type(
         None,
         config=True,
@@ -552,6 +579,7 @@ class KubeSpawner(Spawner):
             mem_limit=self.mem_limit,
             mem_guarantee=self.mem_guarantee,
             lifecycle_hooks=self.singleuser_lifecycle_hooks,
+            init_containers=self.singleuser_init_containers,
         )
 
     def get_pvc_manifest(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
         'jupyterhub',
         'pyyaml',
         'pycurl',
-        'kubernetes==1.*'
+        'kubernetes==2.*'
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -27,6 +27,7 @@ def test_make_simplest_pod():
         image_pull_secret=None,
         labels={},
         lifecycle_hooks=None,
+        init_containers=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -81,6 +82,7 @@ def test_make_labeled_pod():
         image_pull_secret=None,
         labels={"test": "true"},
         lifecycle_hooks=None,
+        init_containers=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -135,6 +137,7 @@ def test_make_pod_with_image_pull_secrets():
         image_pull_secret='super-sekrit',
         labels={},
         lifecycle_hooks=None,
+        init_containers=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -193,6 +196,7 @@ def test_set_pod_uid_fs_gid():
         image_pull_secret=None,
         labels={},
         lifecycle_hooks=None,
+        init_containers=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -251,6 +255,7 @@ def test_make_pod_resources_all():
         fs_gid=None,
         labels={},
         lifecycle_hooks=None,
+        init_containers=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -315,6 +320,7 @@ def test_make_pod_with_env():
         fs_gid=None,
         labels={},
         lifecycle_hooks=None,
+        init_containers=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -377,6 +383,7 @@ def test_make_pod_with_lifecycle():
                 }
             }
         },
+        init_containers=None,
     ) == {
         "metadata": {
             "name": "test",
@@ -409,6 +416,88 @@ def test_make_pod_with_lifecycle():
                             }
                         }
                     }
+                }
+            ],
+            'volumes': [],
+        },
+        "kind": "Pod",
+        "apiVersion": "v1"
+    }
+
+
+def test_make_pod_with_init_containers():
+    """
+    Test specification of a pod with initContainers
+    """
+    assert make_pod_spec(
+        name='test',
+        image_spec='jupyter/singleuser:latest',
+        env={},
+        volumes=[],
+        volume_mounts=[],
+        cmd=['jupyterhub-singleuser'],
+        working_dir=None,
+        port=8888,
+        cpu_limit=None,
+        cpu_guarantee=None,
+        mem_limit=None,
+        mem_guarantee=None,
+        image_pull_policy='IfNotPresent',
+        image_pull_secret=None,
+        run_as_uid=None,
+        fs_gid=None,
+        labels={},
+        lifecycle_hooks=None,
+        init_containers=[
+            {
+                'name': 'init-myservice',
+                'image': 'busybox',
+                'command': ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+            },
+            {
+                'name': 'init-mydb',
+                'image': 'busybox',
+                'command': ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']
+            }
+        ],
+    ) == {
+        "metadata": {
+            "name": "test",
+            "labels": {},
+        },
+        "spec": {
+            "securityContext": {},
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{
+                        "name": "notebook-port",
+                        "containerPort": 8888
+                    }],
+                    'volumeMounts': [],
+                    "resources": {
+                        "limits": {
+                        },
+                        "requests": {
+                        }
+                    },
+                }
+            ],
+            "initContainers": [
+                {
+                    "name": "init-myservice",
+                    "image": "busybox",
+                    "command": ["sh", "-c",
+                                "until nslookup myservice; do echo waiting for myservice; sleep 2; done;"]
+                },
+                {
+                    "name": "init-mydb",
+                    "image": "busybox",
+                    "command": ["sh", "-c", "until nslookup mydb; do echo waiting for mydb; sleep 2; done;"]
                 }
             ],
             'volumes': [],


### PR DESCRIPTION
To enable some configuration which notebook user has no permission. One example is disable accessing to metadata service from notebook server.