### PR TITLE
Apply security context to container instead of pod where it is possible

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -259,7 +259,9 @@ def make_pod(
        pod_security_context.fs_group = int(fs_gid)
     if supplemental_gids is not None and supplemental_gids:
        pod_security_context.supplemental_groups = [int(gid) for gid in supplemental_gids]
-    pod.spec.security_context = pod_security_context
+    # Only clutter pod spec with actual content
+    if not all([e is None for e in pod_security_context.to_dict().values()]):
+        pod.spec.security_context = pod_security_context
 
     container_security_context = V1SecurityContext()
     if run_as_uid is not None:
@@ -268,7 +270,7 @@ def make_pod(
         container_security_context.run_as_group = int(run_as_gid)
     if run_privileged:
         container_security_context.privileged = True
-    # Clean output to prevent empty dictionaries from needlessly appearing in tests
+    # Only clutter container spec with actual content
     if all([e is None for e in container_security_context.to_dict().values()]):
         container_security_context = None
 

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -243,16 +243,22 @@ def make_pod(
         lifecycle_hooks = get_k8s_model(V1Lifecycle, lifecycle_hooks)
 
     security_context = V1SecurityContext()
-    if fs_gid is not None:
-        security_context.fs_group = int(fs_gid)
-    if supplemental_gids is not None and supplemental_gids:
-        security_context.supplemental_groups = [int(gid) for gid in supplemental_gids]
+
+    # this is a pod-only parameter
+    # if fs_gid is not None:
+    #    security_context.fs_group = int(fs_gid)
+    # this is a pod-only parameter
+    # if supplemental_gids is not None and supplemental_gids:
+    #    security_context.supplemental_groups = [int(gid) for gid in supplemental_gids]
     if run_as_uid is not None:
         security_context.run_as_user = int(run_as_uid)
     if run_as_gid is not None:
         security_context.run_as_group = int(run_as_gid)
     if run_privileged:
         security_context.privileged = True
+    # Clean output to prevent empty dictionaries from needlessly appearing in tests
+    if all([e is None for e in security_context.to_dict().values()]):
+        security_context = None
 
     notebook_container = V1Container(
         name='notebook',

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -185,7 +185,7 @@ def test_make_pod_with_image_pull_secrets():
     }
 
 
-def test_set_pod_uid_and_gid():
+def test_set_container_uid_and_gid():
     """
     Test specification of the simplest possible pod specification
     """
@@ -234,7 +234,7 @@ def test_set_pod_uid_and_gid():
         "apiVersion": "v1"
     }
 
-def test_set_pod_uid_fs_gid():
+def test_set_container_uid_and_pod_fs_gid():
     """
     Test specification of the simplest possible pod specification
     """
@@ -276,6 +276,9 @@ def test_set_pod_uid_fs_gid():
                 }
             ],
             'restartPolicy': 'OnFailure',
+            'securityContext': {
+                'fsGroup': 1000,
+            },
             'volumes': [],
         },
         "kind": "Pod",
@@ -324,6 +327,9 @@ def test_set_pod_supplemental_gids():
                 }
             ],
             'restartPolicy': 'OnFailure',
