### PR TITLE
[BREAKING] Don't use {userid} in default pod / claim templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
         'jupyterhub',
         'pyyaml',
         'pycurl',
-        'kubernetes==2.*'
+        'kubernetes==2.*',
+        'escapism',
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],


### PR DESCRIPTION
The reason they existed was because we were earlier sanitizing
the usernames to be pod / PVC names in a lossy fashion, and thus
needed an extra unique identifier (user.id). However, this can
cause some fun problems - such as https://github.com/data-8/infrastructure/blob/master/incidents/2017-02-09-datahub-db-outage.md.
The user id is really the only piece of info that's inherently
generated by the db, and having the db be blown away causes a lot
of problems because we were using {userid}.

This is a breaking Change! If you are using this spawner right
now and using the default naming scheme, you have a couple of options:

If you are not using the PVC autogeneration feature:

1. Delete all user's pods, and have them log back in. This should
   be enough, and everything should just work.
2. (Not recommended) In your jupyterhub_config.py, add:
   c.KubeSpawner.pod_name_template = 'jupyter-{legacy_escaped_username}-{userid}'

   The {legacy-escaped-username} will use the older lossy username
   escaping. It's deprecated, and it'll be removed at a future time.

If you are using the PVC autogeneration feature:

1. Mass rename all the PVCs to match the new names. Usually just getting rid of
   the -{userid} at the end will be enough. If your users have special characters
   in their usernames, you might have to generate the new names with the following
   code:

     safe_username = escapism.escape(self.user.name, safe=safe_chars, escape_char='-').lower()

   and use the new code.
2. (Not recommended) In your jupyterhub_config.py, replace `{username}` in
   c.KubeSpawner.pvc_name_template with `{legacy_escaped_username}`. Note that
   support for this will also be removed at a future version.