### PR TITLE
Add timeout handling to reflector (replaces #88)

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -25,7 +25,6 @@ from jinja2 import Environment, BaseLoader
 
 from .clients import shared_client
 from kubespawner.traitlets import Callable
-from kubespawner.utils import Callable
 from kubespawner.objects import make_pod, make_pvc
 from kubespawner.reflector import NamespacedResourceReflector
 from asyncio import sleep

--- a/kubespawner/traitlets.py
+++ b/kubespawner/traitlets.py
@@ -1,7 +1,7 @@
 """
 Traitlets that are used in Kubespawner
 """
-from traitlets import TraitType, TraitError, Dict
+from traitlets import TraitType
 
 
 class Callable(TraitType):
@@ -16,6 +16,6 @@ class Callable(TraitType):
 
     def validate(self, obj, value):
         if callable(value):
-           return value
+            return value
         else:
             self.error(obj, value)

--- a/kubespawner/utils.py
+++ b/kubespawner/utils.py
@@ -1,10 +1,8 @@
 """
 Misc. general utility functions, not tied to Kubespawner directly
 """
-import random
 import hashlib
 
-from traitlets import TraitType
 
 def generate_hashed_slug(slug, limit=63, hash_length=6):
     """
@@ -29,19 +27,3 @@ def generate_hashed_slug(slug, limit=63, hash_length=6):
         prefix=slug[:limit - hash_length - 1],
         hash=slug_hash[:hash_length],
     ).lower()
-
-
-class Callable(TraitType):
-    """A trait which is callable.
-    Notes
-    -----
-    Classes are callable, as are instances
-    with a __call__() method."""
-
-    info_text = 'a callable'
-
-    def validate(self, obj, value):
-        if callable(value):
-            return value
-        else:
-            self.error(obj, value)


### PR DESCRIPTION
Add watch and network timeout options to NamespacedResourceReflector.

This replaces #88.

The issue was, that due to some networking issues, the watcher (and sometimes even the urllib3 connection pool) stopped receiving data from the api server, without ever receiving a tcp disconnect. (most likely due to some tcp connection tracking timeout or something similar ?).

This patch allows setting kuberenetes api watch timeout (recommended to use anyway), and setting urllib3 request timeout. In case the kube client never receives a disconnect, then at least the urllib3 read timeout will be triggered, which will cause a watch restart. 