### PR TITLE
[Part 5 of #205] Tolerations for node taints

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -20,6 +20,7 @@ from kubernetes.client.models import (
     V1beta1Ingress, V1beta1IngressSpec, V1beta1IngressRule,
     V1beta1HTTPIngressRuleValue, V1beta1HTTPIngressPath,
     V1beta1IngressBackend,
+    V1Toleration,
 )
 
 def make_pod(
@@ -54,6 +55,7 @@ def make_pod(
     extra_pod_config=None,
     extra_containers=None,
     scheduler_name=None,
+    tolerations=None,
     logger=None,
 ):
     """
@@ -146,6 +148,13 @@ def make_pod(
         Extra containers besides notebook container. Used for some housekeeping jobs (e.g. crontab).
     scheduler_name:
         The pod's scheduler explicitly named.
+    tolerations:
+        Tolerations can allow a pod to schedule or execute on a tainted node. To
+        learn more about pod tolerations, see
+        https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.
+
+        Pass this field an array of "Toleration" objects.*
+        * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#nodeselectorterm-v1-core
     """
 
     pod = V1Pod()
@@ -235,6 +244,8 @@ def make_pod(
 
     if extra_containers:
         pod.spec.containers.extend([get_k8s_model(V1Container, obj) for obj in extra_containers])
+    if tolerations:
+        pod.spec.tolerations = [get_k8s_model(V1Toleration, obj) for obj in tolerations]
     if init_containers:
         pod.spec.init_containers = [get_k8s_model(V1Container, obj) for obj in init_containers]
     if volumes:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -816,7 +816,7 @@ class KubeSpawner(Spawner):
     extra_pod_config = Dict(
         config=True,
         help="""
-        Extra configuration (e.g. tolerations) for the pod which is not covered by other attributes.
+        Extra configuration for the pod which is not covered by other attributes.
 
         This dict will be directly merge into pod,so you should use the same structure.
         Each item in the dict is field of pod configuration
@@ -861,6 +861,35 @@ class KubeSpawner(Spawner):
         help="""
         Set the pod's scheduler explicitly by name. See `the Kubernetes documentation <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podspec-v1-core>`_
         for more information.
+        """
+    )
+
+    tolerations = List(
+        config=True,
+        help="""
+        List of tolerations that are to be assigned to the pod in order to be able to schedule the pod
+        on a node with the corresponding taints. See the official Kubernetes documentation for additional details
+        https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+
+        Pass this field an array of "Toleration" objects.*
+        * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#nodeselectorterm-v1-core
+
+        Example:
+
+            [
+                {
+                    'key': 'key',
+                    'operator': 'Equal',
+                    'value': 'value',
+                    'effect': 'NoSchedule'
+                },
+                {
+                    'key': 'key',
+                    'operator': 'Exists',
+                    'effect': 'NoSchedule'
+                }
+            ]
+
         """
     )
 
@@ -1239,6 +1268,7 @@ class KubeSpawner(Spawner):
             extra_pod_config=self.extra_pod_config,
             extra_containers=self.extra_containers,
             scheduler_name=self.scheduler_name,
+            tolerations=self.tolerations,
             logger=self.log,
         )
 


### PR DESCRIPTION
Adds the possibility to configure a pod's *tolerations*, allowing the pod to schedule and execute on nodes with tolerated node taint.