### PR TITLE
Pin kubernetes version to 8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',
-        'kubernetes>=7',
+        'kubernetes==7.0.0',
         'escapism',
         'jinja2',
         'async_generator>=1.8',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',
-        'kubernetes==7.0.0',
+        'kubernetes==8.0.*',
         'escapism',
         'jinja2',
         'async_generator>=1.8',


### PR DESCRIPTION
9.0 alpha has breaking changes, and our version selector
was including 9.0alpha.

Breaking changes listed here:

https://github.com/kubernetes-client/python/blob/master/CHANGELOG.md#v900a1