### PR TITLE
pin kubernetes client to 3.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ script:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - python: nightly

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jupyterhub-kubespawner',
-    version='0.7.1',
+    version='0.8.1',
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',
-        'kubernetes==4.*',
+        'kubernetes==3.*',
         'escapism',
     ],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
Reverts kube upgrade in #114 to deal with https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/461

(#125 reverted kubespawner version, not kubernetes version)

bumps kubespawner version to 0.8.1