### PR TITLE
[MRG] CI reworked and bugs affecting tests fixed

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+select = F
+ignore = E,W,C,F401,F841
+exclude = __init__.py
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Artifacts from running kubespawner tests with minikube
+bin/
+lib64
+minikube-linux-amd64
+node_modules/
+package-lock.json
+pyvenv.cfg
+share/
+
 # JupyterHub running from kubespawner folder for development purposes
 jupyterhub-proxy.pid
 jupyterhub.sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,26 @@ after_success:
   - codecov
 
 matrix:
-  fast_finish: true
   allow_failures:
     - python: nightly
+  fast_finish: true
   include:
-    - python: nightly
-    - python: 3.5
+    # Test the oldest supported python on
+    # the latest supported kubernetes-client,
+    # and use the latest supported kubernetes
+    # version along for the kubernetes-client.
+    - python: 3.8
       env: KUBE_PY=7
-    - python: 3.6
-      env: KUBE_PY=7
+      # env: KUBE_PY=7 KUBE_VERSION=1.11.*
     - python: 3.7
       env: KUBE_PY=8
+      # env: KUBE_PY=8 KUBE_VERSION=1.12.*
+    - python: 3.6
+      env: KUBE_PY=9
+      # env: KUBE_PY=9 KUBE_VERSION=1.13.*
+    - python: 3.5
+      env: KUBE_PY=10
+      # env: KUBE_PY=10 KUBE_VERSION=1.14.*
+    - python: nightly
+      env: KUBE_PY=11
+      # env: KUBE_PY=11 KUBE_VERSION=1.15.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,16 @@ dist: xenial
 # install dependencies
 install:
   - pip install --upgrade setuptools pip
-  - |
-    if [[ ! -z "$KUBE_PY" ]]; then
-      # install pinned kubernetes
-      pip install -e ".[test]" "kubernetes==$KUBE_PY.*"
-    else
-      # add --pre so that we test with prereleases of dependencies
-      # to catch compatibility issues before they enter final releases
-      pip install --upgrade --pre -e ".[test]"
-    fi
+  # Only add the --pre flag if $PRE_RELEASES is specified to test pre-releases
+  # of dependencies, and only pin kubernetes if $KUBE_PY is specified.
+  - pip install -e ".[test]" ${PRE_RELEASES:+--pre} ${KUBE_PY:+kubernetes==${KUBE_PY}}
+  - pip freeze
+  # flake8 runs a very quick code analysis
+  # without running any of the code it analyses
+  - flake8 kubespawner
+  # install kubectl, minikube and start minikube
   - source ci/minikube.env
   - ./ci/install-kube.sh
-  - pip freeze
 
 # command to run tests
 script:
@@ -26,26 +24,38 @@ after_success:
   - codecov
 
 matrix:
-  allow_failures:
-    - python: nightly
-  fast_finish: true
   include:
     # Test the oldest supported python on
     # the latest supported kubernetes-client,
     # and use the latest supported kubernetes
     # version along for the kubernetes-client.
     - python: 3.8
-      env: KUBE_PY=7
-      # env: KUBE_PY=7 KUBE_VERSION=1.11.*
+      env: KUBE_PY=7 KUBE_VERSION=1.11.10
     - python: 3.7
-      env: KUBE_PY=8
-      # env: KUBE_PY=8 KUBE_VERSION=1.12.*
+      env: KUBE_PY=8 KUBE_VERSION=1.12.10
     - python: 3.6
-      env: KUBE_PY=9
-      # env: KUBE_PY=9 KUBE_VERSION=1.13.*
+      env: KUBE_PY=9 KUBE_VERSION=1.13.12
     - python: 3.5
