### PR TITLE
Try getting image_spec from POST parameters, fallback to self.image_spec

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1324,6 +1324,9 @@ class KubeSpawner(Spawner):
         else:
             real_cmd = None
 
+        # JupyterHub user options via REST
+        self.image_spec = self.user_options.get("image_spec", self.image_spec)
+
         labels = self._build_pod_labels(self._expand_all(self.extra_labels))
         annotations = self._build_common_annotations(self._expand_all(self.extra_annotations))
 


### PR DESCRIPTION
Allow specifying the docker image to be spawned.
Example usecase: 
`POST /user/test/server/projectA
{
    "image_spec": "projectA:latest"
}`

`user_options` is provided by JupyterHub as seen [here](https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/user.py)