### PR TITLE
Add image data to state exposed via API

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1424,6 +1424,7 @@ class KubeSpawner(Spawner):
         """
         state = super().get_state()
         state['pod_name'] = self.pod_name
+        state['image'] = self.image
         return state
 
     def get_env(self):


### PR DESCRIPTION
Looking at [#2598 over at JH](https://github.com/jupyterhub/jupyterhub/issues/2598), it would be beneficial to add more runtime data to the data exposed through the API to allow for more flexible services.

Right now, this only adds the image data to the state dict. I'm wary of the implications of loading that field and overriding configuration since I'm not as familiar with how that will affect the spawner process. If it's not going to break anything, that can be added as well.

Still need to check if it even records valid data in combination with profile_list and options_form overrides.

Update: Looks to work fine w/ options_form and profile_list overrides.

It also appears that Kubespawner already exposes the selected profile name under `user_options` in the JH db. Perhaps the `/users` API endpoint should be corrected to return that data instead. Opinions? The selected profile name may be a better, more flexible choice as it's going to be independent from the actual image (and tag).