### PR TITLE
Permit storage class to be empty string.

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -426,7 +426,7 @@ def make_pvc(
     pvc.spec.resources = V1ResourceRequirements()
     pvc.spec.resources.requests = {"storage": storage}
 
-    if storage_class:
+    if storage_class is not None:
         pvc.metadata.annotations.update({"volume.beta.kubernetes.io/storage-class": storage_class})
         pvc.spec.storage_class_name = storage_class
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -674,8 +674,7 @@ class KubeSpawner(Spawner):
         config=True,
         allow_none=True,
         help="""
-        The storage class that the pvc will use. If left blank, the kubespawner will not
-        create a pvc for the pod.
+        The storage class that the pvc will use.
 
         This will be added to the `annotations: volume.beta.kubernetes.io/storage-class:`
         in the pvc metadata.
@@ -684,6 +683,9 @@ class KubeSpawner(Spawner):
         that matches the criteria of the StorageClass, the pvc will mount to that. Otherwise,
         b/c it has a storage class, k8s will dynamically spawn a pv for the pvc to bind to
         and a machine in the cluster for the pv to bind to.
+
+        Note that an empty string is a valid value and is always interpreted to be
+        requesting a pv with no class.
 
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/storage/storage-classes/>`__
         for more information on how StorageClasses work.

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -883,7 +883,7 @@ def test_make_pvc_simple():
     """
     assert api_client.sanitize_for_serialization(make_pvc(
         name='test',
-        storage_class='',
+        storage_class=None,
         access_modes=[],
         storage=None,
         labels={}
@@ -902,6 +902,38 @@ def test_make_pvc_simple():
                     'storage': None
                 }
             }
+        }
+    }
+
+
+def test_make_pvc_empty_storage_class():
+    """
+    Test specification of pvc with empty storage class
+    """
+    assert api_client.sanitize_for_serialization(make_pvc(
+        name='test',
+        storage_class='',
+        access_modes=[],
+        storage=None,
+        labels={}
+    )) == {
+        'kind': 'PersistentVolumeClaim',
+        'apiVersion': 'v1',
+        'metadata': {
+            'name': 'test',
+            'annotations': {
+                'volume.beta.kubernetes.io/storage-class': ''
+            },
+            'labels': {}
+        },
+        'spec': {
+            'accessModes': [],
+            'resources': {
+                'requests': {
+                    'storage': None
+                }
+            },
+            'storageClassName': ''
         }
     }
 


### PR DESCRIPTION
Adds support for using empty storage class per https://github.com/jupyterhub/kubespawner/issues/335

Test has been added, with modification to existing test to use `None` for storage class in most simple pvc test, but can't run test suite myself.

Still need to validate change in actual deployment, creating as draft PR for now so can be reviewed.