### PR TITLE
Add {username} expansion to extra_pod_config

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1361,7 +1361,7 @@ class KubeSpawner(Spawner):
             init_containers=self._expand_all(self.init_containers),
             service_account=self.service_account,
             extra_container_config=self.extra_container_config,
-            extra_pod_config=self.extra_pod_config,
+            extra_pod_config=self._expand_all(self.extra_pod_config),
             extra_containers=self._expand_all(self.extra_containers),
             scheduler_name=self.scheduler_name,
             tolerations=self.tolerations,


### PR DESCRIPTION
I need to add {username} expansion to extra_pod_config. 

I need the singleuser pods to be resolved from other pods (I need this to use an external spark cluster in my notebooks).

The solution I found is to set [pod's hostname and subdomain fields](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields).

I set this up in my values.yaml:
 ```
 hub:
    extraConfig:
      00-custom-singleuser-hostname: |
         c.KubeSpawner.extra_pod_config = {
            "hostname": "jupyter-{username}",
            "subdomain": "jupyterhub"
         }
```

With the provided PR patch and a headless service I can resolve singleuser pods at jupyter-{username}.jupyterhub.{namespace}.svc.cluster.local.
