### PR TITLE
Fix CI build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,19 @@ matrix:
     # the latest supported kubernetes-client,
     # and use the latest supported kubernetes
     # version along for the kubernetes-client.
+    #
+    # KUBE_PY represent the version of kubernetes-client/python, and client
+    # version 8 supports k8s API version 1.12, and version 9 supports k8s API
+    # version 1.13 and so on.
     - python: 3.8
       env: KUBE_PY=8 KUBE_VERSION=1.12.10
-    - python: 3.7
-      dist: xenial
+    # NOTE: TravisCI's linux kernel, has since 2020 or so, when specifying
+    #       bionic as a distribution, made minikube fail to start a k8s 1.13
+    #       cluster. This is why we use xenial here.
+    # Reference - a build failure with bionic:
+    #       https://travis-ci.org/jupyterhub/kubespawner/jobs/642305915
+    - dist: xenial
+      python: 3.7
       env: KUBE_PY=9 KUBE_VERSION=1.13.12
     - python: 3.6
       env: &latest_supported KUBE_PY=10 KUBE_VERSION=1.14.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
     - python: 3.8
       env: KUBE_PY=8 KUBE_VERSION=1.12.10
     - python: 3.7
+      dist: xenial
       env: KUBE_PY=9 KUBE_VERSION=1.13.12
     - python: 3.6
       env: &latest_supported KUBE_PY=10 KUBE_VERSION=1.14.9
@@ -52,13 +53,13 @@ matrix:
     #    python dependencies
     - &allowed_failure_1
       python: 3.8
-      env: PRE_RELEASES=TRUE KUBE_VERSION=1.15.3
+      env: PRE_RELEASES=TRUE KUBE_VERSION=1.15.9
 
     # 2. Test with latest stable kubernetes client along with the latest
     #    kubernetes cluster version
     - &allowed_failure_2
       python: 3.8
-      env: KUBE_PY=10 KUBE_VERSION=1.16.3
+      env: KUBE_PY=10 KUBE_VERSION=1.17.2
 
     # 3. Test with a nightly python build using latest known
     #    supported configuration.

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -1,10 +1,10 @@
 # default values for relevant environment variables
 
-# ref: https://github.com/kubernetes/minikube/releases
-export KUBE_VERSION=${KUBE_VERSION:-1.16.3}
+# ref: https://github.com/kubernetes/kubernetes/releases
+export KUBE_VERSION=${KUBE_VERSION:-1.17.2}
 
 # ref: https://github.com/kubernetes/minikube/releases
-export MINIKUBE_VERSION=${MINIKUBE_VERSION:-1.5.2}
+export MINIKUBE_VERSION=${MINIKUBE_VERSION:-1.6.2}
 
 # ref: https://github.com/helm/helm/releases
 export HELM_VERSION=${HELM_VERSION:-2.16.1}


### PR DESCRIPTION
Fixes CI build error on k8s 1.13, closes #392. It did it by using the `xenial` TravisCI build environment instead of the `bionic` one, as the following in a combination minikube/k8s 1.13/TravisCI's bionic environment, had an issue since about the start of 2020.

- Update minikube version used
- Updates k8s patch versions used
- Update the newest k8s version we test against (1.17.2)
