### PR TITLE
Let kubespawner_override merge environment config instead of replacing it

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1993,7 +1993,7 @@ class KubeSpawner(Spawner):
             else:
                 self.log.debug(".. overriding KubeSpawner value %s=%s", k, v)
             # if the override value is a dict and a similar dict exists in spawner do a shallow copy with 
-            # kubespawner key/value overriding simlar key in spawner.  This is important for example if you
+            # kubespawner key/value overriding similar key in spawner.  This is important for example if you
             # have set environment key/values in pre_spawn_start to prevent them from being removed.
             if isinstance(v,dict): 
                 self.log.debug(".. The value for key %s is a dict so we check if similar dict exists on spawner", k)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1997,8 +1997,8 @@ class KubeSpawner(Spawner):
             if isinstance(v,dict): 
                 self.log.debug(".. The value is a dict so we will do shallow copy")
                 if (hasattr(self,k)):
-                    self.log.debug("... shallow copy of KubeSpawner key %s values %s over spawner %s", k,**self[k], **v)
-                    v = {**self[k], **v}
+                    self.log.debug("... shallow copy of KubeSpawner key %s values %s over spawner %s", k,getattr(self,k), v)
+                    v = {**getattr(self,k), **v}
             setattr(self, k, v)
 
     # set of recognised user option keys

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1992,6 +1992,10 @@ class KubeSpawner(Spawner):
                 self.log.debug(".. overriding KubeSpawner value %s=%s (callable result)", k, v)
             else:
                 self.log.debug(".. overriding KubeSpawner value %s=%s", k, v)
+                if (k == "environment"):
+                    if self.environment:
+                        self.log.debug(".. joining Spawner environment with KubeSpawner environment")
+                        v = {**self.environment, **v}
             setattr(self, k, v)
 
     # set of recognised user option keys

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1995,9 +1995,10 @@ class KubeSpawner(Spawner):
             # if the override value is a dict and a similar dict exists in spawner do a shallow copy with 
             # kubespawner values overriding values for existing keys in spawner. 
             if isinstance(v,dict): 
+                self.log.debug(".. The value is a dict so we will do shallow copy")
                 if (hasattr(self,k)):
-                    self.log.debug("... shallow copy of KubeSpawner key %s values %s over spawner %s", k,**self.k, **v)
-                    v = {**self.k, **v}
+                    self.log.debug("... shallow copy of KubeSpawner key %s values %s over spawner %s", k,**self[k], **v)
+                    v = {**self[k], **v}
             setattr(self, k, v)
 
     # set of recognised user option keys

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1993,11 +1993,11 @@ class KubeSpawner(Spawner):
             else:
                 self.log.debug(".. overriding KubeSpawner value %s=%s", k, v)
             # if the override value is a dict and a similar dict exists in spawner do a shallow copy with 
-            # kubespawner values overriding values for existing keys in spawner. 
+            # kubespawner key/value overriding simlar key in spawner. 
             if isinstance(v,dict): 
-                self.log.debug(".. The value is a dict so we will do shallow copy")
+                self.log.debug(".. The value for key %s is a dict so we check if similar dict exists on spawner", k)
                 if (hasattr(self,k)):
-                    self.log.debug("... shallow copy of KubeSpawner key %s values %s over spawner %s", k,getattr(self,k), v)
+                    self.log.debug("... shallow copy of KubeSpawner key %s values %s over spawner %s", k,v,getattr(self,k))
                     v = {**getattr(self,k), **v}
             setattr(self, k, v)
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1993,7 +1993,8 @@ class KubeSpawner(Spawner):
             else:
                 self.log.debug(".. overriding KubeSpawner value %s=%s", k, v)
             # if the override value is a dict and a similar dict exists in spawner do a shallow copy with 
-            # kubespawner key/value overriding simlar key in spawner. 
+            # kubespawner key/value overriding simlar key in spawner.  This is important for example if you
+            # have set environment key/values in pre_spawn_start to prevent them from being removed.
             if isinstance(v,dict): 
                 self.log.debug(".. The value for key %s is a dict so we check if similar dict exists on spawner", k)
                 if (hasattr(self,k)):

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1992,10 +1992,12 @@ class KubeSpawner(Spawner):
                 self.log.debug(".. overriding KubeSpawner value %s=%s (callable result)", k, v)
             else:
                 self.log.debug(".. overriding KubeSpawner value %s=%s", k, v)
-                if (k == "environment"):
-                    if self.environment:
-                        self.log.debug(".. joining Spawner environment with KubeSpawner environment")
-                        v = {**self.environment, **v}
+            # if the override value is a dict and a similar dict exists in spawner do a shallow copy with 
+            # kubespawner values overriding values for existing keys in spawner. 
+            if isinstance(v,dict): 
+                if (hasattr(self,k)):
+                    self.log.debug("... shallow copy of KubeSpawner key %s values %s over spawner %s", k,**self.k, **v)
+                    v = {**self.k, **v}
             setattr(self, k, v)
 
     # set of recognised user option keys


### PR DESCRIPTION
current behavior is that the kubespawner profile completely overrides the spawner environment.  I have set the AD_TOKEN into the spawner environment in pre_spawn_start so I don't want my kubespawner profile environment override to remove this which it currently does.

This PR changes the behavior from override to merge for dict() overrides.  Now the kubespawner environment dict is combined with the spawner environment dict where the kubespawner environment values overrides any existing spawner environment variables.

This also fixes an inconsistent behavior where after the first failed spawn the spawner and kubespawner are combined on the second try.  (not really sure how that was happening)