### PR TITLE
set default restartPolicy to Never for user pods

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -149,6 +149,7 @@ def make_pod(
     )
 
     pod.spec = V1PodSpec(containers=[])
+    pod.spec.restartPolicy = 'Never'
 
     security_context = V1PodSecurityContext()
     if fs_gid is not None:


### PR DESCRIPTION
so that user pods exiting do not get restarted

needed for self-culling, otherwise a culled pod gets restarted automatically