### PR TITLE
Handle named-servers functionality enabled by jupyterhub 0.8x

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -150,7 +150,7 @@ class KubeSpawner(Spawner):
     ).tag(config=True)
 
     pod_name_template = Unicode(
-        'jupyter-{username}' + '-{servername}' if servername is not None,
+        'jupyter-{username}' + '-{servername}' if getattr(self, 'name', None) is not None,
         config=True,
         help="""
         Template to use to form the name of user's pods.
@@ -176,7 +176,7 @@ class KubeSpawner(Spawner):
     )
 
     pvc_name_template = Unicode(
-        'claim-{username}' + '-{servername}' if servername is not None,
+        'claim-{username}' + '-{servername}' if getattr(self, 'name', None) is not None,
         config=True,
         help="""
         Template to use to form the name of user's pvc.

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -608,12 +608,12 @@ class KubeSpawner(Spawner):
     def _expand_user_properties(self, template):
         # Make sure username and servername match the restrictions for DNS labels
         safe_chars = set(string.ascii_lowercase + string.digits)
+
         # Set servername based on whether named-server initialised
-        temp_name = getattr(self, 'name', '')
-        if temp_name:
-            server_name = '-' + temp_name
+        if self.name:
+            servername = '-{}'.format(self.name)
         else:
-            server_name = ''
+            servername = ''
 
         legacy_escaped_username = ''.join([s if s in safe_chars else '-' for s in self.user.name.lower()])
         safe_username = escapism.escape(self.user.name, safe=safe_chars, escape_char='-').lower()
@@ -621,7 +621,7 @@ class KubeSpawner(Spawner):
             userid=self.user.id,
             username=safe_username,
             legacy_escape_username=legacy_escaped_username,
-            servername=server_name
+            servername=servername
             )
 
     def _expand_all(self, src):
@@ -663,10 +663,9 @@ class KubeSpawner(Spawner):
             'hub.jupyter.org/username': escapism.escape(self.user.name)
         }
 
-        # check if a named-server servername has been set and if so, extend pod labels.
-        temp_servername = getattr(self, 'name', None)
-        if temp_servername:
-            labels['hub.jupyter.org/servername']=temp_servername
+        if self.name:
+            # FIXME: Make sure this is dns safe?
+            labels['hub.jupyter.org/servername'] = self.name
 
         labels.update(self._expand_all(self.singleuser_extra_labels))
 
@@ -708,9 +707,9 @@ class KubeSpawner(Spawner):
         }
 
         # check if a named-server servername has been set and if so, extend pvc labels.
