### PR TITLE
Deprecate singleuser_ and user_ trait prefixes

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -15,7 +15,7 @@ c.JupyterHub.cleanup_servers = False
 c.KubeSpawner.start_timeout = 60 * 5
 
 # Our simplest user image! Optimized to just... start, and be small!
-c.KubeSpawner.singleuser_image_spec = 'jupyterhub/singleuser:0.8'
+c.KubeSpawner.image_spec = 'jupyterhub/singleuser:0.8'
 
 # Find the IP of the machine that minikube is most likely able to talk to
 # Graciously used from https://stackoverflow.com/a/166589
@@ -27,11 +27,11 @@ s.close()
 c.KubeSpawner.hub_connect_ip = host_ip
 c.JupyterHub.hub_connect_ip = c.KubeSpawner.hub_connect_ip
 
-c.KubeSpawner.singleuser_service_account = 'default'
+c.KubeSpawner.service_account = 'default'
 # Do not use any authentication at all - any username / password will work.
 c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
 
-c.KubeSpawner.user_storage_pvc_ensure = False
+c.KubeSpawner.storage_pvc_ensure = False
 
 c.JupyterHub.allow_named_servers = True
 
@@ -40,14 +40,14 @@ c.KubeSpawner.profile_list = [
         'display_name': 'Training Env - Python',
         'default': True,
         'kubespawner_override': {
-            'singleuser_image_spec': 'training/python:label',
+            'image_spec': 'training/python:label',
             'cpu_limit': 0.5,
         },
         'description': 'Something description of what is going on here, maybe a <a href="#">link too!</a>'
     }, {
         'display_name': 'Training Env - Datascience',
         'kubespawner_override': {
-            'singleuser_image_spec': 'training/datascience:label',
+            'image_spec': 'training/datascience:label',
             'cpu_limit': 0.2,
         },
         'description': 'Something description of how this is different, maybe a <a href="#">link too!</a>'


### PR DESCRIPTION
These are redundant and inconsistent with each other, since they refer to the same thing.

Every `singleuser_foo` and `user_foo` trait is now just `foo`. The prefixed name is deprecated and continues to work with a DeprecationWarning.

closes #101