### PR TITLE
Bump kubernetes client version to 4.0

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -137,7 +137,7 @@ def make_pod(
     if annotations:
         pod.metadata.annotations = annotations.copy()
 
-    pod.spec = V1PodSpec()
+    pod.spec = V1PodSpec(containers=[])
 
     security_context = V1PodSecurityContext()
     if fs_gid is not None:
@@ -155,7 +155,6 @@ def make_pod(
     if node_selector:
         pod.spec.node_selector = node_selector
 
-    pod.spec.containers = []
     notebook_container = V1Container()
     notebook_container.name = "notebook"
     notebook_container.image = image_spec

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -131,11 +131,11 @@ def make_pod(
     pod.kind = "Pod"
     pod.api_version = "v1"
 
-    pod.metadata = V1ObjectMeta()
-    pod.metadata.name = name
-    pod.metadata.labels = labels.copy()
-    if annotations:
-        pod.metadata.annotations = annotations.copy()
+    pod.metadata = V1ObjectMeta(
+        name=name,
+        labels=labels.copy(),
+        annotations=annotations.copy()
+    )
 
     pod.spec = V1PodSpec(containers=[])
 
@@ -155,20 +155,17 @@ def make_pod(
     if node_selector:
         pod.spec.node_selector = node_selector
 
-    notebook_container = V1Container()
-    notebook_container.name = "notebook"
-    notebook_container.image = image_spec
-    notebook_container.working_dir = working_dir
-    notebook_container.ports = []
-    port_ = V1ContainerPort()
-    port_.name = "notebook-port"
-    port_.container_port = port
-    notebook_container.ports.append(port_)
-    notebook_container.env = [V1EnvVar(k, v) for k, v in env.items()]
-    notebook_container.args = cmd
-    notebook_container.image_pull_policy = image_pull_policy
-    notebook_container.lifecycle = lifecycle_hooks
-    notebook_container.resources = V1ResourceRequirements()
+    notebook_container = V1Container(
+        name='notebook',
+        image=image_spec,
+        working_dir=working_dir,
+        ports=[V1ContainerPort(name='notebook-port', container_port=port)],
+        env=[V1EnvVar(k, v) for k, v in env.items()],
+        args=cmd,
+        image_pull_policy=image_pull_policy,
+        lifecycle=lifecycle_hooks,
+        resources=V1ResourceRequirements()
+    )
 
     if service_account is None:
         # Add a hack to ensure that no service accounts are mounted in spawned pods
@@ -176,15 +173,14 @@ def make_pod(
         # kubernetes API to the users in the spawned pods.
         # Note: We don't simply use `automountServiceAccountToken` here since we wanna be compatible
         # with older kubernetes versions too for now.
-        hack_volume = V1Volume()
-        hack_volume.name =  "no-api-access-please"
-        hack_volume.empty_dir = {}
+        hack_volume = V1Volume(name='no-api-access-please', empty_dir={})
         hack_volumes = [hack_volume]
 
-        hack_volume_mount = V1VolumeMount()
-        hack_volume_mount.name = "no-api-access-please"
-        hack_volume_mount.mount_path = "/var/run/secrets/kubernetes.io/serviceaccount"
-        hack_volume_mount.read_only = True
+        hack_volume_mount = V1VolumeMount(
+            name='no-api-access-please',
+            mount_path="/var/run/secrets/kubernetes.io/serviceaccount",
+            read_only=True
+        )
         hack_volume_mounts = [hack_volume_mount]
 
         # Non-hacky way of not mounting service accounts
@@ -196,9 +192,9 @@ def make_pod(
         pod.spec.service_account_name = service_account
 
     if run_privileged:
-        container_security_context = V1SecurityContext()
-        container_security_context.privileged = True
-        notebook_container.security_context = container_security_context
+        notebook_container.security_context = V1SecurityContext(
+            privileged=True
+        )
 
     notebook_container.resources.requests = {}
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',
-        'kubernetes==3.*',
+        'kubernetes==4.*',
         'escapism',
     ],
     setup_requires=['pytest-runner'],

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -21,6 +21,7 @@ def test_make_simplest_pod():
         "metadata": {
             "name": "test",
             "labels": {},
+            "annotations": {}
         },
         "spec": {
             "securityContext": {},
@@ -64,6 +65,7 @@ def test_make_labeled_pod():
         "metadata": {
             "name": "test",
             "labels": {"test": "true"},
+            "annotations": {}
         },
         "spec": {
             "securityContext": {},
@@ -150,6 +152,7 @@ def test_make_pod_with_image_pull_secrets():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -198,6 +201,7 @@ def test_set_pod_uid_fs_gid():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -244,6 +248,7 @@ def test_run_privileged_container():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -295,6 +300,7 @@ def test_make_pod_resources_all():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -349,6 +355,7 @@ def test_make_pod_with_env():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -400,6 +407,7 @@ def test_make_pod_with_lifecycle():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -464,6 +472,7 @@ def test_make_pod_with_init_containers():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -531,6 +540,7 @@ def test_make_pod_with_extra_container_config():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -592,6 +602,7 @@ def test_make_pod_with_extra_pod_config():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -651,6 +662,7 @@ def test_make_pod_with_extra_containers():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -708,6 +720,7 @@ def test_make_pod_with_extra_resources():
     )) == {
         "metadata": {
             "name": "test",
+            "annotations": {},
             "labels": {},
         },
         "spec": {
@@ -763,8 +776,7 @@ def test_make_pvc_simple():
         'apiVersion': 'v1',
         'metadata': {
             'name': 'test',
-            'annotations': {
-            },
+            'annotations': {},
             'labels': {}
         },
         'spec': {
@@ -827,6 +839,7 @@ def test_make_pod_with_service_account():
         "metadata": {
             "name": "test",
             "labels": {},
+            "annotations": {}
         },
         "spec": {
             "securityContext": {},


### PR DESCRIPTION
There are some performance improvements, and this stops the 
(mostly pointless) warning about 'connection pool full' that confuses
a lot of people.