-      env: KUBE_PY=10
-      # env: KUBE_PY=10 KUBE_VERSION=1.14.*
-    - python: nightly
-      env: KUBE_PY=11
-      # env: KUBE_PY=11 KUBE_VERSION=1.15.*
+      env: &latest_supported KUBE_PY=10 KUBE_VERSION=1.14.9
+    # We make some tests that are allowed to fail
+    # 1. Test with pre-releases of kubernetes-client/python
+    #    and other dependencies
+    # 2. Test with kubernetes-client/python used with a
+    #    Kubernetes cluster of a higher version than it is
+    #    declared to have support for.
+    # 3. Test with a nightly python build using latest known
+    #    supported configuration.
+    - &allowed_failure_1
+      python: 3.8
+      env: PRE_RELEASES=TRUE KUBE_VERSION=1.14.9
+    - &allowed_failure_2
+      python: 3.8
+      env: KUBE_PY=10 KUBE_VERSION=1.16.3
+    - &allowed_failure_3
+      python: nightly
+      env: *latest_supported
+  allow_failures:
+    - *allowed_failure_1
+    - *allowed_failure_2
+    - *allowed_failure_3
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: required
-dist: xenial
+dist: bionic
 
 # install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,33 +24,38 @@ after_success:
   - codecov
 
 matrix:
+  # NOTE: We may end up updating these set versions with time, when doing that,
+  # these links are relevant.
+  #
+  # ref: KUBE_VERSION's valid values
+  #      https://github.com/kubernetes/kubernetes/tags
+  # ref: KUBE_PY's valid values
+  #      https://github.com/kubernetes-client/python#compatibility
   include:
     # Test the oldest supported python on
     # the latest supported kubernetes-client,
     # and use the latest supported kubernetes
     # version along for the kubernetes-client.
     - python: 3.8
-      env: KUBE_PY=7 KUBE_VERSION=1.11.10
-    - python: 3.7
       env: KUBE_PY=8 KUBE_VERSION=1.12.10
     - python: 3.6
       env: KUBE_PY=9 KUBE_VERSION=1.13.12
     - python: 3.5
       env: &latest_supported KUBE_PY=10 KUBE_VERSION=1.14.9
-    # We make some tests that are allowed to fail
-    # 1. Test with pre-releases of kubernetes-client/python
-    #    and other dependencies
-    # 2. Test with kubernetes-client/python used with a
-    #    Kubernetes cluster of a higher version than it is
-    #    declared to have support for.
-    # 3. Test with a nightly python build using latest known
-    #    supported configuration.
+    # Allowed failure tests:
+    # ----------------------
+    # 1. Test with pre-releases of kubernetes-client/python and other
+    #    dependencies
     - &allowed_failure_1
       python: 3.8
-      env: PRE_RELEASES=TRUE KUBE_VERSION=1.14.9
+      env: PRE_RELEASES=TRUE KUBE_VERSION=1.15.3
+    # 2. Test with latest stable kubernetes client along with the latest
+    #    kubernetes cluster version
     - &allowed_failure_2
       python: 3.8
       env: KUBE_PY=10 KUBE_VERSION=1.16.3
+    # 3. Test with a nightly python build using latest known
+    #    supported configuration.
     - &allowed_failure_3
       python: nightly
       env: *latest_supported

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,27 +38,32 @@ matrix:
     # version along for the kubernetes-client.
     - python: 3.8
       env: KUBE_PY=8 KUBE_VERSION=1.12.10
-    - python: 3.6
+    - python: 3.7
       env: KUBE_PY=9 KUBE_VERSION=1.13.12
-    - python: 3.5
+    - python: 3.6
       env: &latest_supported KUBE_PY=10 KUBE_VERSION=1.14.9
+
     # Allowed failure tests:
     # ----------------------
+
     # 1. Test with pre-releases of kubernetes-client/python and other
-    #    dependencies
+    #    python dependencies
     - &allowed_failure_1
       python: 3.8
       env: PRE_RELEASES=TRUE KUBE_VERSION=1.15.3
