### PR TITLE
Improve doc build and docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,7 @@ sys.path.insert(0, os.path.join(docs, 'sphinxext'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon',
     'autodoc_traits',
 ]
 
@@ -172,8 +173,6 @@ texinfo_documents = [
      author, 'Kubespawner', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
 
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,9 +7,9 @@ Kubespawner
    :maxdepth: 2
 
    overview.md
+   spawner
    objects
    reflector
-   spawner
    traitlets
    utils
 

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -21,7 +21,7 @@ simultaneous users), Kubernetes is a wonderful way to do it. Features include:
   monitoring and failover for the hub process itself.
 
 * Spawn multiple hubs in the same kubernetes cluster, with support for
-  [namespaces](http://kubernetes.io/docs/admin/namespaces/). You can limit the
+  [namespaces](https://kubernetes.io/docs/tasks/administer-cluster/namespaces/). You can limit the
   amount of resources each namespace can use, effectively limiting the amount
   of resources a single JupyterHub (and its users) can use. This allows
   organizations to easily maintain multiple JupyterHubs with just one
@@ -29,18 +29,19 @@ simultaneous users), Kubernetes is a wonderful way to do it. Features include:
   utilization.
 
 * Provide guarantees and limits on the amount of resources (CPU / RAM) that
-  single-user notebooks can use. Kubernetes has comprehensive [resource control](http://kubernetes.io/docs/user-guide/compute-resources/) that can
+  single-user notebooks can use. Kubernetes has comprehensive [resource control](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) that can
   be used from the spawner.
 
-* Mount various types of [persistent volumes](http://kubernetes.io/docs/user-guide/persistent-volumes/)
+* Mount various types of
+  [persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
   onto the single-user notebook's container.
 
 * Control various security parameters (such as userid/groupid, SELinux, etc)
-  via flexible [Pod Security Policies](http://kubernetes.io/docs/user-guide/pod-security-policy/).
+  via flexible [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
 
 * Run easily in multiple clouds (or on your own machines). Helps avoid vendor
   lock-in. You can even spread out your cluster across
-  [multiple clouds at the same time](http://kubernetes.io/docs/user-guide/federation/).
+  [multiple clouds at the same time](https://kubernetes.io/docs/concepts/cluster-administration/federation/).
 
 In general, Kubernetes provides a ton of well thought out, useful features -
 and you can use all of them along with this spawner.
@@ -51,13 +52,13 @@ and you can use all of them along with this spawner.
 
 Everything should work from Kubernetes v1.2+.
 
-The [Kube DNS addon](http://kubernetes.io/docs/user-guide/connecting-applications/#dns)
+The [Kube DNS addon](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#dns)
 is not strictly required - the spawner uses
-[environment variable](http://kubernetes.io/docs/user-guide/connecting-applications/#environment-variables)
+[environment variable](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables)
 based discovery instead. Your kubernetes cluster will need to be configured to
 support the types of volumes you want to use.
 
 If you are just getting started and want a kubernetes cluster to play with,
-[Google Container Engine](https://cloud.google.com/container-engine/) is
+[Google Container Engine](https://cloud.google.com/kubernetes-engine/) is
 probably the nicest option. For AWS/Azure,
 [kops](https://github.com/kubernetes/kops) is probably the way to go.

--- a/docs/source/reflector.rst
+++ b/docs/source/reflector.rst
@@ -7,11 +7,4 @@ Module: :mod:`kubespawner.reflector`
 
 .. automodule:: kubespawner.reflector
 
-.. currentmodule:: kubespawner.reflector
-
-
-:class:`PodReflector`
----------------------
-
-.. autoconfigurable:: PodReflector
-    :members:
+.. autoclass:: kubespawner.reflector.NamespacedResourceReflector

--- a/docs/source/spawner.rst
+++ b/docs/source/spawner.rst
@@ -8,10 +8,7 @@ Module: :mod:`kubespawner.spawner`
 
 .. automodule:: kubespawner.spawner
 
-.. currentmodule:: kubespawner.spawner
-
 :class:`KubeSpawner`
 --------------------
 
 .. autoconfigurable:: KubeSpawner
-    :members:

--- a/docs/source/traitlets.rst
+++ b/docs/source/traitlets.rst
@@ -6,11 +6,3 @@ Module: :mod:`kubespawner.traitlets`
 ------------------------------------
 
 .. automodule:: kubespawner.traitlets
-
-.. currentmodule:: kubespawner.traitlets
-
-:class:`Callable`
------------------
-
-.. autoclass:: Callable
-    :members:

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -7,12 +7,4 @@ Module: :mod:`kubespawner.utils`
 
 .. automodule:: kubespawner.utils
 
-.. currentmodule:: kubespawner.utils
-
-.. autofunction:: request_maker
-
-.. autofunction:: request_maker_serviceaccount
-
-.. autofunction:: request_maker_kubeconfig
-
-.. autofunction:: k8s_url
+.. autofunction:: kubespawner.utils.generate_hashed_slug

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -53,77 +53,78 @@ def make_pod(
     """
     Make a k8s pod specification for running a user notebook.
 
-    Parameters:
-      - name:
+    Parameters
+    ----------
+    name:
         Name of pod. Must be unique within the namespace the object is
         going to be created in. Must be a valid DNS label.
-      - image_spec:
+    image_spec:
         Image specification - usually a image name and tag in the form
         of image_name:tag. Same thing you would use with docker commandline
         arguments
-      - image_pull_policy:
+    image_pull_policy:
         Image pull policy - one of 'Always', 'IfNotPresent' or 'Never'. Decides
         when kubernetes will check for a newer version of image and pull it when
         running a pod.
-      - image_pull_secret:
+    image_pull_secret:
         Image pull secret - Default is None -- set to your secret name to pull
         from private docker registry.
-      - port:
+    port:
         Port the notebook server is going to be listening on
-      - cmd:
+    cmd:
         The command used to execute the singleuser server.
-      - node_selector:
+    node_selector:
         Dictionary Selector to match nodes where to launch the Pods
-      - run_as_uid:
+    run_as_uid:
         The UID used to run single-user pods. The default is to run as the user
         specified in the Dockerfile, if this is set to None.
-      - fs_gid
+    fs_gid
         The gid that will own any fresh volumes mounted into this pod, if using
         volume types that support this (such as GCE). This should be a group that
         the uid the process is running as should be a member of, so that it can
         read / write to the volumes mounted.
-      - run_privileged:
+    run_privileged:
         Whether the container should be run in privileged mode.
-      - env:
+    env:
         Dictionary of environment variables.
-      - volumes:
+    volumes:
         List of dictionaries containing the volumes of various types this pod
         will be using. See k8s documentation about volumes on how to specify
         these
-      - volume_mounts:
+    volume_mounts:
         List of dictionaries mapping paths in the container and the volume(
         specified in volumes) that should be mounted on them. See the k8s
         documentaiton for more details
-      - working_dir:
+    working_dir:
         String specifying the working directory for the notebook container
-      - labels:
+    labels:
         Labels to add to the spawned pod.
-      - annotations:
+    annotations:
         Annotations to add to the spawned pod.
-      - cpu_limit:
+    cpu_limit:
         Float specifying the max number of CPU cores the user's pod is
         allowed to use.
-      - cpu_guarentee:
+    cpu_guarentee:
         Float specifying the max number of CPU cores the user's pod is
         guaranteed to have access to, by the scheduler.
-      - mem_limit:
+    mem_limit:
         String specifying the max amount of RAM the user's pod is allowed
         to use. String instead of float/int since common suffixes are allowed
-      - mem_guarantee:
+    mem_guarantee:
         String specifying the max amount of RAM the user's pod is guaranteed
         to have access to. String ins loat/int since common suffixes
         are allowed
-      - lifecycle_hooks:
+    lifecycle_hooks:
         Dictionary of lifecycle hooks
-      - init_containers:
+    init_containers:
         List of initialization containers belonging to the pod.
-      - service_account:
+    service_account:
         Service account to mount on the pod. None disables mounting
-      - extra_container_config:
+    extra_container_config:
         Extra configuration (e.g. envFrom) for notebook container which is not covered by parameters above.
-      - extra_pod_config:
+    extra_pod_config:
         Extra configuration (e.g. tolerations) for pod which is not covered by parameters above.
-      - extra_containers:
+    extra_containers:
         Extra containers besides notebook container. Used for some housekeeping jobs (e.g. crontab).
     """
 
@@ -254,15 +255,16 @@ def make_pvc(
     """
     Make a k8s pvc specification for running a user notebook.
 
-    Parameters:
-      - name:
+    Parameters
+    ----------
+    name:
         Name of persistent volume claim. Must be unique within the namespace the object is
         going to be created in. Must be a valid DNS label.
-      - storage_class
+    storage_class:
         String of the name of the k8s Storage Class to use.
-      - access_modes:
+    access_modes:
         A list of specifying what access mode the pod should have towards the pvc
-      - storage
+    storage:
         The ammount of storage needed for the pvc
 
     """

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -646,7 +646,9 @@ class KubeSpawner(Spawner):
         which follows spec at https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#container-v1-core.
 
         One usage is disabling access to metadata service from single-user notebook server with configuration below:
-        initContainers::
+        initContainers:
+
+        .. code::yaml
 
             - name: init-iptables
               image: <image with iptables installed>
@@ -656,6 +658,7 @@ class KubeSpawner(Spawner):
                   add:
                   - NET_ADMIN
 
+        
         See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ for more
         info on what init containers are and why you might want to use them!
 
@@ -667,23 +670,27 @@ class KubeSpawner(Spawner):
         None,
         config=True,
         help="""
-        Extra configuration (e.g. envFrom) for notebook container which is not covered by other attributes.
+        Extra configuration (e.g. ``envFrom``) for notebook container which is not covered by other attributes.
 
         This dict will be directly merge into `container` of notebook server,
         so you should use the same structure. Each item in the dict is field of container configuration
         which follows spec at https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#container-v1-core.
 
-        One usage is set envFrom on notebook container with configuration below:
-        envFrom: [
-            {
-                configMapRef: {
-                    name: special-config
-                }
-            }
-        ]
+        One usage is set ``envFrom`` on notebook container with configuration below:
 
-        The key could be either camelcase word (used by Kubernetes yaml, e.g. envFrom)
-        or underscore-separated word (used by kubernetes python client, e.g. env_from).
+        .. code::yaml
+
+            envFrom: [
+                {
+                    configMapRef: {
+                        name: special-config
+                    }
+                }
+            ]
+
+        The key could be either camelcase word (used by Kubernetes yaml, e.g. ``envFrom``)
+        or underscore-separated word (used by kubernetes python client, e.g. ``env_from``).
+
         """
     )
 
@@ -716,13 +723,16 @@ class KubeSpawner(Spawner):
         which follows spec at https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#container-v1-core.
 
         One usage is setting crontab in a container to clean sensitive data with configuration below:
-        [
-            {
-                'name': 'crontab',
-                'image': 'supercronic',
-                'command': ['/usr/local/bin/supercronic', '/etc/crontab']
-            }
-        ]
+        
+        .. code::yaml
+            [
+                {
+                    'name': 'crontab',
+                    'image': 'supercronic',
+                    'command': ['/usr/local/bin/supercronic', '/etc/crontab']
+                }
+            ]
+        
         """
     )
 
@@ -732,8 +742,9 @@ class KubeSpawner(Spawner):
         help="""
         The dictionary used to request arbitrary resources.
         Default is None and means no additional resources are requested.
-        For example, to request 3 Nvidia GPUs
-            `{"nvidia.com/gpu": "3"}`
+        For example, to request 3 Nvidia GPUs:
+
+            {"nvidia.com/gpu": "3"}
         """
     )
 
@@ -743,8 +754,9 @@ class KubeSpawner(Spawner):
         help="""
         The dictionary used to limit arbitrary resources.
         Default is None and means no additional resources are limited.
-        For example, to add a limit of 3 Nvidia GPUs
-            `{"nvidia.com/gpu": "3"}`
+        For example, to add a limit of 3 Nvidia GPUs:
+
+            {"nvidia.com/gpu": "3"}
         """
     )
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -108,7 +108,7 @@ class KubeSpawner(Spawner):
 
         Increase this if you are dealing with a very large number of users.
 
-        Defaults to '5 * cpu_cores', which is the default for ThreadPoolExecutor.
+        Defaults to `5 * cpu_cores`, which is the default for `ThreadPoolExecutor`.
         """
     )
 
@@ -118,7 +118,7 @@ class KubeSpawner(Spawner):
         Kubernetes namespace to spawn user pods in.
 
         If running inside a kubernetes cluster with service accounts enabled,
-        defaults to the current namespace. If not, defaults to 'default'
+        defaults to the current namespace. If not, defaults to `default`
         """
     )
 
@@ -127,7 +127,7 @@ class KubeSpawner(Spawner):
         Set namespace default to current namespace if running in a k8s cluster
 
         If not in a k8s cluster with service accounts enabled, default to
-        'default'
+        `default`
         """
         ns_path = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
         if os.path.exists(ns_path):
@@ -160,7 +160,7 @@ class KubeSpawner(Spawner):
         Some spawners allow shell-style expansion here, allowing you to use environment variables.
         Most, including the default, do not. Consult the documentation for your spawner to verify!
 
-        If set to None, Kubernetes will start the CMD that is specified in the Docker image being started.
+        If set to `None`, Kubernetes will start the `CMD` that is specified in the Docker image being started.
         """
     ).tag(config=True)
 
@@ -180,10 +180,10 @@ class KubeSpawner(Spawner):
         help="""
         The service account to be mounted in the spawned user pod.
 
-        When set to None (the default), no service account is mounted, and the default service account
+        When set to `None` (the default), no service account is mounted, and the default service account
         is explicitly disabled.
 
-        This serviceaccount must already exist in the namespace the user pod is being spawned in.
+        This `serviceaccount` must already exist in the namespace the user pod is being spawned in.
 
         WARNING: Be careful with this configuration! Make sure the service account being mounted
         has the minimal permissions needed, and nothing more. When misconfigured, this can easily
@@ -197,7 +197,7 @@ class KubeSpawner(Spawner):
         help="""
         Template to use to form the name of user's pods.
 
-        {username} and {userid} are expanded to the escaped, dns-label safe
+        `{username}` and `{userid}` are expanded to the escaped, dns-label safe
         username & integer user id respectively.
 
         This must be unique within the namespace the pods are being spawned
@@ -223,7 +223,7 @@ class KubeSpawner(Spawner):
         help="""
         Template to use to form the name of user's pvc.
 
-        {username} and {userid} are expanded to the escaped, dns-label safe
+        `{username}` and `{userid}` are expanded to the escaped, dns-label safe
         username & integer user id respectively.
 
         This must be unique within the namespace the pvc are being spawned
@@ -293,7 +293,7 @@ class KubeSpawner(Spawner):
         See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more
         info on what labels are and why you might want to use them!
 
-        {username} and {userid} are expanded to the escaped, dns-label safe
+        `{username}` and `{userid}` are expanded to the escaped, dns-label safe
         username & integer user id respectively, wherever they are used.
         """
     )
@@ -310,7 +310,7 @@ class KubeSpawner(Spawner):
         See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ for more
         info on what annotations are and why you might want to use them!
 
-        {username} and {userid} are expanded to the escaped, dns-label safe
+        `{username}` and `{userid}` are expanded to the escaped, dns-label safe
         username & integer user id respectively, wherever they are used.
         """
     )
@@ -336,11 +336,10 @@ class KubeSpawner(Spawner):
 
         If your image is very large, you might need to increase the timeout
         for starting the single user container from the default. You can
-        set this with:
+        set this with::
 
-        ```
-        c.KubeSpawner.start_timeout = 60 * 5  # Upto 5 minutes
-        ```
+           c.KubeSpawner.start_timeout = 60 * 5  # Upto 5 minutes
+        
         """
     )
 
@@ -349,15 +348,15 @@ class KubeSpawner(Spawner):
         config=True,
         help="""
         The image pull policy of the docker container specified in
-        singleuser_image_spec.
+        `singleuser_image_spec`.
 
         Defaults to `IfNotPresent` which causes the Kubelet to NOT pull the image
         specified in singleuser_image_spec if it already exists, except if the tag
-        is :latest. For more information on image pull policy, refer to
-        http://kubernetes.io/docs/user-guide/images/
+        is `:latest`. For more information on image pull policy, refer to
+        https://kubernetes.io/docs/concepts/containers/images/
 
         This configuration is primarily used in development if you are
-        actively changing the singleuser_image_spec and would like to pull the image
+        actively changing the `singleuser_image_spec` and would like to pull the image
         whenever a user container is spawned.
         """
     )
@@ -370,9 +369,9 @@ class KubeSpawner(Spawner):
         The kubernetes secret to use for pulling images from private repository.
 
         Set this to the name of a Kubernetes secret containing the docker configuration
-        required to pull the image specified in singleuser_image_spec.
+        required to pull the image specified in `singleuser_image_spec`.
 
-        https://kubernetes.io/docs/user-guide/images/#specifying-imagepullsecrets-on-a-pod
+        https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
         has more information on when and why this might need to be set, and what it
         should be set to.
         """
@@ -386,8 +385,9 @@ class KubeSpawner(Spawner):
 
         Default is None and means it will be launched in any available Node.
 
-        For example to match the Nodes that have a label of `disktype: ssd` use:
-            `{"disktype": "ssd"}`
+        For example to match the Nodes that have a label of `disktype: ssd` use::
+
+            {"disktype": "ssd"}
         """
     )
 
@@ -444,7 +444,7 @@ class KubeSpawner(Spawner):
         upgrades to break.
 
         You'll *have* to set this if you are using auto-provisioned volumes with most
-        cloud providers. See [fsGroup](http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_podsecuritycontext)
+        cloud providers. See `fsGroup <https://kubernetes.io/docs/api-reference/v1.9/#podsecuritycontext-v1-core>`_
         for more details.
         """
     )
@@ -489,20 +489,20 @@ class KubeSpawner(Spawner):
         so you should use the same structure. Each item in the list must have the
         following two keys:
 
-          - name
+          - `name`
             Name that'll be later used in the `volume_mounts` config to mount this
             volume at a specific path.
-          - <name-of-a-supported-volume-type> (such as `hostPath`, `persistentVolumeClaim`,
+          - `<name-of-a-supported-volume-type>` (such as `hostPath`, `persistentVolumeClaim`,
             etc)
             The key name determines the type of volume to mount, and the value should
             be an object specifying the various options available for that kind of
             volume.
 
-        See http://kubernetes.io/docs/user-guide/volumes/ for more information on the
+        See https://kubernetes.io/docs/concepts/storage/volumes for more information on the
         various kinds of volumes available and their options. Your kubernetes cluster
         must already be configured to support the volume types you want to use.
 
-        {username} and {userid} are expanded to the escaped, dns-label safe
+        `{username}` and `{userid}` are expanded to the escaped, dns-label safe
         username & integer user id respectively, wherever they are used.
         """
     )
@@ -517,16 +517,13 @@ class KubeSpawner(Spawner):
         container in the kubernetes pod spec, so you should use the same structure as that.
         Each item in the list should be a dictionary with at least these two keys:
 
-          - mountPath
-            The path on the container in which we want to mount the volume.
-          - name
-            The name of the volume we want to mount, as specified in the `volumes`
-            config.
+           - `mountPath` The path on the container in which we want to mount the volume.
+           - `name` The name of the volume we want to mount, as specified in the `volumes` config.
 
-        See http://kubernetes.io/docs/user-guide/volumes/ for more information on how
-        the volumeMount item works.
+        See https://kubernetes.io/docs/concepts/storage/volumes for more information on how
+        the `volumeMount` item works.
 
-        {username} and {userid} are expanded to the escaped, dns-label safe
+        `{username}` and `{userid}` are expanded to the escaped, dns-label safe
         username & integer user id respectively, wherever they are used.
         """
     )
@@ -543,13 +540,13 @@ class KubeSpawner(Spawner):
 
         This will be added to the `resources: requests: storage:` in the k8s pod spec.
 
-        See http://kubernetes.io/docs/user-guide/persistent-volumes/#persistentvolumeclaims
+        See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
         for more information on how storage works.
 
         Quantities can be represented externally as unadorned integers, or as fixed-point
-        integers with one of these SI suffices (E, P, T, G, M, K, m) or their power-of-two
-        equivalents (Ei, Pi, Ti, Gi, Mi, Ki). For example, the following represent roughly
-        'the same value: 128974848, "129e6", "129M" , "123Mi".
+        integers with one of these SI suffices (`E, P, T, G, M, K, m`) or their power-of-two
+        equivalents (`Ei, Pi, Ti, Gi, Mi, Ki`). For example, the following represent roughly
+        the same value: `128974848`, `129e6`, `129M`, `123Mi`.
         (https://github.com/kubernetes/kubernetes/blob/master/docs/design/resources.md)
         """
     )
@@ -567,7 +564,7 @@ class KubeSpawner(Spawner):
         See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more
         info on what labels are and why you might want to use them!
 
-        {username} and {userid} are expanded to the escaped, dns-label safe
+        `{username}` and `{userid}` are expanded to the escaped, dns-label safe
         username & integer user id respectively, wherever they are used.
         """
     )
@@ -588,8 +585,9 @@ class KubeSpawner(Spawner):
         b/c it has a storage class, k8s will dynamically spawn a pv for the pvc to bind to
         and a machine in the cluster for the pv to bind to.
 
-        See http://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses for
+        See https://kubernetes.io/docs/concepts/storage/storage-classes/ for
         more information on how StorageClasses work.
+
         """
     )
 
@@ -600,12 +598,12 @@ class KubeSpawner(Spawner):
         List of access modes the user has for the pvc.
 
         The access modes are:
-            The access modes are:
-                ReadWriteOnce – the volume can be mounted as read-write by a single node
-                ReadOnlyMany – the volume can be mounted read-only by many nodes
-                ReadWriteMany – the volume can be mounted as read-write by many nodes
+   
+            - `ReadWriteOnce` – the volume can be mounted as read-write by a single node
+            - `ReadOnlyMany` – the volume can be mounted read-only by many nodes
+            - `ReadWriteMany` – the volume can be mounted as read-write by many nodes
 
-        See http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes for
+        See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes for
         more information on how access modes work.
         """
     )
@@ -619,16 +617,16 @@ class KubeSpawner(Spawner):
         The keys is name of hooks and there are only two hooks, postStart and preStop.
         The values are handler of hook which executes by Kubernetes management system when hook is called.
 
-        Below are a sample copied from Kubernetes doc
-        https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
+        Below is an sample copied from 
+        `Kubernetes doc <https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/>`_ ::
 
-        lifecycle:
-          postStart:
-            exec:
-              command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
-          preStop:
-            exec:
-              command: ["/usr/sbin/nginx","-s","quit"]
+            lifecycle:
+            postStart:
+                exec:
+                command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+            preStop:
+                exec:
+                command: ["/usr/sbin/nginx","-s","quit"]
 
         See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ for more
         info on what lifecycle hooks are and why you might want to use them!
@@ -722,9 +720,8 @@ class KubeSpawner(Spawner):
         so you should use the same structure. Each item in the list is container configuration
         which follows spec at https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#container-v1-core.
 
-        One usage is setting crontab in a container to clean sensitive data with configuration below:
+        One usage is setting crontab in a container to clean sensitive data with configuration below::
         
-        .. code::yaml
             [
                 {
                     'name': 'crontab',
@@ -742,7 +739,7 @@ class KubeSpawner(Spawner):
         help="""
         The dictionary used to request arbitrary resources.
         Default is None and means no additional resources are requested.
-        For example, to request 3 Nvidia GPUs:
+        For example, to request 3 Nvidia GPUs::
 
             {"nvidia.com/gpu": "3"}
         """
@@ -754,7 +751,7 @@ class KubeSpawner(Spawner):
         help="""
         The dictionary used to limit arbitrary resources.
         Default is None and means no additional resources are limited.
-        For example, to add a limit of 3 Nvidia GPUs:
+        For example, to add a limit of 3 Nvidia GPUs::
 
             {"nvidia.com/gpu": "3"}
         """
@@ -911,11 +908,11 @@ class KubeSpawner(Spawner):
         """
         Save state required to reinstate this user's pod from scratch
 
-        We save the pod_name, even though we could easily compute it,
+        We save the `pod_name`, even though we could easily compute it,
         because JupyterHub requires you save *some* state! Otherwise
         it assumes your server is dead. This works around that.
 
-        It's also useful for cases when the pod_template changes between
+        It's also useful for cases when the `pod_template` changes between
         restarts - this keeps the old pods around.
         """
         state = super().get_state()
@@ -926,9 +923,9 @@ class KubeSpawner(Spawner):
         """
         Load state from storage required to reinstate this user's pod
 
-        Since this runs after __init__, this will override the generated pod_name
+        Since this runs after `__init__`, this will override the generated `pod_name`
         if there's one we have saved in state. These are the same in most cases,
-        but if the pod_template has changed in between restarts, it will no longer
+        but if the `pod_template` has changed in between restarts, it will no longer
         be the case. This allows us to continue serving from the old pods with
         the old names.
         """

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -702,11 +702,12 @@ class KubeSpawner(Spawner):
         Each item in the dict is field of pod configuration
         which follows spec at https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#podspec-v1-core.
 
-        One usage is set dnsPolicy with configuration below:
-        dnsPolicy: ClusterFirstWithHostNet
+        One usage is set dnsPolicy with configuration below::
 
-        The key could be either camelcase word (used by Kubernetes yaml, e.g. dnsPolicy)
-        or underscore-separated word (used by kubernetes python client, e.g. dns_policy).
+            dnsPolicy: ClusterFirstWithHostNet
+
+        The `key` could be either camelcase word (used by Kubernetes yaml, e.g. `dnsPolicy`)
+        or underscore-separated word (used by kubernetes python client, e.g. `dns_policy`).
         """
     )
 


### PR DESCRIPTION
Closes #80 

This PR includes:

- fix for duplicate entries in autodoc
- adds napoleon for better parsing for autodoc
- updates the kubernetes links that have changed due to K8's docs restructure
- reordered contents to put spawner before other autodoc sections

[Rendered test docs](http://test-kubespawner.readthedocs.io/en/test-build/index.html)