### PR TITLE
Removed hack for security in k8s <= v1.5

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -233,15 +233,11 @@ def make_pod(
         pod.spec.containers.extend(extra_containers)
 
     pod.spec.init_containers = init_containers
-<<<<<<< 4d0221e2e8c670cfe712551035add23012f48cce
-    pod.spec.volumes = volumes + hack_volumes
+    pod.spec.volumes = volumes
 
     if scheduler_name:
         pod.spec.scheduler_name = scheduler_name
 
-=======
-    pod.spec.volumes = volumes
->>>>>>> Removed hack for security in k8s <= v1.5
     return pod
 
 

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -187,31 +187,15 @@ def make_pod(
         args=cmd,
         image_pull_policy=image_pull_policy,
         lifecycle=lifecycle_hooks,
-        resources=V1ResourceRequirements()
+        resources=V1ResourceRequirements(),
+        volume_mounts=volume_mounts
     )
 
     if service_account is None:
-        # Add a hack to ensure that no service accounts are mounted in spawned pods
-        # This makes sure that we don"t accidentally give access to the whole
+        # This makes sure that we don't accidentally give access to the whole
         # kubernetes API to the users in the spawned pods.
-        # Note: We don't simply use `automountServiceAccountToken` here since we wanna be compatible
-        # with older kubernetes versions too for now.
-        hack_volume = V1Volume(name='no-api-access-please', empty_dir={})
-        hack_volumes = [hack_volume]
-
-        hack_volume_mount = V1VolumeMount(
-            name='no-api-access-please',
-            mount_path="/var/run/secrets/kubernetes.io/serviceaccount",
-            read_only=True
-        )
-        hack_volume_mounts = [hack_volume_mount]
-
-        # Non-hacky way of not mounting service accounts
         pod.spec.automount_service_account_token = False
     else:
-        hack_volumes = []
-        hack_volume_mounts = []
-
         pod.spec.service_account_name = service_account
 
     if run_privileged:
@@ -220,7 +204,6 @@ def make_pod(
         )
 
     notebook_container.resources.requests = {}
-
     if cpu_guarantee:
         notebook_container.resources.requests['cpu'] = cpu_guarantee
     if mem_guarantee:
@@ -238,7 +221,6 @@ def make_pod(
         for k in extra_resource_limits:
             notebook_container.resources.limits[k] = extra_resource_limits[k]
 
-    notebook_container.volume_mounts = volume_mounts + hack_volume_mounts
     pod.spec.containers.append(notebook_container)
 
     if extra_container_config:
@@ -251,11 +233,15 @@ def make_pod(
         pod.spec.containers.extend(extra_containers)
 
     pod.spec.init_containers = init_containers
+<<<<<<< 4d0221e2e8c670cfe712551035add23012f48cce
     pod.spec.volumes = volumes + hack_volumes
 
     if scheduler_name:
         pod.spec.scheduler_name = scheduler_name
 
+=======
+    pod.spec.volumes = volumes
+>>>>>>> Removed hack for security in k8s <= v1.5
     return pod
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -317,14 +317,14 @@ def test_set_pod_supplemental_gids():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {},
                         "requests": {}
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -37,14 +37,14 @@ def test_make_simplest_pod():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {},
                         "requests": {}
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -81,14 +81,14 @@ def test_make_labeled_pod():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {},
                         "requests": {}
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -125,14 +125,14 @@ def test_make_annotated_pod():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {},
                         "requests": {}
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -172,14 +172,14 @@ def test_make_pod_with_image_pull_secrets():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {},
                         "requests": {}
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -221,14 +221,14 @@ def test_set_pod_uid_and_gid():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {},
                         "requests": {}
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -269,14 +269,14 @@ def test_set_pod_uid_fs_gid():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {},
                         "requests": {}
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -368,10 +368,10 @@ def test_run_privileged_container():
                     "securityContext": {
                         "privileged": True,
                     },
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -415,7 +415,7 @@ def test_make_pod_resources_all():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": 2,
@@ -428,7 +428,7 @@ def test_make_pod_resources_all():
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -468,7 +468,7 @@ def test_make_pod_with_env():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                         },
@@ -477,7 +477,7 @@ def test_make_pod_with_env():
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -520,7 +520,7 @@ def test_make_pod_with_lifecycle():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                         },
@@ -536,7 +536,7 @@ def test_make_pod_with_lifecycle():
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -585,7 +585,7 @@ def test_make_pod_with_init_containers():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                         },
@@ -607,7 +607,7 @@ def test_make_pod_with_init_containers():
                     "command": ["sh", "-c", "until nslookup mydb; do echo waiting for mydb; sleep 2; done;"]
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -653,7 +653,7 @@ def test_make_pod_with_extra_container_config():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                         },
@@ -669,7 +669,7 @@ def test_make_pod_with_extra_container_config():
                     ]
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -715,7 +715,7 @@ def test_make_pod_with_extra_pod_config():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                         },
@@ -724,7 +724,7 @@ def test_make_pod_with_extra_pod_config():
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
             'tolerations': [
                 {
                     'key': 'dedicated',
@@ -775,7 +775,7 @@ def test_make_pod_with_extra_containers():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                         },
@@ -789,7 +789,7 @@ def test_make_pod_with_extra_containers():
                     'command': ['/usr/local/bin/supercronic', '/etc/crontab']
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -835,7 +835,7 @@ def test_make_pod_with_extra_resources():
                         "name": "notebook-port",
                         "containerPort": 8888
                     }],
-                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": 2,
@@ -851,7 +851,7 @@ def test_make_pod_with_extra_resources():
                     }
                 }
             ],
-            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"


### PR DESCRIPTION
This PR reduces some complexity and could perhaps avoid some unexpected complication by removing code only relevant for k8s <= 1.5. It would also avoid adding unexpected volumeMounts to the generated singleuser-server pod specifications.

Pre k8s 1.6, the `automountServiceAccountToken` option was not available in pod specification, so a code hack was used to disable auto mounting of a `ServiceAccount` token. This was done since such token could be used to access the kubernetes master api-server in some way as far as I understand. I think the 'disable-k8s-api-access' hack worked by making a dummy mount to the same path either overriding the previously auto-mounted path or prohibiting a future mount on the path.

This PR simply removes that code and relies setting the k8s >= 1.6 `automountServiceAccountToken` option to false.

## Research

#### Questions
Some questions I hope to find answers to...
- __Q1__: What does the typical default `ServiceAccount` secret mounted for pods in `/var/run/secrets/kubernetes.io/serviceaccount` contain? I realize the volumeMount hack might have served a greater purpose than simply removing access to the `...../token` path depending on the content...
- __Q2__: Will `/var/run/secrets/kubernetes.io/serviceaccount/token` be accessible by the pod containers if they are `root`, or even `jovyan`? I think `root` has access at least, but I'd like to have this confirmed... we might expose sensitive information (the `imagePullSecret`) anyhow!

## Related
- [z2jh#447](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/447)