### PR TITLE
[Part 6 of #205] priority_class_name

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -56,6 +56,7 @@ def make_pod(
     extra_containers=None,
     scheduler_name=None,
     tolerations=None,
+    priority_class_name=None,
     logger=None,
 ):
     """
@@ -155,6 +156,8 @@ def make_pod(
 
         Pass this field an array of "Toleration" objects.*
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#nodeselectorterm-v1-core
+    priority_class_name:
+        The name of the PriorityClass to be assigned the pod. This feature is Beta available in K8s 1.11.
     """
 
     pod = V1Pod()
@@ -260,6 +263,8 @@ def make_pod(
 
 
 
+    if priority_class_name:
+        pod.spec.priority_class_name = priority_class_name
 
     if extra_pod_config:
         pod.spec = update_k8s_model(

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1040,6 +1040,18 @@ class KubeSpawner(Spawner):
         """
     )
 
+    priority_class_name = Unicode(
+        None,
+        allow_none=True,
+        config=True,
+        help="""
+        The priority class that the pods will use.
+
+        See https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption for
+        more information on how pod priority works.
+        """
+    )
+
     # deprecate redundant and inconsistent singleuser_ and user_ prefixes:
     _deprecated_traits = [
         "singleuser_working_dir",
@@ -1269,6 +1281,7 @@ class KubeSpawner(Spawner):
             extra_containers=self.extra_containers,
             scheduler_name=self.scheduler_name,
             tolerations=self.tolerations,
+            priority_class_name=self.priority_class_name,
             logger=self.log,
         )
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -223,6 +223,7 @@ class KubeSpawner(Spawner):
         """
     )
 
+    # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     working_dir = Unicode(
         None,
         allow_none=True,
@@ -233,6 +234,7 @@ class KubeSpawner(Spawner):
         """
     )
 
+    # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     service_account = Unicode(
         None,
         allow_none=True,
@@ -292,6 +294,7 @@ class KubeSpawner(Spawner):
         """
     )
 
+    # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     hub_connect_ip = Unicode(
         None,
         allow_none=True,
@@ -435,6 +438,7 @@ class KubeSpawner(Spawner):
         """
     )
 
+    # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     image_pull_secrets = Unicode(
         None,
         allow_none=True,
@@ -649,6 +653,7 @@ class KubeSpawner(Spawner):
         """
     )
 
+    # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     storage_capacity = Unicode(
         None,
         config=True,
@@ -688,6 +693,7 @@ class KubeSpawner(Spawner):
         """
     )
 
+    # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     storage_class = Unicode(
         None,
         config=True,
@@ -854,6 +860,7 @@ class KubeSpawner(Spawner):
         """
     )
 
+    # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     scheduler_name = Unicode(
         None,
         allow_none=True,
@@ -1041,8 +1048,6 @@ class KubeSpawner(Spawner):
     )
 
     priority_class_name = Unicode(
-        None,
-        allow_none=True,
         config=True,
         help="""
         The priority class that the pods will use.

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1073,3 +1073,49 @@ def test_make_pod_with_tolerations():
         "kind": "Pod",
         "apiVersion": "v1"
     }
+
+
+def test_make_pod_with_priority_class_name():
+    """
+    Test specification of the simplest possible pod specification with non-default priorityClassName set
+    """
+    assert api_client.sanitize_for_serialization(make_pod(
+        name='test',
+        image_spec='jupyter/singleuser:latest',
+        cmd=['jupyterhub-singleuser'],
+        port=8888,
+        image_pull_policy='IfNotPresent',
+        priority_class_name='my-custom-priority-class'
+    )) == {
+        "metadata": {
+            "name": "test",
+            "annotations": {},
+            "labels": {},
+        },
+        "spec": {
+            "securityContext": {},
+            'automountServiceAccountToken': False,
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{
+                        "name": "notebook-port",
+                        "containerPort": 8888
+                    }],
+                    'volumeMounts': [],
+                    "resources": {
+                        "limits": {},
+                        "requests": {}
+                    }
+                }
+            ],
+            'volumes': [],
+            'priorityClassName': 'my-custom-priority-class',
+        },
+        "kind": "Pod",
+        "apiVersion": "v1"
+    }


### PR DESCRIPTION
Allows the priorityClassName to be specified on pods.

A priorityClass object is a very simple k8s object that has a field called `priority`.
All pods referencing  this priorityClass through the priorityClassName field in their spec will get that priority.

A higher priority pod can evict a lower priority pod if it would help it schedule, and it needed that to happen in order to schedule.

This kind of eviction behavior is enabled by default on k8s 1.11 but it must be explicitly enabled with previous versions. With this in place, it is possible to utilize placeholder pods to scale up, and have them be evicted by real users.

This is an example from a functionality to be supported in zero-to-jupyterhub-k8s in the future.

![ca](https://user-images.githubusercontent.com/3837114/42521913-312a2966-846a-11e8-9a16-399e02268029.gif)