### PR TITLE
Pending pods cause inconsistent state after timeout

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1068,6 +1068,8 @@ class KubeSpawner(Spawner):
             yield self.pod_reflector.first_load_future
         data = self.pod_reflector.pods.get(self.pod_name, None)
         if data is not None:
+            if data.status.phase == 'Pending':
+                return None
             for c in data.status.container_statuses:
                 # return exit code if notebook container has terminated
                 if c.name == 'notebook':


### PR DESCRIPTION
If a pod remains in pending state longer than `start_timeout`, we are in an inconsistent state that the user can not stop nor start new one.

To reproduce: make the singleuser image's resource request unreasonably high so it is impossible to schedule, and wait for the timeout.