### PR TITLE
monkeypatch kubernetes to avoid ThreadPool problems

### DIFF
--- a/kubespawner/clients.py
+++ b/kubespawner/clients.py
@@ -1,6 +1,23 @@
+"""Shared clients for kubernetes
+
+avoids creating multiple kubernetes client objects,
+each of which spawns an unused max-size thread pool
+"""
+
+from unittest.mock import Mock
 import weakref
 
 import kubernetes.client
+from kubernetes.client import api_client
+
+# FIXME: remove when instantiating a kubernetes client
+# doesn't create N-CPUs threads unconditionally.
+# monkeypatch threadpool in kubernetes api_client
+# to avoid instantiating ThreadPools.
+# This is known to work for kubernetes-4.0
+# and may need updating with later kubernetes clients
+_dummy_pool = Mock()
+api_client.ThreadPool = lambda *args, **kwargs: _dummy_pool
 
 _client_cache = {}
 

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -7,9 +7,9 @@ import threading
 
 from traitlets.config import LoggingConfigurable
 from traitlets import Any, Dict, Unicode
-from kubernetes import client, config, watch
+from kubernetes import config, watch
 from tornado.ioloop import IOLoop
-
+from .clients import shared_client
 
 class NamespacedResourceReflector(LoggingConfigurable):
     """
@@ -92,7 +92,7 @@ class NamespacedResourceReflector(LoggingConfigurable):
             config.load_incluster_config()
         except config.ConfigException:
             config.load_kube_config()
-        self.api = getattr(client, self.api_group_name)()
+        self.api = shared_client(self.api_group_name)
 
         # FIXME: Protect against malicious labels?
         self.label_selector = ','.join(['{}={}'.format(k, v) for k, v in self.labels.items()])


### PR DESCRIPTION
kubernetes creates client objects in a number of places e.g. every time a Watch is instantiated.

These objects create a max-size thread pool for async requests, which bogs down the process if enough client objects are instantiated (#165). Since we don't
use async requests, these pool objects go totally unused.

We setup shared clients to reduce the number of client objects created in #128, but there are some places we can't prevent clients from being instantiated (Watches), so the new EventReflector caused a problem in a big way by instantiating N-CPUs threads for every spawn.

To solve this at the root, api_client is monkeypatched to avoid creating these ThreadPools in the first place. A patch has been submitted [upstream](https://github.com/swagger-api/swagger-codegen/pull/8061) to swagger-codegen, which is responsible for creating the ThreadPool in the kubernetes client.

Related to #153, which creates a Watch per spawn, so we cannot avoid creating a very large number of ApiClient objects and thereby threadpools without monkeypatching Kubernetes.

The alternative is to go back to pinning kubernetes-3.0.