### PR TITLE
Expand username and userid in extra_containers

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -834,6 +834,9 @@ class KubeSpawner(Spawner):
                 "image": "supercronic",
                 "command": ["/usr/local/bin/supercronic", "/etc/crontab"]
             }]
+
+        `{username}` and `{userid}` are expanded to the escaped, dns-label safe
+        username & integer user id respectively, wherever they are used.
         """
     )
 
@@ -1333,7 +1336,7 @@ class KubeSpawner(Spawner):
             service_account=self.service_account,
             extra_container_config=self.extra_container_config,
             extra_pod_config=self.extra_pod_config,
-            extra_containers=self.extra_containers,
+            extra_containers=self._expand_all(self.extra_containers),
             scheduler_name=self.scheduler_name,
             tolerations=self.tolerations,
             node_affinity_preferred=self.node_affinity_preferred,


### PR DESCRIPTION
This will help in our use-case: a volume is mounted on the jupyter container, this volume's is parametrized with `{username}`.
We have an extra container (to collect metrics) that also needs to mount this volume, but currently it's not possible, because the volume's name doesn't get expanded in the `extra_containers` section.