### PR TITLE
Put usernames as annotations, not labels

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -251,7 +251,7 @@ def make_pvc(
     access_modes,
     storage,
     labels,
-    extra_annotations={}
+    annotations={}
     ):
     """
     Make a k8s pvc specification for running a user notebook.
@@ -273,7 +273,7 @@ def make_pvc(
     pvc.api_version = "v1"
     pvc.metadata = V1ObjectMeta()
     pvc.metadata.name = name
-    pvc.metadata.annotations = extra_annotations
+    pvc.metadata.annotations = annotations
     pvc.metadata.labels = {}
     pvc.metadata.labels.update(labels)
     pvc.spec = V1PersistentVolumeClaimSpec()

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -250,7 +250,8 @@ def make_pvc(
     storage_class,
     access_modes,
     storage,
-    labels
+    labels,
+    extra_annotations={}
     ):
     """
     Make a k8s pvc specification for running a user notebook.
@@ -272,15 +273,17 @@ def make_pvc(
     pvc.api_version = "v1"
     pvc.metadata = V1ObjectMeta()
     pvc.metadata.name = name
-    pvc.metadata.annotations = {}
-    if storage_class:
-        pvc.metadata.annotations.update({"volume.beta.kubernetes.io/storage-class": storage_class})
+    pvc.metadata.annotations = extra_annotations
     pvc.metadata.labels = {}
     pvc.metadata.labels.update(labels)
     pvc.spec = V1PersistentVolumeClaimSpec()
     pvc.spec.access_modes = access_modes
     pvc.spec.resources = V1ResourceRequirements()
     pvc.spec.resources.requests = {"storage": storage}
+
+    if storage_class:
+        pvc.metadata.annotations.update({"volume.beta.kubernetes.io/storage-class": storage_class})
+        pvc.spec.storage_class_name = storage_class
 
     return pvc
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -787,6 +787,7 @@ def test_make_resources_all():
             }
         },
         'spec': {
+            'storageClassName': 'gce-standard-storage',
             'accessModes': ['ReadWriteOnce'],
             'resources': {
                 'requests': {


### PR DESCRIPTION
- Labels aren't very useful here, since it's a very high
  cardinality number
- Labels need escaping, since their values are heavily constrained.
  Annotations do not have this problem
- Add storage_class_name to its proper place in spec rather than just
  as an annotation.

Fixes #97