### PR TITLE
Bump version + version required for JupyterHub 0.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup, find_packages
 
 setup(
     name='jupyterhub-kubespawner',
-    version='0.6.1',
+    version='0.7',
     install_requires=[
-        'jupyterhub',
+        'jupyterhub>=0.8',
         'pyYAML',
         'kubernetes==3.*',
         'escapism',


### PR DESCRIPTION
I now deem master to require JupyterHub 0.8 minimum!