### PR TITLE
Add support for matching persistent volume using storage selector.

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -394,6 +394,7 @@ def make_pvc(
     name,
     storage_class,
     access_modes,
+    selector,
     storage,
     labels=None,
     annotations=None,
@@ -410,6 +411,8 @@ def make_pvc(
         String of the name of the k8s Storage Class to use.
     access_modes:
         A list of specifying what access mode the pod should have towards the pvc
+    selector:
+        Dictionary Selector to match pvc to pv.
     storage:
         The ammount of storage needed for the pvc
 
@@ -429,6 +432,9 @@ def make_pvc(
     if storage_class:
         pvc.metadata.annotations.update({"volume.beta.kubernetes.io/storage-class": storage_class})
         pvc.spec.storage_class_name = storage_class
+
+    if selector:
+        pvc.spec.selector = selector
 
     return pvc
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -708,6 +708,20 @@ class KubeSpawner(Spawner):
         """
     )
 
+    storage_selector = Dict(
+        config=True,
+        help="""
+        The dictionary Selector labels used to match a PersistentVolumeClaim to
+        a PersistentVolume.
+
+        Default is None and means it will match based only on other storage criteria.
+
+        For example to match the Nodes that have a label of `content: jupyter` use::
+
+           c.KubeSpawner.storage_selector = {'matchLabels':{'content': 'jupyter'}}
+        """
+    )
+
     lifecycle_hooks = Dict(
         config=True,
         help="""
@@ -1390,6 +1404,7 @@ class KubeSpawner(Spawner):
             name=self.pvc_name,
             storage_class=self.storage_class,
             access_modes=self.storage_access_modes,
+            selector=self.storage_selector,
             storage=self.storage_capacity,
             labels=labels,
             annotations=annotations

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -886,6 +886,7 @@ def test_make_pvc_simple():
         storage_class='',
         access_modes=[],
         storage=None,
+        selector=None,
         labels={}
     )) == {
         'kind': 'PersistentVolumeClaim',
@@ -914,6 +915,7 @@ def test_make_resources_all():
         name='test',
         storage_class='gce-standard-storage',
         access_modes=['ReadWriteOnce'],
+        selector={'matchLabels':{'content': 'jupyter'}},
         storage='10Gi',
         labels={'key': 'value'}
     )) == {
@@ -931,6 +933,11 @@ def test_make_resources_all():
         'spec': {
             'storageClassName': 'gce-standard-storage',
             'accessModes': ['ReadWriteOnce'],
+            'selector': {
+                'matchLabels': {
+                    'content': 'jupyter'
+                }
+            },
             'resources': {
                 'requests': {
                     'storage': '10Gi'

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -915,6 +915,7 @@ def test_make_pvc_empty_storage_class():
         name='test',
         storage_class='',
         access_modes=[],
+        selector=None,
         storage=None,
         labels={}
     )) == {

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -885,8 +885,8 @@ def test_make_pvc_simple():
         name='test',
         storage_class='',
         access_modes=[],
-        storage=None,
         selector=None,
+        storage=None,
         labels={}
     )) == {
         'kind': 'PersistentVolumeClaim',


### PR DESCRIPTION
Add support for matching using storage selector per https://github.com/jupyterhub/kubespawner/issues/336

Test has been added, but can't run test suite myself.

Note that because of overlapping changes in tests in https://github.com/jupyterhub/kubespawner/pull/337 one of these two PRs will likely need to be updated after the first of the two is merged.

Still need to validate change in actual deployment, creating as draft PR for now so can be reviewed.