+
     # 2. Test with latest stable kubernetes client along with the latest
     #    kubernetes cluster version
     - &allowed_failure_2
       python: 3.8
       env: KUBE_PY=10 KUBE_VERSION=1.16.3
+
     # 3. Test with a nightly python build using latest known
     #    supported configuration.
     - &allowed_failure_3
       python: nightly
       env: *latest_supported
+
   allow_failures:
     - *allowed_failure_1
     - *allowed_failure_2

--- a/ci/install-kube.sh
+++ b/ci/install-kube.sh
@@ -17,8 +17,8 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_V
 chmod +x minikube
 mv minikube bin/
 
-echo "starting minikube with RBAC"
-sudo CHANGE_MINIKUBE_NONE_USER=true $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC --bootstrapper=localkube
+echo "starting minikube"
+sudo CHANGE_MINIKUBE_NONE_USER=true $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
 minikube update-context
 
 echo "waiting for kubernetes"

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -9,4 +9,11 @@ export MINIKUBE_VERSION=${MINIKUBE_VERSION:-1.5.2}
 # ref: https://github.com/helm/helm/releases
 export HELM_VERSION=${HELM_VERSION:-2.16.1}
 
+# ref: https://github.com/LiliC/travis-minikube/blob/master/.travis.yml
+export CHANGE_MINIKUBE_NONE_USER=true
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME=$HOME
+export KUBECONFIG=$HOME/.kube/config
+
 export PATH="$PWD/bin:$PATH"

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -1,5 +1,12 @@
-# environment variables for installing kubernetes on CI
-export MINIKUBE_VERSION=0.28.0
-export HELM_VERSION=2.9.1
-export KUBE_VERSION=1.10.0
+# default values for relevant environment variables
+
+# ref: https://github.com/kubernetes/minikube/releases
+export KUBE_VERSION=${KUBE_VERSION:-1.16.3}
+
+# ref: https://github.com/kubernetes/minikube/releases
+export MINIKUBE_VERSION=${MINIKUBE_VERSION:-1.5.2}
+
+# ref: https://github.com/helm/helm/releases
+export HELM_VERSION=${HELM_VERSION:-2.16.1}
+
 export PATH="$PWD/bin:$PATH"

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -24,7 +24,7 @@ s.connect(("8.8.8.8", 80))
 host_ip = s.getsockname()[0]
 s.close()
 
-c.KubeSpawner.hub_connect_ip = host_ip
+c.JupyterHub.hub_connect_ip = host_ip
 c.JupyterHub.hub_connect_ip = c.KubeSpawner.hub_connect_ip
 
 c.KubeSpawner.service_account = 'default'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',
-        'kubernetes>=7.0',
+        'kubernetes>=8.0',
         'escapism',
         'jinja2',
         'async_generator>=1.8',

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup, find_packages
 import sys
 
 v = sys.version_info
