### PR TITLE
Fix poll() when pod exists but is not running

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -835,7 +835,7 @@ class KubeSpawner(Spawner):
         JupyterHub expects.
         """
         data = self.pod_reflector.pods.get(self.pod_name, None)
-        if data is not None and self.is_pod_running(data):
+        if data is not None:
             return None
 
         return 1


### PR DESCRIPTION
`poll()` should only return 1 if the pod is dead-as-a-doornail,
based on the current JupyterHub interface. However, `is_pod_running()`
only returns True if the pod is in a `Running` state, not (for example)
`ContainerCreating`, which is technically a not-dead state. So we remove it.

On the other hand, the reflector's `_watch_and_update()` function, which
runs as its own thread, and keeps `self.pods` up-to-date. In particular,
as soon as kubernetes reports a `DELETED` event, `watch_and_update()`
removes that pod information from the list of active pods (see
reflector.py:L112). So we're safe to have /just/ the
`if data is not None` check.