### PR TITLE
Allow None on UID and GID

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -447,6 +447,7 @@ class KubeSpawner(Spawner):
             Integer(),
             Callable(),
         ],
+        allow_none=True,
         config=True,
         help="""
         The UID to run the single-user server containers as.
@@ -471,6 +472,7 @@ class KubeSpawner(Spawner):
             Integer(),
             Callable(),
         ],
+        allow_none=True,
         config=True,
         help="""
         The GID to run the single-user server containers as.
@@ -495,6 +497,7 @@ class KubeSpawner(Spawner):
             Integer(),
             Callable(),
         ],
+        allow_none=True,
         config=True,
         help="""
         The GID of the group that should own any volumes that are created & mounted.

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -61,6 +61,35 @@ def test_deprecated_runtime_access():
     assert spawner.image == 'abc:123'
 
 
+def test_spawner_values():
+    """Spawner values are set correctly"""
+    spawner = KubeSpawner(_mock=True)
+
+    def set_id(spawner):
+        return 1
+
+    spawner.uid = 10
+    assert spawner.uid == 10
+    spawner.uid = set_id
+    assert spawner.uid == set_id
+    spawner.uid = None
+    assert spawner.uid == None
+
+    spawner.gid = 20
+    assert spawner.gid == 20
+    spawner.gid = set_id
+    assert spawner.gid == set_id
+    spawner.gid = None
+    assert spawner.gid == None
+
+    spawner.fs_gid = 30
+    assert spawner.fs_gid == 30
+    spawner.fs_gid = set_id
+    assert spawner.fs_gid == set_id
+    spawner.fs_gid = None
+    assert spawner.fs_gid == None
+
+
 @pytest.mark.asyncio
 async def test_spawn(kube_ns, kube_client, config):
     spawner = KubeSpawner(hub=Hub(), user=MockUser(), config=config)


### PR DESCRIPTION
My production environment doesn't allow to set `0` UID and GID by PSP, but I can't set `None` on those fields by the following error.

```
    HTTPServerRequest(protocol='https', host='192.168.99.100:30005', method='GET', uri='/hub/user/dtaniwaki/', version='HTTP/1.1', remote_ip='::ffff:10.1.0.1')
    Traceback (most recent call last):
      File "/usr/local/lib/python3.5/dist-packages/tornado/web.py", line 1592, in _execute
        result = yield result
      File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
        raise self._exception
      File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
        result = coro.send(None)
      File "/usr/local/lib/python3.5/dist-packages/jupyterhub/handlers/base.py", line 987, in get
        spawner = user.spawner
      File "/usr/local/lib/python3.5/dist-packages/jupyterhub/user.py", line 228, in spawner
        return self.spawners['']
      File "/usr/local/lib/python3.5/dist-packages/jupyterhub/user.py", line 125, in __getitem__
        self[key] = self.spawner_factory(key)
      File "/usr/local/lib/python3.5/dist-packages/jupyterhub/user.py", line 221, in _new_spawner
        spawner = spawner_class(**spawn_kwargs)
      File "/usr/local/lib/python3.5/dist-packages/kubespawner/spawner.py", line 104, in __init__
        super().__init__(*args, **kwargs)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/config/configurable.py", line 84, in __init__
        self.config = config
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 585, in __set__
        self.set(obj, value)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 574, in set
        obj._notify_trait(self.name, old_value, new_value)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 1139, in _notify_trait
        type='change',
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 1176, in notify_change
        c(change)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 819, in compatible_observer
        return func(self, change)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/config/configurable.py", line 186, in _config_changed
        self._load_config(change.new, traits=traits, section_names=section_names)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/config/configurable.py", line 153, in _load_config
        setattr(self, name, deepcopy(config_value))
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 585, in __set__
        self.set(obj, value)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 559, in set
        new_value = self._validate(obj, value)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 591, in _validate
        value = self.validate(obj, value)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 1803, in validate
        self.error(obj, value)
      File "/usr/local/lib/python3.5/dist-packages/traitlets/traitlets.py", line 625, in error
        raise TraitError(e)
    traitlets.traitlets.TraitError: The 'fs_gid' trait of a KubeSpawner instance must be an int or a callable, but a value of None <class 'NoneType'> was specified.
```

I think we should be able to set `None` because these fields are optional.