### PR TITLE
Fix for failing docs build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,10 +2,11 @@ name: kubespawner
 channels:
   - conda-forge
 dependencies:
-- python=3.5
-- sphinx>=1.7
-- sphinx_rtd_theme
+  - python=3.5
+  - sphinx>=1.7
+  - sphinx_rtd_theme
+  - traitlets>=4.1
 - pip:
-    - recommonmark==0.4.0
-    - pyyaml
-    - sphinx-copybutton
+  - recommonmark==0.4.0
+  - pyyaml
+  - sphinx-copybutton

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,6 @@
 name: kubespawner
 type: sphinx
 conda:
-    file: docs/environment.yml
+  file: docs/environment.yml
 python:
   version: 3


### PR DESCRIPTION
I made the docs build start failing in a previous PR by removing a dependency for traitlets by mistake. Fixing that now.