### PR TITLE
PVC quota conflict

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -7,6 +7,7 @@ implementation that should be used by JupyterHub.
 
 from functools import partial
 import os
+import sys
 import string
 from urllib.parse import urlparse, urlunparse
 import multiprocessing

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1347,7 +1347,7 @@ class KubeSpawner(Spawner):
                                 namespace=self.namespace)
 
                         except ApiException as e:
-                            raise t, v, tb
+                            raise v.with_traceback(tb)
 
                         self.log.info("PVC " + self.pvc_name + " already exists, possibly have reached quota though.")
 


### PR DESCRIPTION
Closes #188

Upon getting a HTTP 403 error response on creating PVC, explicitly check whether PVC exists. This can arise where PVC existed, but was at quota limit, and derives from Kubernetes performing quota check before deciding whether a PVC needed to be created.