-        temp_servername = getattr(self, 'name', None)
-        if temp_servername:
-            labels['hub.jupyter.org/servername']=temp_servername
+        if self.name:
+            # FIXME: make sure this is DNS safe?
+            labels['hub.jupyter.org/servername'] = self.name
 
         labels.update(self._expand_all(self.user_storage_extra_labels))
         return make_pvc(

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -586,9 +586,9 @@ class KubeSpawner(Spawner):
         # Make sure username and servername match the restrictions for DNS labels
         safe_chars = set(string.ascii_lowercase + string.digits)
         # Set servername based on whether named-server initialised
-        name = getattr(self, name, '')
-        if name:
-            servername = '-' + name
+        temp_name = getattr(self, name, '')
+        if temp_name:
+            servername = '-' + temp_name
         else:
             servername = ''
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -586,7 +586,7 @@ class KubeSpawner(Spawner):
         # Make sure username and servername match the restrictions for DNS labels
         safe_chars = set(string.ascii_lowercase + string.digits)
         # Set servername based on whether named-server initialised
-        temp_name = getattr(self, name, '')
+        temp_name = getattr(self, 'name', '')
         if temp_name:
             servername = '-' + temp_name
         else:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -594,8 +594,12 @@ class KubeSpawner(Spawner):
 
         legacy_escaped_username = ''.join([s if s in safe_chars else '-' for s in self.user.name.lower()])
         safe_username = escapism.escape(self.user.name, safe=safe_chars, escape_char='-').lower()
-        d = {'username': safe_username, 'servername': server_name}
-        return self.pod_name_template.format(**d)
+        return template.format(
+            userid=self.user.id,
+            username=safe_username,
+            legacy_escape_username=legacy_escaped_username,
+            servername=server_name
+            )
 
     def _expand_all(self, src):
         if isinstance(src, list):

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -861,16 +861,3 @@ class KubeSpawner(Spawner):
                 args[i] = '--hub-api-url="%s"' % (self.accessible_hub_api_url)
                 break
         return args
-
-    def get_env(self):
-        # HACK: This is deprecated, and should be removed soon.
-        # We set these to be compatible with DockerSpawner and earlie KubeSpawner
-        env = super(KubeSpawner, self).get_env()
-        env.update({
-            'JPY_USER': self.user.name,
-            'JPY_COOKIE_NAME': self.server.cookie_name,
-            'JPY_BASE_URL': self.server.base_url,
-            'JPY_HUB_PREFIX': self.hub.server.base_url,
-            'JPY_HUB_API_URL': self.accessible_hub_api_url
-        })
-        return env

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -588,18 +588,14 @@ class KubeSpawner(Spawner):
         # Set servername based on whether named-server initialised
         temp_name = getattr(self, 'name', '')
         if temp_name:
-            servername = '-' + temp_name
+            server_name = '-' + temp_name
         else:
-            servername = ''
+            server_name = ''
 
         legacy_escaped_username = ''.join([s if s in safe_chars else '-' for s in self.user.name.lower()])
         safe_username = escapism.escape(self.user.name, safe=safe_chars, escape_char='-').lower()
-        return template.format(
-            userid=self.user.id,
-            username=safe_username,
-            legacy_escape_username=legacy_escaped_username,
-            servername=servername
-            )
+        d = {'username': safe_username, 'servername': server_name}
+        return self.pod_name_template.format(**d)
 
     def _expand_all(self, src):
         if isinstance(src, list):
@@ -610,18 +606,6 @@ class KubeSpawner(Spawner):
             return self._expand_user_properties(src)
         else:
             return src
-
-    # def determine_servername(self):
-    #     """
-    #     Determine if server being spawned is of type 'default' or 'named-server'.
-    #     From an API perspective, calling POST '/users/:user/server' results in a default server.
-    #     Calling POST '/users/:user/servers/:server_name' results in a named-server
-    #     In the case of the latter, the servername should get integrated into pod and pvc names to ensure uniqueness.
-    #     """
-    #     if getattr(self, 'name', None) is None:
-    #         return getattr(self, 'user.name')
-    #     else:
-    #         return getattr(self, 'name')
 
     @gen.coroutine
     def get_pod_manifest(self):

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -850,8 +850,8 @@ class KubeSpawner(Spawner):
         env = super(KubeSpawner, self).get_env()
         env.update({
             'JPY_USER': self.user.name,
-            'JPY_COOKIE_NAME': self.user.server.cookie_name,
-            'JPY_BASE_URL': self.user.server.base_url,
+            'JPY_COOKIE_NAME': self.server.cookie_name,
+            'JPY_BASE_URL': self.server.base_url,
             'JPY_HUB_PREFIX': self.hub.server.base_url,
             'JPY_HUB_API_URL': self.accessible_hub_api_url
         })

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -653,6 +653,11 @@ class KubeSpawner(Spawner):
             'hub.jupyter.org/username': escapism.escape(self.user.name)
         }
 
+        # check if a named-server servername has been set and if so, extend pod labels.
+        temp_servername = getattr(self, 'name', None)
+        if temp_servername:
+            labels['hub.jupyter.org/servername']=temp_servername
+
         labels.update(self._expand_all(self.singleuser_extra_labels))
 
         return make_pod(
@@ -690,6 +695,11 @@ class KubeSpawner(Spawner):
             'app': 'jupyterhub',
             'hub.jupyter.org/username': escapism.escape(self.user.name)
         }
+
+        # check if a named-server servername has been set and if so, extend pvc labels.
+        temp_servername = getattr(self, 'name', None)
+        if temp_servername:
+            labels['hub.jupyter.org/servername']=temp_servername
 
         labels.update(self._expand_all(self.user_storage_extra_labels))
         return make_pvc(


### PR DESCRIPTION
@yuvipanda @minrk 
This PR isn't working as yet (hence WIP), but adding here for some guidance, as I'm probably doing this in an awkward way.

I extended the `_extend_user_properties` [here](https://github.com/Analect/kubespawner/blob/5fce05901a5127a9bd74829aab4215133b1b48d3/kubespawner/spawner.py#L585-L609), hoping to set a `servername` variable in the case where a named-server has been initialised.

The objective, as per [here](https://github.com/Analect/kubespawner/commit/eeba9e55f00b97ddca34f8381604599c56b29482) was to then use that `servername` to extend 'pod_name_template' and 'pvc_name_template' where appropriate, but I'm clearly doing it in syntactically incorrect way!  ... 

Could either of you set me straight on best achieving this.  Thanks.