### PR TITLE
Add kubernetes service creation/destruction along with the pod

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -150,6 +150,9 @@ def make_pod(
     pod.kind = "Pod"
     pod.api_version = "v1"
 
+    # Add pod name in meta labels
+    labels.update({"name": name})
+
     pod.metadata = V1ObjectMeta(
         name=name,
         labels=labels.copy(),
@@ -251,6 +254,34 @@ def _map_attribute(attribute_map, attribute):
             return key
     else:
         raise ValueError('Attribute must be one of {}'.format(attribute_map.values()))
+
+
+def make_service(
+    name,
+    labels={},
+    annotations={},
+    ):
+
+    target_port = 4040
+    # Make service object
+    service = V1Service(
+        kind='Service',
+        spec=V1ServiceSpec(
+            ports=[V1ServicePort(port=target_port, target_port=target_port, name="sparkui")],
+            selector={"name": name},
+            cluster_ip="None"
+        )
+    )
+
+    labels.update({"name": name})
+
+    service.api_version = "v1"
+    service.metadata = V1ObjectMeta(
+        name=name,
+        labels=labels.copy(),
+        annotations=annotations.copy()
+    )
+    return service
 
 
 def make_pvc(


### PR DESCRIPTION
When you create a Jupyter pod, if you want to connect to a Spark cluster (e.g. standalone mode) in your notebook, you need to set up a k8s service for allow Spark worker to respond to your pod.

This PR code create/destruct a k8s service along to the pod with the same pod name. The service is only accessible inside the cluster (for Spark workers).

It's basically the Kubernetes solution equivalent to Docker --net=host describe below:
http://jupyter-docker-stacks.readthedocs.io/en/latest/using/specifics.html#connecting-to-a-spark-cluster-in-standalone-mode
