### PR TITLE
Revert "Bump kubespawner version"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jupyterhub-kubespawner',
-    version='0.8',
+    version='0.7.1',
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',


### PR DESCRIPTION
Reverts jupyterhub/kubespawner#124

As of v4, creating an ApiClient object immediately creates a ThreadPool,
which takes up CPU by merely existing. Since we create a lot of those,
it takes up a ton of CPU and stops things from doing real work.

Should fix https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/461