### PR TITLE
Use reflector pattern to speed up polls

### DIFF
--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -1,0 +1,138 @@
+import time
+import threading
+
+from traitlets.config import SingletonConfigurable
+from traitlets import Dict, Unicode
+from kubernetes import client, config, watch
+
+
+class PodReflector(SingletonConfigurable):
+    """
+    Local up-to-date copy of a set of kubernetes pods
+    """
+    labels = Dict(
+        {
+            'heritage': 'jupyterhub',
+            'component': 'singleuser-server',
+        },
+        config=True,
+        help="""
+        Labels to reflect onto local cache
+        """
+    )
+
+    namespace = Unicode(
+        None,
+        allow_none=True,
+        help="""
+        Namespace to watch for resources in
+        """
+    )
+
+    pods = Dict(
+        {},
+        help="""
+        Dictionary of pod names to Pod objects.
+
+        This can be directly accessed from multiple threads.
+        """
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Load kubernetes config here, since this is a Singleton and
+        # so this __init__ will be run way before anything else gets run.
+        try:
+            config.load_incluster_config()
+        except config.ConfigException:
+            config.load_kube_config()
+        self.api = client.CoreV1Api()
+
+        # FIXME: Protect against malicious labels?
+        self.label_selector = ','.join(['{}={}'.format(k, v) for k, v in self.labels.items()])
+
+        self.start()
+
+    def _list_and_update(self):
+        """
+        Update current list of pods by doing a full fetch of pod information.
+
+        Overwrites all current pod info.
+        """
+        initial_pods = self.api.list_namespaced_pod(
+            self.namespace,
+            label_selector=self.label_selector
+        )
+        # This is an atomic operation on the dictionary!
+        self.pods = {p.metadata.name: p for p in initial_pods.items}
+
+    def _watch_and_update(self):
+        """
+        Keeps the current list of pods up-to-date
+
+        This method is to be run not on the main thread!
+
+        We first fetch the list of current pods, and store that. Then we
+        register to be notified of changes to those pods, and keep our
+        local store up-to-date based on these notifications.
+
+        We also perform exponential backoff, giving up after we hit 32s
+        wait time. This should protect against network connections dropping
+        and intermittent unavailability of the api-server. Every time we
+        recover from an exception we also do a full fetch, to pick up
+        changes that might've been missed in the time we were not doing
+        a watch.
+
+        Note that we're playing a bit with fire here, by updating a dictionary
+        in this thread while it is probably being read in another thread
+        without using locks! However, dictionary access itself is atomic,
+        and as long as we don't try to mutate them (do a 'fetch / modify /
+        update' cycle on them), we should be ok!
+        """
+        cur_delay = 0.1
+        while True:
+            self.log.info("watching for pods with label selector %s in namespace %s", self.label_selector, self.namespace)
+            try:
+                self._list_and_update()
+                w = watch.Watch()
+                for ev in w.stream(
+                        self.api.list_namespaced_pod,
+                        self.namespace,
+                        label_selector=self.label_selector
+                ):
+                    cur_delay = 0.1
+                    pod = ev['object']
+                    if ev['type'] == 'DELETED':
+                        # This is an atomic delete operation on the dictionary!
+                        self.pods.pop(pod.metadata.name, None)
+                    else:
+                        # This is an atomic operation on the dictionary!
+                        self.pods[pod.metadata.name] = pod
+            except:
+                cur_delay = cur_delay * 2
+                self.log.exception("Error when watching pods, retrying in %ss", cur_delay)
+                time.sleep(cur_delay)
+                if cur_delay > 30:
+                    raise
+                continue
+            finally:
+                w.stop()
+
+    def start(self):
+        """
+        Start the reflection process!
+
+        We'll do a blocking read of all pods first, so that we don't
+        race with any operations that are checking the state of the pod
+        store - such as polls. This should be called only once at the
+        start of program initialization (when the singleton is being created),
+        and not afterwards!
+        """
+        if hasattr(self, 'watch_thread'):
+            raise ValueError('Thread watching for pods is already running')
+
+        self._list_and_update()
+        self.watch_thread = threading.Thread(target=self._watch_and_update)
+        # If the watch_thread is only thread left alive, exit app
+        self.watch_thread.daemon = True
+        self.watch_thread.start()

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -24,143 +24,14 @@ from jupyterhub.traitlets import Command
 from kubernetes.client.models.v1_volume import V1Volume
 from kubernetes.client.models.v1_volume_mount import V1VolumeMount
 from kubernetes.client.rest import ApiException
-from kubernetes import client, config, watch
+from kubernetes import client
 import escapism
 
 from kubespawner.traitlets import Callable
 from kubespawner.utils import request_maker, k8s_url
 from kubespawner.objects import make_pod, make_pvc
+from kubespawner.reflector import PodReflector
 
-class PodReflector(SingletonConfigurable):
-    """
-    Local up-to-date copy of a set of kubernetes pods
-    """
-    labels = Dict(
-        {
-            'heritage': 'jupyterhub',
-            'component': 'singleuser-server',
-        },
-        config=True,
-        help="""
-        Labels to reflect onto local cache
-        """
-    )
-
-    namespace = Unicode(
-        None,
-        allow_none=True,
-        help="""
-        Namespace to watch for resources in
-        """
-    )
-
-    pods = Dict(
-        {},
-        help="""
-        Dictionary of pod names to Pod objects.
-
-        This can be directly accessed from multiple threads.
-        """
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Load kubernetes config here, since this is a Singleton and
-        # so this __init__ will be run way before anything else gets run.
-        try:
-            config.load_incluster_config()
-        except config.ConfigException:
-            config.load_kube_config()
-        self.api = client.CoreV1Api()
-
-        # FIXME: Protect against malicious labels?
-        self.label_selector = ','.join(['{}={}'.format(k, v) for k, v in self.labels.items()])
-
-        self.start()
-
-    def _list_and_update(self):
-        """
-        Update current list of pods by doing a full fetch of pod information.
-
-        Overwrites all current pod info.
-        """
-        initial_pods = self.api.list_namespaced_pod(
-            self.namespace,
-            label_selector=self.label_selector
-        )
-        # This is an atomic operation on the dictionary!
-        self.pods = {p.metadata.name: p for p in initial_pods.items}
-
-    def _watch_and_update(self):
-        """
-        Keeps the current list of pods up-to-date
-
-        This method is to be run not on the main thread!
-
-        We first fetch the list of current pods, and store that. Then we
-        register to be notified of changes to those pods, and keep our
-        local store up-to-date based on these notifications.
-
-        We also perform exponential backoff, giving up after we hit 32s
-        wait time. This should protect against network connections dropping
-        and intermittent unavailability of the api-server. Every time we
-        recover from an exception we also do a full fetch, to pick up
-        changes that might've been missed in the time we were not doing
-        a watch.
-
-        Note that we're playing a bit with fire here, by updating a dictionary
-        in this thread while it is probably being read in another thread
-        without using locks! However, dictionary access itself is atomic,
-        and as long as we don't try to mutate them (do a 'fetch / modify /
-        update' cycle on them), we should be ok!
-        """
-        cur_delay = 0.1
-        while True:
-            self.log.info("watching for pods with label selector %s in namespace %s", self.label_selector, self.namespace)
-            try:
-                self._list_and_update()
-                w = watch.Watch()
-                for ev in w.stream(
-                        self.api.list_namespaced_pod,
-                        self.namespace,
-                        label_selector=self.label_selector
-                ):
-                    cur_delay = 0.1
-                    pod = ev['object']
-                    if ev['type'] == 'DELETED':
-                        # This is an atomic delete operation on the dictionary!
-                        self.pods.pop(pod.metadata.name, None)
-                    else:
-                        # This is an atomic operation on the dictionary!
-                        self.pods[pod.metadata.name] = pod
-            except:
-                cur_delay = cur_delay * 2
-                self.log.exception("Error when watching pods, retrying in %ss", cur_delay)
-                time.sleep(cur_delay)
-                if cur_delay > 30:
-                    raise
-                continue
-            finally:
-                w.stop()
-
-    def start(self):
-        """
-        Start the reflection process!
-
-        We'll do a blocking read of all pods first, so that we don't
-        race with any operations that are checking the state of the pod
-        store - such as polls. This should be called only once at the
-        start of program initialization (when the singleton is being created),
-        and not afterwards!
-        """
-        if hasattr(self, 'watch_thread'):
-            raise ValueError('Thread watching for pods is already running')
-
-        self._list_and_update()
-        self.watch_thread = threading.Thread(target=self._watch_and_update)
-        # If the watch_thread is only thread left alive, exit app
-        self.watch_thread.daemon = True
-        self.watch_thread.start()
 
 class SingletonExecutor(SingletonConfigurable, ThreadPoolExecutor):
     """

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -9,6 +9,7 @@ import json
 import time
 import string
 import threading
+import sys
 from urllib.parse import urlparse, urlunparse
 from concurrent.futures import ThreadPoolExecutor
 import multiprocessing


### PR DESCRIPTION
We need to keep state within JupyterHub about the current running
status of all pods. We were currently doing this by making one
API request per pod every `poll_interval` - this is quite expensive,
and makes jupyterhub's polling scale linearly with number of
total users on the hub. Ideally we want this to be as close to
constant time as possible.

With this commit, we'll instead start an extra thread that'll
perform a 'list and watch' operation on the types of resources
we are interested in, and make sure that it is kept up to date
as atomically as possible (although there might be some lag sometime).
This makes poll be a simple synchronous dictionary access, rather
than a much more complex network poll.

This should make everything much faster - polling was one of the
biggest consumers of network time without this patch, and that
should significantly reduce with this patch.

We also take this opportunity to encode better the conditions
in which the pod is no longer considered running - particularly
when it is in 'Terminating' stage. This was a little bit flaky
before, but is ok now!