### PR TITLE
Provide raw_event in spawner progress

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1554,6 +1554,7 @@ class KubeSpawner(Spawner):
                     progress += (90 - progress) / 3
                     await yield_({
                         'progress': int(progress),
+                        'raw_event': event,
                         'message':  "%s [%s] %s" % (
                             event.last_timestamp,
                             event.type,


### PR DESCRIPTION
This allows users to provide more concise/accurate progress page by overriding `spawner_pending` and with raw events.