-if v[:2] < (3, 5):
-    error = "ERROR: jupyterhub-kubespawner requires Python version 3.5 or above."
+if v[:2] < (3, 6):
+    error = "ERROR: jupyterhub-kubespawner requires Python version 3.6 or above."
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -19,7 +19,7 @@ setup(
         'jinja2',
         'async_generator>=1.8',
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     extras_require={
         'test': [
             'flake8',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     python_requires='>=3.5',
     extras_require={
         'test': [
+            'flake8',
             'pytest>=3.3',
             'pytest-cov',
             'pytest-asyncio',

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -135,12 +135,12 @@ async def test_spawn_progress(kube_ns, kube_client, config):
     start_future = spawner.start()
     # check progress events
     messages = []
-    async for event in spawner.progress():
-        assert 'progress' in event
-        assert isinstance(event['progress'], int)
-        assert 'message' in event
-        assert isinstance(event['message'], str)
-        messages.append(event['message'])
+    async for progress in spawner.progress():
+        assert 'progress' in progress
+        assert isinstance(progress['progress'], int)
+        assert 'message' in progress
+        assert isinstance(progress['message'], str)
+        messages.append(progress['message'])
     assert 'Started container' in '\n'.join(messages)
 
     await start_future

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -28,25 +28,25 @@ class MockUser(Mock):
     def url(self):
         return self.server.url
 
-
 def test_deprecated_config():
     """Deprecated config is handled correctly"""
-    c = Config()
-    # both set, non-deprecated wins
-    c.KubeSpawner.singleuser_fs_gid = 5
-    c.KubeSpawner.fs_gid = 10
-    # only deprecated set, should still work
-    c.KubeSpawner.hub_connect_ip = '10.0.1.1'
-    c.KubeSpawner.singleuser_extra_pod_config = extra_pod_config = {"key": "value"}
-    c.KubeSpawner.image_spec = 'abc:123'
-    spawner = KubeSpawner(hub=Hub(), config=c, _mock=True)
-    assert spawner.hub.connect_ip == '10.0.1.1'
-    assert spawner.fs_gid == 10
-    assert spawner.extra_pod_config == extra_pod_config
-    # deprecated access gets the right values, too
-    assert spawner.singleuser_fs_gid == spawner.fs_gid
-    assert spawner.singleuser_extra_pod_config == spawner.extra_pod_config
-    assert spawner.image == 'abc:123'
+    with pytest.warns(DeprecationWarning):
+        c = Config()
+        # both set, non-deprecated wins
+        c.KubeSpawner.singleuser_fs_gid = 5
+        c.KubeSpawner.fs_gid = 10
+        # only deprecated set, should still work
+        c.KubeSpawner.hub_connect_ip = '10.0.1.1'
+        c.KubeSpawner.singleuser_extra_pod_config = extra_pod_config = {"key": "value"}
+        c.KubeSpawner.image_spec = 'abc:123'
+        spawner = KubeSpawner(hub=Hub(), config=c, _mock=True)
+        assert spawner.hub.connect_ip == '10.0.1.1'
+        assert spawner.fs_gid == 10
+        assert spawner.extra_pod_config == extra_pod_config
+        # deprecated access gets the right values, too
+        assert spawner.singleuser_fs_gid == spawner.fs_gid
+        assert spawner.singleuser_extra_pod_config == spawner.extra_pod_config
+        assert spawner.image == 'abc:123'
 
 
 def test_deprecated_runtime_access():


### PR DESCRIPTION
## Final summary
- flake8 used for static code testing and that closes #358
- tests now run in 18.04 (bionic) from 16.04 (xenial)
- k8s version 1.12-1.16 tested instead of 1.10 only
- Kubespawner now require `kubernetes>=8`, which is the kubernetes-client/python library, not kubernetes itself.
- We now test pre-releases of the kubernetes client version but allow for failures in it
- We now test nightly python
- We now test a kubernetes client version with the latest not officially supported kubernetes cluster version.
- I corrected a bad solution in #362 where k8s events without `last_timestamp` was set to the 0 timestamp. We now instead fallback to use `event_time` which is a high resolution timestamp that sometimes replaces `last_timestamp` in modern k8s versions.
- I fixed bugs causing test instabilities and potential dropping of events reported `spawner.py`'s `progress()` function. The solution was to ensure to never return without being sure all events that has arrived during the spawning process got a chance to be parsed before returning.
- I conclude that `async for` loops are unstable in python 3.5 even together with the `async_generator` library, and that we should warn about this or require kubespawner to use Py36 or higher in another PR.
- Closes #373 by adding a requirements of Python 3.6+
- Adds inline docs that has helped me grasp important pieces of the code base.
- Test and mute that a DeprecationWarning is warned about from deprecated code.


## PS
I've spent about 30-40 hours on this PR. I've struggled with a mix of non-deterministic errors that doesn't always reproduce, intertwined with py35 specific errors, intertwined with k8s version specific errors. It feels sooooooo good to have the test reliably go green now.