### PR TITLE
Update SETUP.md instructions to match current state of JupyterHub

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -84,9 +84,11 @@ development fairly easily on your host machine.
    pip install -e .
    ```
 
-4. Install the nodejs configurable HTTP proxy:
+4. Install the nodejs configurable HTTP proxy, and make it accessible to JupyterHub:
+
    ```sh
-   sudo npm install -g configurable-http-proxy
+   npm install configurable-http-proxy
+   export PATH=$(pwd)/node_modules/.bin:$PATH
    ```
 
 5. Ensure user pods can communicate with the hub:

--- a/SETUP.md
+++ b/SETUP.md
@@ -105,7 +105,7 @@ development fairly easily on your host machine.
    ```sh
    # Make sure jupyterhub finds the provided jupyterhub_config.py and run this
    # from the repo's root directory.
-   jupyterhub --no-ssl
+   jupyterhub
    ```
 
    The `jupyterhub_config.py` file that ships in this repo will read that environment variable to figure out what IP the pods should connect to the JupyterHub on. Replace `vboxnet4` with whatever interface name you used in step 4 of the previous section.

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -15,7 +15,7 @@ c.JupyterHub.cleanup_servers = False
 c.KubeSpawner.start_timeout = 60 * 5
 
 # Our simplest user image! Optimized to just... start, and be small!
-c.KubeSpawner.image_spec = 'jupyterhub/singleuser:0.8'
+c.KubeSpawner.image = 'jupyterhub/singleuser:1.0'
 
 # Find the IP of the machine that minikube is most likely able to talk to
 # Graciously used from https://stackoverflow.com/a/166589
@@ -34,22 +34,3 @@ c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
 c.KubeSpawner.storage_pvc_ensure = False
 
 c.JupyterHub.allow_named_servers = True
-
-c.KubeSpawner.profile_list = [
-    {
-        'display_name': 'Training Env - Python',
-        'default': True,
-        'kubespawner_override': {
-            'image_spec': 'training/python:label',
-            'cpu_limit': 0.5,
-        },
-        'description': 'Something description of what is going on here, maybe a <a href="#">link too!</a>'
-    }, {
-        'display_name': 'Training Env - Datascience',
-        'kubespawner_override': {
-            'image_spec': 'training/datascience:label',
-            'cpu_limit': 0.2,
-        },
-        'description': 'Something description of how this is different, maybe a <a href="#">link too!</a>'
-    }
-]


### PR DESCRIPTION
- Remove unneeded '--no-ssl'
- The example config for using profile_list made SETUP.md fail.
  The examples are in the docs already, so we remove that here
  to make jupyterhub_config.py as simple as possible.
- Update version of singleuser image used to match the current
  version of JupyterHub
- Install configurable-http-proxy locally rather than globally,
  to keep our environment self contained
