### PR TITLE
install minikube on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
-sudo: false
+sudo: required
+dist: xenial
 python:
   - nightly
   - 3.6
@@ -8,6 +9,8 @@ python:
 # install dependencies
 install:
   - pip install --pre -e ".[test]"
+  - source ci/minikube.env
+  - ./ci/install-kube.sh
 
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,14 @@ python:
 
 # install dependencies
 install:
-  - pip install --no-cache-dir -e .
+  - pip install --pre -e ".[test]"
 
 # command to run tests
 script:
-  - python setup.py test
+  - pytest --cov kubespawner -v
+after_success:
+  - pip install codecov
+  - codecov
 
 matrix:
   fast_finish: true

--- a/ci/install-kube.sh
+++ b/ci/install-kube.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# install minikube on CI
+# this sets up minikube with vm-driver=none, so should not be used anywhere but CI
+set -eux
+
+mkdir -p bin
+
+# install kubectl, minikube
+# based on https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
+echo "installing kubectl"
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
+chmod +x kubectl
+mv kubectl bin/
+
+echo "installing minikube"
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64
+chmod +x minikube
+mv minikube bin/
+
+echo "starting minikube with RBAC"
+sudo CHANGE_MINIKUBE_NONE_USER=true $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC --bootstrapper=localkube
+minikube update-context
+
+echo "waiting for kubernetes"
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
+  sleep 1
+done
+kubectl get nodes

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -1,0 +1,5 @@
+# environment variables for installing kubernetes on CI
+export MINIKUBE_VERSION=0.28.0
+export HELM_VERSION=2.9.1
+export KUBE_VERSION=1.10.0
+export PATH="$PWD/bin:$PATH"

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,12 @@ setup(
         'async_generator>=1.8',
     ],
     python_requires='>=3.5',
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest>=3.3',
+            'pytest-cov',
+        ]
+    },
     description='JupyterHub Spawner targeting Kubernetes',
     url='http://github.com/jupyterhub/kubespawner',
     author='Yuvi Panda',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'test': [
             'pytest>=3.3',
             'pytest-cov',
+            'pytest-asyncio',
         ]
     },
     description='JupyterHub Spawner targeting Kubernetes',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ def kube_ns():
     """Fixture for the kubernetes namespace"""
     return os.environ.get("KUBESPAWNER_TEST_NAMESPACE") or "kubespawner-test"
 
+
 @pytest.fixture
 def config(kube_ns):
     """Return a traitlets Config object
@@ -28,7 +29,7 @@ def config(kube_ns):
 
 
 @pytest.fixture(scope="session")
-def kube_client(kube_ns):
+def kube_client(request, kube_ns):
     """fixture for the Kubernetes client object.
 
     skips test that require kubernetes if kubernetes cannot be contacted
@@ -44,4 +45,6 @@ def kube_client(kube_ns):
         client.create_namespace(V1Namespace(metadata=dict(name=kube_ns)))
     else:
         print("Using existing namespace %s" % kube_ns)
+    # delete the test namespace when we finish
+    request.addfinalizer(lambda: client.delete_namespace(kube_ns, {}))
     return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""pytest fixtures for kubespawner"""
+
+import os
+
+from kubernetes.client import V1Namespace
+from kubernetes.config import load_kube_config
+import pytest
+from traitlets.config import Config
+
+from kubespawner.clients import shared_client
+
+
+@pytest.fixture(scope="session")
+def kube_ns():
+    """Fixture for the kubernetes namespace"""
+    return os.environ.get("KUBESPAWNER_TEST_NAMESPACE") or "kubespawner-test"
+
+@pytest.fixture
+def config(kube_ns):
+    """Return a traitlets Config object
+
+    The base configuration for testing.
+    Use when constructing Spawners for tests
+    """
+    cfg = Config()
+    cfg.KubeSpawner.namespace = kube_ns
+    return cfg
+
+
+@pytest.fixture(scope="session")
+def kube_client(kube_ns):
+    """fixture for the Kubernetes client object.
+
+    skips test that require kubernetes if kubernetes cannot be contacted
+    """
+    load_kube_config()
+    client = shared_client('CoreV1Api')
+    try:
+        namespaces = client.list_namespace(_request_timeout=3)
+    except Exception as e:
+        pytest.skip("Kubernetes not found: %s" % e)
+    if not any(ns.metadata.name == kube_ns for ns in namespaces.items):
+        print("Creating namespace %s" % kube_ns)
+        client.create_namespace(V1Namespace(metadata=dict(name=kube_ns)))
+    else:
+        print("Using existing namespace %s" % kube_ns)
+    return client


### PR DESCRIPTION
and run a couple very basic tests that actually launch pods

this should get us setup so that we can start testing actual functionality

I think there's room to consolidate the boilerplate for tests that look like:

1. given this config
2. instantiate and launch a KubeSpawner
3. assert some condition

so we can get some nice test coverage, but this gets the ball rolling.

additionally, this enables [coverage on codecov](https://codecov.io/gh/jupyterhub/kubespawner/tree/bc1a4ac8febec1df0830999cdbde899781230c3d/kubespawner), which can point us to where we need to assemble those tests. However, since most kubespawner case coverage is really in configuration, code line coverage doesn't give us a useful view of how we are doing there.