### PR TITLE
use resource_version to avoid missing events

### DIFF
--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -94,9 +94,9 @@ class PodReflector(SingletonConfigurable):
         cur_delay = 0.1
         while True:
             self.log.info("watching for pods with label selector %s in namespace %s", self.label_selector, self.namespace)
+            w = watch.Watch()
             try:
                 resource_version = self._list_and_update()
-                w = watch.Watch()
                 for ev in w.stream(
                         self.api.list_namespaced_pod,
                         self.namespace,


### PR DESCRIPTION
We have observed a race missing DELETE events sent before the stream is connected:

1. request deletion of pod X
2. list_and_update shows pod X is running
3. pod X is deleted
4. watch stream is connected

which would result in pod X never being notified that it stopped until the next `list_and_update` call. 

Kubernetes API has a `resource_version` field for exactly this purpose - to hook up a list & watch pair ([ref](http://borismattijssen.github.io/articles/kubernetes-informers-controllers-reflectors-stores).

closes https://github.com/jupyterhub/jupyterhub/issues/1420