### PR TITLE
[MRG]: Travis pypi: only use pre for nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 language: python
 sudo: required
 dist: xenial
-python:
-  - nightly
-  - 3.7
-  - 3.6
-  - 3.5
 
 # install dependencies
 install:
   - pip install --upgrade setuptools pip
-  # add --pre so that we test with prereleases of dependencies
-  # to catch compatibility issues before they enter final releases
-  - pip install --upgrade --pre -e ".[test]"
   - |
-    # install pinned kubernetes
     if [[ ! -z "$KUBE_PY" ]]; then
-      pip install "kubernetes==$KUBE_PY.*"
+      # install pinned kubernetes
+      pip install -e ".[test]" "kubernetes==$KUBE_PY.*"
+    else
+      # add --pre so that we test with prereleases of dependencies
+      # to catch compatibility issues before they enter final releases
+      pip install --upgrade --pre -e ".[test]"
     fi
   - source ci/minikube.env
   - ./ci/install-kube.sh
@@ -34,6 +30,9 @@ matrix:
   allow_failures:
     - python: nightly
   include:
+    - python: nightly
+    - python: 3.5
+      env: KUBE_PY=7
     - python: 3.6
       env: KUBE_PY=7
     - python: 3.7


### PR DESCRIPTION
Fix travis errors due to using prerelease of kubernetes client e.g. https://github.com/jupyterhub/kubespawner/pull/365#issuecomment-554997459