### PR TITLE
Enable pods to be launched on user namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ jupyterhub_cookie_secret
 
 # Editors
 .vscode
+.idea
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -124,7 +124,7 @@ def make_user_rules():
                      resources=['events'],
                      verbs=['get', 'list', 'watch']),
         V1PolicyRule([''],
-                     resources=['pods', 'persistentvolumnes', 'persistentvolumeclaims'],
+                     resources=['pods', 'persistentvolumes', 'persistentvolumeclaims'],
                      verbs=['get', 'list', 'watch']),
     ]
 

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -10,14 +10,14 @@ from jupyterhub.utils import exponential_backoff
 
 from kubespawner.objects import make_ingress
 from kubespawner.utils import generate_hashed_slug
-from kubespawner.reflector import NamespacedResourceReflector
+from kubespawner.reflector import ResourceReflector
 from .clients import shared_client
 from traitlets import Unicode
 from tornado import gen
 from tornado.concurrent import run_on_executor
 
 
-class IngressReflector(NamespacedResourceReflector):
+class IngressReflector(ResourceReflector):
     kind = 'ingresses'
     labels = {
         'component': 'singleuser-server',
@@ -31,7 +31,7 @@ class IngressReflector(NamespacedResourceReflector):
     def ingresses(self):
         return self.resources
 
-class ServiceReflector(NamespacedResourceReflector):
+class ServiceReflector(ResourceReflector):
     kind = 'services'
     labels = {
         'component': 'singleuser-server',
@@ -44,7 +44,7 @@ class ServiceReflector(NamespacedResourceReflector):
     def services(self):
         return self.resources
 
-class EndpointsReflector(NamespacedResourceReflector):
+class EndpointsReflector(ResourceReflector):
     kind = 'endpoints'
     labels = {
         'component': 'singleuser-server',

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -145,8 +145,6 @@ class ResourceReflector(LoggingConfigurable):
             '_request_timeout': self.request_timeout
         }
 
-        print(list_args)
-
         initial_resources = getattr(self.api, self.list_method_name)(**list_args)
 
         # This is an atomic operation on the dictionary!

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1,7 +1,7 @@
-from unittest.mock import Mock
-
-from jupyterhub.objects import Hub, Server
 import pytest
+
+from unittest.mock import Mock
+from jupyterhub.objects import Hub, Server
 from traitlets.config import Config
 from asyncio import get_event_loop
 from kubespawner import KubeSpawner
@@ -59,6 +59,14 @@ def test_deprecated_runtime_access():
     spawner.image = 'abc:123'
     assert spawner.image_spec == 'abc:123'
     assert spawner.image == 'abc:123'
+
+@pytest.fixture
+def test_expand_user_properties():
+    c = Config()
+    c.KubeSpawner.namespace = 'hub-{username}'
+
+    spawner = KubeSpawner(hub=Hub(), config=c, _mock=True)
+    assert spawner._expand_user_properties(spawner.namespace) == 'hub-mock-5fname'
 
 
 def test_spawner_values():


### PR DESCRIPTION
Enables namespace template via `namespace_name_template` which
causes pods and other resources to be created on the expanded
user namespace.

`namespace_name_template` example: `hub-{username}`

Note: In order for this functionality to work, the service account
used to manage the JupyterHub deployment needs to be properly configured
globally using ClusterRole and ClusterRoleBinding.


closes #218