### PR TITLE
add unescaped_username to template vars

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -912,7 +912,7 @@ class KubeSpawner(Spawner):
         List of profiles to offer for selection by the user.
 
         Signature is: List(Dict()), where each item is a dictionary that has two keys:
-        
+
         - 'display_name': the human readable display name (should be HTML safe)
         - 'description': Optional description of this profile displayed to the user.
         - 'kubespawner_override': a dictionary with overrides to apply to the KubeSpawner
@@ -1079,6 +1079,7 @@ class KubeSpawner(Spawner):
 
     def _expand_user_properties(self, template):
         # Make sure username and servername match the restrictions for DNS labels
+        # Note: '-' is not in safe_chars, as it is being used as escape character
         safe_chars = set(string.ascii_lowercase + string.digits)
 
         # Set servername based on whether named-server initialised
@@ -1092,6 +1093,7 @@ class KubeSpawner(Spawner):
         return template.format(
             userid=self.user.id,
             username=safe_username,
+            unescaped_username=self.user.name,
             legacy_escape_username=legacy_escaped_username,
             servername=servername
             )


### PR DESCRIPTION
Don't escape dash '-' in user names. It is an allowed symbol in DNS labels.

I am relying on username to set up persistent volume claims and pre-populate the persistent volume with the users data. My usernames do contain one or more '-' characters, and the current escaping even escapes all dash character to '-2d'. Not sure what the preferred way of dealing with this would be. This patch is one option.

Unfortunately, this patch makes removes the ability to unescape user names. If unescaping is required, I would suggest to add up to two additional template variable names. One for the irreversible escaped version and maybe even one for the unescaped username. (can create a pull request for this as well)

Of course it would als be possible to 'legacy_escaped_username', but given that name, it sounds like, this template variable would go away in some time, and looking at the code it felt like it's doing the desired escaping by 'accident' :) .