### PR TITLE
Specify non-hacky way of disabling serviceaccount access

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -170,7 +170,7 @@ def make_pod(
     notebook_container.image_pull_policy = image_pull_policy
     notebook_container.lifecycle = lifecycle_hooks
     notebook_container.resources = V1ResourceRequirements()
-    
+
     if service_account is None:
         # Add a hack to ensure that no service accounts are mounted in spawned pods
         # This makes sure that we don"t accidentally give access to the whole
@@ -187,6 +187,9 @@ def make_pod(
         hack_volume_mount.mount_path = "/var/run/secrets/kubernetes.io/serviceaccount"
         hack_volume_mount.read_only = True
         hack_volume_mounts = [hack_volume_mount]
+
+        # Non-hacky way of not mounting service accounts
+        pod.spec.automount_service_account_token = False
     else:
         hack_volumes = []
         hack_volume_mounts = []

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -24,6 +24,7 @@ def test_make_simplest_pod():
         },
         "spec": {
             "securityContext": {},
+            'automountServiceAccountToken': False,
             "containers": [
                 {
                     "env": [],
@@ -66,6 +67,7 @@ def test_make_labeled_pod():
         },
         "spec": {
             "securityContext": {},
+            'automountServiceAccountToken': False,
             "containers": [
                 {
                     "env": [],
@@ -109,6 +111,7 @@ def test_make_annotated_pod():
         },
         "spec": {
             "securityContext": {},
+            'automountServiceAccountToken': False,
             "containers": [
                 {
                     "env": [],
@@ -151,6 +154,7 @@ def test_make_pod_with_image_pull_secrets():
         },
         "spec": {
             "securityContext": {},
+            'automountServiceAccountToken': False,
             "imagePullSecrets": [
                 {'name': 'super-sekrit'}
             ],
@@ -201,6 +205,7 @@ def test_set_pod_uid_fs_gid():
                 "runAsUser": 1000,
                 "fsGroup": 1000
             },
+            'automountServiceAccountToken': False,
             "containers": [
                 {
                     "env": [],
@@ -243,8 +248,9 @@ def test_run_privileged_container():
         },
         "spec": {
             "securityContext": {},
+            'automountServiceAccountToken': False,
             "containers": [
-                {                    
+                {
                     "env": [],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
@@ -293,6 +299,7 @@ def test_make_pod_resources_all():
         },
         "spec": {
             "securityContext": {},
+            'automountServiceAccountToken': False,
             "imagePullSecrets": [{"name": "myregistrykey"}],
             "nodeSelector": {"disk": "ssd"},
             "containers": [
@@ -345,6 +352,7 @@ def test_make_pod_with_env():
             "labels": {},
         },
         "spec": {
+            'automountServiceAccountToken': False,
             "securityContext": {},
             "containers": [
                 {
@@ -396,6 +404,7 @@ def test_make_pod_with_lifecycle():
         },
         "spec": {
             "securityContext": {},
+            'automountServiceAccountToken': False,
             "containers": [
                 {
                     "env": [],
@@ -458,6 +467,7 @@ def test_make_pod_with_init_containers():
             "labels": {},
         },
         "spec": {
+            'automountServiceAccountToken': False,
             "securityContext": {},
             "containers": [
                 {
@@ -524,6 +534,7 @@ def test_make_pod_with_extra_container_config():
             "labels": {},
         },
         "spec": {
+            'automountServiceAccountToken': False,
             "securityContext": {},
             "containers": [
                 {
@@ -584,6 +595,7 @@ def test_make_pod_with_extra_pod_config():
             "labels": {},
         },
         "spec": {
+            'automountServiceAccountToken': False,
             "securityContext": {},
             "containers": [
                 {
@@ -642,6 +654,7 @@ def test_make_pod_with_extra_containers():
             "labels": {},
         },
         "spec": {
+            'automountServiceAccountToken': False,
             "securityContext": {},
             "containers": [
                 {
@@ -698,6 +711,7 @@ def test_make_pod_with_extra_resources():
             "labels": {},
         },
         "spec": {
+            'automountServiceAccountToken': False,
             "securityContext": {},
             "imagePullSecrets": [{"name": "myregistrykey"}],
             "nodeSelector": {"disk": "ssd"},


### PR DESCRIPTION
This only works on 1.6+, but that's ok. It's a no-op on older
versions.

Also with the previous hacks, if your code had access to
change mounts, it can trivially discover the credentials.