### PR TITLE
Fix image_pull_policy

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -397,8 +397,9 @@ class KubeSpawner(Spawner):
     )
 
     image_pull_policy = Unicode(
-        'IfNotPresent',
+        None,
         config=True,
+        allow_none=True,
         help="""
         The image pull policy of the docker container specified in
         `image_spec`.


### PR DESCRIPTION
`image_pull_policy` **defaults**, i.e. gets derived from `image_spec` tag, only if it is not set explicitly!
`image_pull_policy='IfNotPresent'` + `:latest` tag ≠ `image_pull_policy='Always'`. Event `:latest` image won't be pulled if it exists!
If it is desired to have `image_pull_policy` 'dependent' on the tag (as-if it were `'Always'` for `:latest`/omitted tag and `'IfNotPresent'` otherwise), it should be set to `None`, which corresponds to `imagePullPolicy` omission. https://kubernetes.io/docs/concepts/containers/images#updating-images:
> If you would like to always force a pull, you can do one of the following:
> - omit the `imagePullPolicy` and use `:latest` as the tag for the image to use.
> - omit the `imagePullPolicy` and the tag for the image to use.