+            'securityContext': {
+                'supplementalGroups': [100],
+            },
             'volumes': [],
         },
         "kind": "Pod",

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -23,7 +23,6 @@ def test_make_simplest_pod():
             "annotations": {}
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "containers": [
                 {
@@ -68,7 +67,6 @@ def test_make_labeled_pod():
             "annotations": {}
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "containers": [
                 {
@@ -113,7 +111,6 @@ def test_make_annotated_pod():
             "labels": {},
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "containers": [
                 {
@@ -158,7 +155,6 @@ def test_make_pod_with_image_pull_secrets():
             "labels": {},
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "imagePullSecrets": [
                 {'name': 'super-sekrit'}
@@ -208,13 +204,13 @@ def test_set_pod_uid_and_gid():
             "labels": {},
         },
         "spec": {
-            "securityContext": {
-                "runAsUser": 1000,
-                "runAsGroup": 2000
-            },
             'automountServiceAccountToken': False,
             "containers": [
                 {
+                    "securityContext": {
+                        "runAsUser": 1000,
+                        "runAsGroup": 2000
+                    },
                     "env": [],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
@@ -257,13 +253,12 @@ def test_set_pod_uid_fs_gid():
             "labels": {},
         },
         "spec": {
-            "securityContext": {
-                "runAsUser": 1000,
-                "fsGroup": 1000
-            },
             'automountServiceAccountToken': False,
             "containers": [
                 {
+                    "securityContext": {
+                        "runAsUser": 1000,
+                    },
                     "env": [],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
@@ -306,13 +301,12 @@ def test_set_pod_supplemental_gids():
             "labels": {},
         },
         "spec": {
-            "securityContext": {
-                "runAsUser": 1000,
-                "supplementalGroups": [100]
-            },
             'automountServiceAccountToken': False,
             "containers": [
                 {
+                    "securityContext": {
+                        "runAsUser": 1000,
+                    },
                     "env": [],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
@@ -354,7 +348,6 @@ def test_run_privileged_container():
             "labels": {},
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "containers": [
                 {
@@ -407,7 +400,6 @@ def test_make_pod_resources_all():
             "labels": {},
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "imagePullSecrets": [{"name": "myregistrykey"}],
             "nodeSelector": {"disk": "ssd"},
@@ -464,7 +456,6 @@ def test_make_pod_with_env():
         },
         "spec": {
             'automountServiceAccountToken': False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [{'name': 'TEST_KEY', 'value': 'TEST_VALUE'}],
@@ -516,7 +507,6 @@ def test_make_pod_with_lifecycle():
             "labels": {},
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "containers": [
                 {
@@ -583,7 +573,6 @@ def test_make_pod_with_init_containers():
         },
         "spec": {
             'automountServiceAccountToken': False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -652,7 +641,6 @@ def test_make_pod_with_extra_container_config():
         },
         "spec": {
             'automountServiceAccountToken': False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -719,7 +707,6 @@ def test_make_pod_with_extra_pod_config():
         },
         "spec": {
             'automountServiceAccountToken': False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -781,7 +768,6 @@ def test_make_pod_with_extra_containers():
         },
         "spec": {
             'automountServiceAccountToken': False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -840,7 +826,6 @@ def test_make_pod_with_extra_resources():
         },
         "spec": {
             'automountServiceAccountToken': False,
-            "securityContext": {},
             "imagePullSecrets": [{"name": "myregistrykey"}],
             "nodeSelector": {"disk": "ssd"},
             "containers": [
@@ -990,7 +975,6 @@ def test_make_pod_with_service_account():
             "annotations": {}
         },
         "spec": {
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -1036,7 +1020,6 @@ def test_make_pod_with_scheduler_name():
             "labels": {},
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "containers": [
                 {
@@ -1097,7 +1080,6 @@ def test_make_pod_with_tolerations():
         },
         "spec": {
             "automountServiceAccountToken": False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -1154,7 +1136,6 @@ def test_make_pod_with_node_affinity_preferred():
         },
         "spec": {
             "automountServiceAccountToken": False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -1212,7 +1193,6 @@ def test_make_pod_with_node_affinity_required():
         },
         "spec": {
             "automountServiceAccountToken": False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -1278,7 +1258,6 @@ def test_make_pod_with_pod_affinity_preferred():
         },
         "spec": {
             "automountServiceAccountToken": False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -1339,7 +1318,6 @@ def test_make_pod_with_pod_affinity_required():
         },
         "spec": {
             "automountServiceAccountToken": False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -1403,7 +1381,6 @@ def test_make_pod_with_pod_anti_affinity_preferred():
         },
         "spec": {
             "automountServiceAccountToken": False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -1464,7 +1441,6 @@ def test_make_pod_with_pod_anti_affinity_required():
         },
         "spec": {
             "automountServiceAccountToken": False,
-            "securityContext": {},
             "containers": [
                 {
                     "env": [],
@@ -1514,7 +1490,6 @@ def test_make_pod_with_priority_class_name():
             "labels": {},
         },
         "spec": {
-            "securityContext": {},
             'automountServiceAccountToken': False,
             "containers": [
                 {


### PR DESCRIPTION
# PR Summary (update by @consideRatio)

KubeSpawner can spawn pods with a securityContext field set. But, this exists both for the pod itself, and the notebook server container we put into the pod. Some of these fields of the securityContext could be scoped more narrow to the container only, while others couldn't. This PR scopes what could be scoped narrowly to the container only, to the container only.

Pod scoped:
- `fsGroup` as configured by `kubespawner.fs_gid`
- `supplementalGroups` as configured by `kubespawner.supplemental_gids`
Container scoped:
- `runAsUser` as configured by `kubespawner.run_as_uid`
- `runAsGroup` as configured by `kubespawner.run_as_gid`
- `privileged` as configured by `kubespawner.run_privileged`

For some additional details about security contexts for pods and containers, see:
- about / how to: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
- container reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#securitycontext-v1-core
- pod reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podsecuritycontext-v1-core

# Problem

I'm trying to deploy JupyterHub to a Kubernetes cluster with Istio enabled. When any pod is launched, an Istio sidecar container (`istio-init`) will be injected and requires root permissions.

I first ran into this issue when launching the hub pod and pulled in this fix (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1240), which moves the security context from the pod scope to the container scope.

I'm now running into this issue after authenticating with the hub and initiating a notebook pod launch via KubeSpawner. My understanding is that when I use default `jovyan` (userid=1000), this security context is being applied at the pod level, thereby instructing all containers to run as this user. As a result, my `istio-init` container fails to run because it requires root permissions.

# Implementation Compass

I'm opening this pull request early to get feedback before investing too much time. I plan to deprecate the use of the `V1PodSecurityContext` in favor of specifying the security context at the container level via the `V1SecurityContext` object. Does that seem reasonable?