### PR TITLE
scheduler_name - Complementary pr to #190

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -91,4 +91,16 @@ host machine.
 
    The `jupyterhub_config.py` file that ships in this repo will read that environment variable to figure out what IP the pods should connect to the JupyterHub on. Replace `vboxnet4` with whatever interface name you used in step 4 of the previous section.
 
-This will give you a running JupyterHub that spawns nodes inside the minikube VM! It'll be setup with [DummyAuthenticator](http://github.com/yuvipanda/jupyterhub-dummy-authenticator), so any user + password combo will allow you to log in. You can make changes to the spawner and restart jupyterhub, and rapidly iterate :)
+   This will give you a running JupyterHub that spawns nodes inside the minikube VM! It'll be setup with [DummyAuthenticator](http://github.com/yuvipanda/jupyterhub-dummy-authenticator), so any user + password combo will allow you to log in. You can make changes to the spawner and restart jupyterhub, and rapidly iterate :)
+
+## Running tests
+```
+python setup.py test
+```
+
+If you got a massive amount of errors, it may help to remove your .eggs
+directory.
+
+```
+rm -rf .eggs
+```

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -143,7 +143,7 @@ def make_pod(
     extra_containers:
         Extra containers besides notebook container. Used for some housekeeping jobs (e.g. crontab).
     scheduler_name:
-        A custom scheduler's name.
+        The pod's scheduler explicitly named.
     """
 
     pod = V1Pod()

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1225,7 +1225,7 @@ class KubeSpawner(Spawner):
             extra_container_config=self.extra_container_config,
             extra_pod_config=self.extra_pod_config,
             extra_containers=self.extra_containers,
-            scheduler_name=self.scheduler_name
+            scheduler_name=self.scheduler_name,
         )
 
     def get_pvc_manifest(self):

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -989,6 +989,18 @@ class KubeSpawner(Spawner):
         """
     )
 
+    scheduler_name = Unicode(
+        None,
+        config=True,
+        allow_none=True,
+        help="""
+        Set the pod's scheduler explicitly by name.
+
+        See the Kubernetes API documentation for additional details.
+        - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podspec-v1-core
+        """
+    )
+
     # deprecate redundant and inconsistent singleuser_ and user_ prefixes:
     _deprecated_traits = [
         "singleuser_working_dir",
@@ -1213,6 +1225,7 @@ class KubeSpawner(Spawner):
             extra_container_config=self.extra_container_config,
             extra_pod_config=self.extra_pod_config,
             extra_containers=self.extra_containers,
+            scheduler_name=self.scheduler_name
         )
 
     def get_pvc_manifest(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -17,7 +17,7 @@ def test_make_simplest_pod():
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
-        scheduler_name="my-custom-scheduler"
+        scheduler_name='my-custom-scheduler'
     )) == {
         "metadata": {
             "name": "test",

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -16,7 +16,8 @@ def test_make_simplest_pod():
         image_spec='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
-        image_pull_policy='IfNotPresent'
+        image_pull_policy='IfNotPresent',
+        scheduler_name="my-custom-scheduler"
     )) == {
         "metadata": {
             "name": "test",
@@ -45,6 +46,7 @@ def test_make_simplest_pod():
                 }
             ],
             'volumes': [],
+            'schedulerName': 'my-custom-scheduler'
         },
         "kind": "Pod",
         "apiVersion": "v1"
@@ -959,6 +961,50 @@ def test_make_pod_with_service_account():
             ],
             'volumes': [],
             'serviceAccountName': 'test'
+        },
+        "kind": "Pod",
+        "apiVersion": "v1"
+    }
+
+
+def test_make_pod_with_scheduler_name():
+    """
+    Test specification of the simplest possible pod specification with non-default scheduler name
+    """
+    assert api_client.sanitize_for_serialization(make_pod(
+        name='test',
+        image_spec='jupyter/singleuser:latest',
+        cmd=['jupyterhub-singleuser'],
+        port=8888,
+        image_pull_policy='IfNotPresent'
+    )) == {
+        "metadata": {
+            "name": "test",
+            "annotations": {},
+            "labels": {},
+        },
+        "spec": {
+            "securityContext": {},
+            'automountServiceAccountToken': False,
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{
+                        "name": "notebook-port",
+                        "containerPort": 8888
+                    }],
+                    'volumeMounts': [],
+                    "resources": {
+                        "limits": {},
+                        "requests": {}
+                    }
+                }
+            ],
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1"


### PR DESCRIPTION
In #190 I only added support in the make_pod function to create pods with the `spec.schedulerName` field set, but this is pointless without having a traitlet to configure what it should be in the spawner. This is added in this PR.

I also added a note on what I often need to do in order to get my tests to run, but I don't get whats going on really, but I figure it is something that is cached and needs to be rebuilt within `.eggs`.