### PR TITLE
Support runAsGroup

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -29,6 +29,7 @@ def make_pod(
     image_pull_secret=None,
     node_selector=None,
     run_as_uid=None,
+    run_as_gid=None,
     fs_gid=None,
     supplemental_gids=None,
     run_privileged=False,
@@ -79,6 +80,9 @@ def make_pod(
     run_as_uid:
         The UID used to run single-user pods. The default is to run as the user
         specified in the Dockerfile, if this is set to None.
+    run_as_gid:
+        The GID used to run single-user pods. The default is to run as the primary
+        group of the user specified in the Dockerfile, if this is set to None.
     fs_gid
         The gid that will own any fresh volumes mounted into this pod, if using
         volume types that support this (such as GCE). This should be a group that
@@ -158,6 +162,8 @@ def make_pod(
         security_context.supplemental_groups = [int(gid) for gid in supplemental_gids]
     if run_as_uid is not None:
         security_context.run_as_user = int(run_as_uid)
+    if run_as_gid is not None:
+        security_context.run_as_group = int(run_as_gid)
     pod.spec.security_context = security_context
 
     if image_pull_secret is not None:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',
-        'kubernetes==4.*',
+        'kubernetes==6.*',
         'escapism',
         'jinja2',
         'async_generator>=1.8',

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -186,6 +186,54 @@ def test_make_pod_with_image_pull_secrets():
     }
 
 
+def test_set_pod_uid_and_gid():
+    """
+    Test specification of the simplest possible pod specification
+    """
+    assert api_client.sanitize_for_serialization(make_pod(
+        name='test',
+        image_spec='jupyter/singleuser:latest',
+        cmd=['jupyterhub-singleuser'],
+        port=8888,
+        run_as_uid=1000,
+        run_as_gid=2000,
+        image_pull_policy='IfNotPresent'
+    )) == {
+        "metadata": {
+            "name": "test",
+            "annotations": {},
+            "labels": {},
+        },
+        "spec": {
+            "securityContext": {
+                "runAsUser": 1000,
+                "runAsGroup": 2000
+            },
+            'automountServiceAccountToken': False,
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{
+                        "name": "notebook-port",
+                        "containerPort": 8888
+                    }],
+                    'volumeMounts': [{'name': 'no-api-access-please', 'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount', 'readOnly': True}],
+                    "resources": {
+                        "limits": {},
+                        "requests": {}
+                    }
+                }
+            ],
+            'volumes': [{'name': 'no-api-access-please', 'emptyDir': {}}],
+        },
+        "kind": "Pod",
+        "apiVersion": "v1"
+    }
+
 def test_set_pod_uid_fs_gid():
     """
     Test specification of the simplest possible pod specification


### PR DESCRIPTION
The latest version of Kubernetes client is 6.0 and it supports lots of new configurations.
https://github.com/kubernetes-client/python/blob/master/CHANGELOG.md#v600

We especially need [`runAsGroup`](https://github.com/kubernetes/kubernetes/pull/52077) because we sometimes need different GID over user's default GID which is the same as UID.

Could you consider supporting it?