### PR TITLE
deprecate KubeSpawner.image_spec

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -30,7 +30,7 @@ def make_pod(
     name,
     cmd,
     port,
-    image_spec,
+    image,
     image_pull_policy,
     image_pull_secret=None,
     node_selector=None,
@@ -76,7 +76,7 @@ def make_pod(
     name:
         Name of pod. Must be unique within the namespace the object is
         going to be created in. Must be a valid DNS label.
-    image_spec:
+    image:
         Image specification - usually a image name and tag in the form
         of image_name:tag. Same thing you would use with docker commandline
         arguments
@@ -254,7 +254,7 @@ def make_pod(
         lifecycle_hooks = get_k8s_model(V1Lifecycle, lifecycle_hooks)
     notebook_container = V1Container(
         name='notebook',
-        image=image_spec,
+        image=image,
         working_dir=working_dir,
         ports=[V1ContainerPort(name='notebook-port', container_port=port)],
         env=[V1EnvVar(k, v) for k, v in (env or {}).items()],

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -12,7 +12,7 @@ def test_make_simplest_pod():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent'
@@ -56,7 +56,7 @@ def test_make_labeled_pod():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -101,7 +101,7 @@ def test_make_annotated_pod():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -146,7 +146,7 @@ def test_make_pod_with_image_pull_secrets():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -195,7 +195,7 @@ def test_set_pod_uid_and_gid():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         run_as_uid=1000,
@@ -244,7 +244,7 @@ def test_set_pod_uid_fs_gid():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         run_as_uid=1000,
@@ -293,7 +293,7 @@ def test_set_pod_supplemental_gids():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         run_as_uid=1000,
@@ -342,7 +342,7 @@ def test_run_privileged_container():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         run_privileged=True,
@@ -390,7 +390,7 @@ def test_make_pod_resources_all():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cpu_limit=2,
         cpu_guarantee=1,
         cmd=['jupyterhub-singleuser'],
@@ -449,7 +449,7 @@ def test_make_pod_with_env():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         env={
             'TEST_KEY': 'TEST_VALUE'
         },
@@ -498,7 +498,7 @@ def test_make_pod_with_lifecycle():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -559,7 +559,7 @@ def test_make_pod_with_init_containers():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -631,7 +631,7 @@ def test_make_pod_with_extra_container_config():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -693,7 +693,7 @@ def test_make_pod_with_extra_pod_config():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -762,7 +762,7 @@ def test_make_pod_with_extra_containers():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -820,7 +820,7 @@ def test_make_pod_with_extra_resources():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cpu_limit=2,
         cpu_guarantee=1,
         extra_resource_limits={"nvidia.com/gpu": "5", "k8s.io/new-resource": "1"},
@@ -946,7 +946,7 @@ def test_make_pod_with_service_account():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -992,7 +992,7 @@ def test_make_pod_with_scheduler_name():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -1052,7 +1052,7 @@ def test_make_pod_with_tolerations():
     ]
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -1109,7 +1109,7 @@ def test_make_pod_with_node_affinity_preferred():
     }]
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -1167,7 +1167,7 @@ def test_make_pod_with_node_affinity_required():
     }]
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -1233,7 +1233,7 @@ def test_make_pod_with_pod_affinity_preferred():
     }]
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -1294,7 +1294,7 @@ def test_make_pod_with_pod_affinity_required():
     }]
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -1358,7 +1358,7 @@ def test_make_pod_with_pod_anti_affinity_preferred():
     }]
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -1419,7 +1419,7 @@ def test_make_pod_with_pod_anti_affinity_required():
     }]
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',
@@ -1470,7 +1470,7 @@ def test_make_pod_with_priority_class_name():
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
-        image_spec='jupyter/singleuser:latest',
+        image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent',

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -32,12 +32,14 @@ def test_deprecated_config():
     c.KubeSpawner.fs_gid = 10
     # only deprecated set, should still work
     c.KubeSpawner.singleuser_extra_pod_config = extra_pod_config = {"key": "value"}
+    c.KubeSpawner.image_spec = 'abc:123'
     spawner = KubeSpawner(config=c, _mock=True)
     assert spawner.fs_gid == 10
     assert spawner.extra_pod_config == extra_pod_config
     # deprecated access gets the right values, too
     assert spawner.singleuser_fs_gid == spawner.fs_gid
     assert spawner.singleuser_extra_pod_config == spawner.extra_pod_config
+    assert spawner.image == 'abc:123'
 
 
 def test_deprecated_runtime_access():
@@ -49,6 +51,12 @@ def test_deprecated_runtime_access():
     spawner.uid = 20
     assert spawner.uid == 20
     assert spawner.singleuser_uid == 20
+    spawner.image_spec = 'abc:latest'
+    assert spawner.image_spec == 'abc:latest'
+    assert spawner.image == 'abc:latest'
+    spawner.image = 'abc:123'
+    assert spawner.image_spec == 'abc:123'
+    assert spawner.image == 'abc:123'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
use KubeSpawner.image so that config matches kubernetes terminology. In general, let's try to always have a perfect match of config name -> field name when there is a 1:1 correspondence.

The deprecated traits functionality is expanded to add arbitrary old->new mappings and deprecated versions.