### PR TITLE
Fix return value of _build_common_labels

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -709,8 +709,8 @@ class KubeSpawner(Spawner):
         if self.name:
             # FIXME: Make sure this is dns safe?
             labels['hub.jupyter.org/servername'] = self.name
-
-        return labels.update(extra_labels)
+        labels.update(extra_labels)
+        return labels
 
     def _build_pod_labels(self, extra_labels):
         labels = {


### PR DESCRIPTION
The `update` method returns `None`.  This was introduced in https://github.com/jupyterhub/kubespawner/pull/89

PTAL @ktong @yuvipanda @minrk 