### PR TITLE
Don’t trust pod reflector when deciding whether to delete

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1472,9 +1472,6 @@ class KubeSpawner(Spawner):
                 self.event_reflector.stop()
             self.event_reflector = None
 
-        if self.pod_name not in self.pod_reflector.pods:
-            self.log.info("No pod %s to delete", self.pod_name)
-            return
         delete_options = client.V1DeleteOptions()
 
         if now:


### PR DESCRIPTION
If pod reflector hasn’t noticed this pod yet, removal won’t be attempted, leading to a leak in pods.

Instead, just attempt deletion and handle the 404 if it’s really not there.

This exacerbates a failure mode where the pod_reflector starts missing events because pods that start but aren't noticed will be believed to be not running and won't be deleted.

This optimization was introduced in #196, but isn't worth the cost.