### PR TITLE
Add common labels for Pods & PVCs

### DIFF
--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -20,7 +20,6 @@ from tornado.concurrent import run_on_executor
 class IngressReflector(NamespacedResourceReflector):
     kind = 'ingresses'
     labels = {
-        'heritage': 'jupyterhub',
         'component': 'singleuser-server',
         'hub.jupyter.org/proxy-route': 'true'
     }
@@ -35,7 +34,6 @@ class IngressReflector(NamespacedResourceReflector):
 class ServiceReflector(NamespacedResourceReflector):
     kind = 'services'
     labels = {
-        'heritage': 'jupyterhub',
         'component': 'singleuser-server',
         'hub.jupyter.org/proxy-route': 'true'
     }
@@ -49,7 +47,6 @@ class ServiceReflector(NamespacedResourceReflector):
 class EndpointsReflector(NamespacedResourceReflector):
     kind = 'endpoints'
     labels = {
-        'heritage': 'jupyterhub',
         'component': 'singleuser-server',
         'hub.jupyter.org/proxy-route': 'true'
     }

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -933,9 +933,9 @@ class KubeSpawner(Spawner):
         labels.update(extra_labels)
         labels.update({
             'app': os.getenv('LABEL_APP', 'jupyterhub'),
-            'release': os.getenv('LABEL_RELEASE', 'unknown')
-            'chart': os.getenv('LABEL_CHART', 'unknown')
-            'heritage': os.getenv('LABEL_HERITAGE', 'jupyterhub')
+            'release': os.getenv('LABEL_RELEASE', 'unknown'),
+            'chart': os.getenv('LABEL_CHART', 'unknown'),
+            'heritage': os.getenv('LABEL_HERITAGE', 'jupyterhub'),
         })
         return labels
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -32,8 +32,11 @@ from kubespawner.reflector import NamespacedResourceReflector
 
 class PodReflector(NamespacedResourceReflector):
     kind = 'pods'
+    # FUTURE: These labels are the selection labels for the PodReflector. We
+    # might want to support multiple deployments in the same namespace, so we
+    # would need to select based on additional labels such as `app` and
+    # `release`.
     labels = {
-        'heritage': 'jupyterhub',
         'component': 'singleuser-server',
     }
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -277,6 +277,21 @@ class KubeSpawner(Spawner):
         """
         return self.hub.server.port
 
+    common_labels = Dict(
+        {
+            'app': 'jupyterhub',
+            'heritage': 'jupyterhub',
+        },
+        config=True,
+        help="""
+        Kubernetes labels that both spawned singleuser server pods and created
+        user PVCs will get.
+
+        Note that these are only set when the Pods and PVCs are created, not
+        later when this setting is updated.
+        """
+    )
+
     singleuser_extra_labels = Dict(
         {},
         config=True,
@@ -582,7 +597,7 @@ class KubeSpawner(Spawner):
 
         The keys and values specified here would be set as labels on the PVCs
         created by kubespawner for the user. Note that these are only set
-        when the PVC is created, not later when they are updated.
+        when the PVC is created, not later when this setting is updated.
 
         See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more
         info on what labels are and why you might want to use them!
@@ -931,12 +946,7 @@ class KubeSpawner(Spawner):
         # https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/labels.md
         labels = {}
         labels.update(extra_labels)
-        labels.update({
-            'app': os.getenv('LABEL_APP', 'jupyterhub'),
-            'release': os.getenv('LABEL_RELEASE', 'unknown'),
-            'chart': os.getenv('LABEL_CHART', 'unknown'),
-            'heritage': os.getenv('LABEL_HERITAGE', 'jupyterhub'),
-        })
+        labels.update(self.common_labels)
         return labels
 
     def _build_pod_labels(self, extra_labels):


### PR DESCRIPTION
## Summary
- Changes are fully backwards compatible.
- The kubespawner is hardcoded with the label selector `component=singleuser-server` and still does not support multiple deployments in the same namespace.
- Spawned Pods and PVCs get additional `common_labels`, this allows z2jh to set the `chart` and `release` labels on spawned Pods and PVCs.
- PR utilized by [jupyterhub/zero-to-jupyterhub-k8s#625](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/625)

## Background
In [jupyterhub/zero-to-jupyterhub-k8s#625](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/625), I wanted to make all objects created within the z2jh helm chart follow [Helms Best Practices for labels](https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/labels.md). This PR helps ensure that and thereby fixes #159.

## Details
These are the labels of relevance in this PR. Note that the `PodReflector` is hardcoded to find only the pods with a `singleuser-server` label.

Object|Label|Traitlet|Default value
-|-|-|-
PVC / Pod|`component`|hardcoded|`'singleuser-storage'` / `'singleuser-server'`
PVC / Pod|`app`|`common_labels`|`'jupyterhub'`
PVC / Pod|`heritage`|`common_labels`|`'jupyterhub'`

## History
I thought of using environment variables to configure certain labels. But configuring specific variables would couple kubespawner unnecessarily (to z2jh and Helm for example).

## Implementation notes
- I made sure `common_labels` couldn't be overridden by extra labels provided to the kubespawner

## PR TODO
- [x] Configure using traitlets
- [x] Exclude all helm chart presumptions
- [x] Test this in conjunction with [jupyterhub/zero-to-jupyterhub-k8s#625](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/625)
- [x] Consider if singleuser-server's need a restart while introducing this code or changes to `common_labels` and how to avoid it. _Update_: I decided to keep a hardcoded pod-selection based on the namespace, `heritage=jupyter,component=singleuser-server` for now.
- [x] Figure out all interactions KubeSpawner might have with pods after spawn. _Update_: `start`, `poll` and `stop`, using the `PodReflector` to find the pods.
- [x] Test this better together with [jupyterhub/zero-to-jupyterhub-k8s#625](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/625). 

#### Excluded from this PR
- Figure out how / when / why KubeIngressProxy is used
- Figure out all interactions KubeIngressProxy might have with pods after spawn
- Consider sharing `common_labels` trait with KubeIngressProxy