### PR TITLE
Update doc build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,3 +10,4 @@ dependencies:
     - recommonmark==0.4.0
     - pyyaml
     - sphinx-copybutton
+    - setuptools

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+sphinx>=1.7
+sphinx_rtd_theme
+traitlets>=4.1
+recommonmark==0.4.0
+pyyaml
+sphinx-copybutton
+setuptools

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,6 @@
 name: kubespawner
 type: sphinx
-conda:
-  file: docs/environment.yml
+requirements_file: docs/requirements.txt
 python:
   version: 3
+  setup_py_install: true


### PR DESCRIPTION
Closes #263 

- Move build to pip from conda until RTD/Sphinx work out what is up with conda and Sphinx 1.8.
- Add setuptools to dependencies for docs

Link to passing build on my test RTD project: https://readthedocs.org/projects/test-kubespawner/builds/7813627/

