### PR TITLE
Always load user_options

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1620,6 +1620,13 @@ class KubeSpawner(Spawner):
         start returns, which we can use to terminate
         .progress()
         """
+        for k, v in self.user_options.items():
+            if callable(v):
+                v = v(self)
+                self.log.debug(".. overriding KubeSpawner value %s=%s (callable result)", k, v)
+            else:
+                self.log.debug(".. overriding KubeSpawner value %s=%s", k, v)
+            setattr(self, k, v)
         self._start_future = self._start()
         return self._start_future
 
@@ -1841,12 +1848,4 @@ class KubeSpawner(Spawner):
         selected_profile = int(formdata.get('profile', [0])[0])
         options = self._profile_list[selected_profile]
         self.log.debug("Applying KubeSpawner override for profile '%s'", options['display_name'])
-        kubespawner_override = options.get('kubespawner_override', {})
-        for k, v in kubespawner_override.items():
-            if callable(v):
-                v = v(self)
-                self.log.debug(".. overriding KubeSpawner value %s=%s (callable result)", k, v)
-            else:
-                self.log.debug(".. overriding KubeSpawner value %s=%s", k, v)
-            setattr(self, k, v)
-        return options
+        self.user_options = options.get('kubespawner_override', {})


### PR DESCRIPTION
- options_from_form shouldn't load any options, only return the
   user_options dict. This method only exists to convert HTML form inputs, which don't allow specifying JSON-style input (all inputs are lists of strings, no integer types or scalars)
   to the user_options dict, which may come fully formed via the API.
- user_options only contains a 'profile' key for picking the profile,
  allowing API requests to spawn with a selected profile.
- Loading of the profile occurs in start.
- Subclasses may override `.load_user_options()` to support more options (e.g. user-provided overrides)
- always load user_options on start
- load default profile if no profile is specified (ensures default profile
   is loaded for API spawns with no args)

Finishes up #285
closes #284