### PR TITLE
Use slugs to slugs to select profile via user_options_form

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1957,7 +1957,7 @@ class KubeSpawner(Spawner):
         if not self.profile_list or self._profile_list is None:
             return formdata
         return {
-            'profile': formdata.get('profile',[None])[0]
+            'profile': formdata.get('profile', [None])[0]
         }
 
     @gen.coroutine

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1954,8 +1954,6 @@ class KubeSpawner(Spawner):
             user_options (dict): the selected profile in the user_options form,
                 e.g. ``{"profile": "cpus-8"}``
         """
-        if not self.profile_list or self._profile_list is None:
-            return formdata
         return {
             'profile': formdata.get('profile', [None])[0]
         }

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2000,9 +2000,9 @@ class KubeSpawner(Spawner):
 
     def _init_profile_list(self, profile_list):
         # generate missing slug fields from display_name
-        for i, v in enumerate(profile_list):
-            if 'slug' not in profile_list[i]:
-                profile_list[i]['slug'] = slugify(profile_list[i]['display_name'])
+        for profile in profile_list:
+            if 'slug' not in profile:
+                profile['slug'] = slugify(profile['display_name'])
 
         return profile_list
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -44,7 +44,7 @@ from kubespawner.objects import make_pod, make_pvc
 from kubespawner.reflector import NamespacedResourceReflector
 from asyncio import sleep
 from async_generator import async_generator, yield_
-
+from slugify import slugify
 
 class PodReflector(NamespacedResourceReflector):
     """
@@ -1062,9 +1062,9 @@ class KubeSpawner(Spawner):
 
         <div class='form-group' id='kubespawner-profiles-list'>
         {% for profile in profile_list %}
-        <label for='profile-item-{{ loop.index0 }}' class='form-control input-group'>
+        <label for='profile-item-{{ profile.slug }}' class='form-control input-group'>
             <div class='col-md-1'>
-                <input type='radio' name='profile' id='profile-item-{{ loop.index0 }}' value='{{ loop.index0 }}' {% if profile.default %}checked{% endif %} />
+                <input type='radio' name='profile' id='profile-item-{{ profile.slug }}' value='{{ profile.slug }}' {% if profile.default %}checked{% endif %} />
             </div>
             <div class='col-md-11'>
                 <strong>{{ profile.display_name }}</strong>
@@ -1101,6 +1101,8 @@ class KubeSpawner(Spawner):
         Signature is: `List(Dict())`, where each item is a dictionary that has two keys:
 
         - `display_name`: the human readable display name (should be HTML safe)
+        - `slug`: the machine readable slug to ifentify the profile
+          (missing slugs are generated from display_name)
         - `description`: Optional description of this profile displayed to the user.
         - `kubespawner_override`: a dictionary with overrides to apply to the KubeSpawner
           settings. Each value can be either the final value to change or a callable that
@@ -1112,6 +1114,7 @@ class KubeSpawner(Spawner):
             c.KubeSpawner.profile_list = [
                 {
                     'display_name': 'Training Env - Python',
+                    'slug': 'training-python',
                     'default': True,
                     'kubespawner_override': {
                         'image': 'training/python:label',
@@ -1120,6 +1123,7 @@ class KubeSpawner(Spawner):
                     }
                 }, {
                     'display_name': 'Training Env - Datascience',
+                    'slug': 'training-datascience',
                     'kubespawner_override': {
                         'image': 'training/datascience:label',
                         'cpu_limit': 4,
@@ -1127,6 +1131,7 @@ class KubeSpawner(Spawner):
                     }
                 }, {
                     'display_name': 'DataScience - Small instance',
+                    'slug': 'datascience-small',
                     'kubespawner_override': {
                         'image': 'datascience/small:label',
                         'cpu_limit': 10,
@@ -1134,6 +1139,7 @@ class KubeSpawner(Spawner):
                     }
                 }, {
                     'display_name': 'DataScience - Medium instance',
+                    'slug': 'datascience-medium',
                     'kubespawner_override': {
                         'image': 'datascience/medium:label',
                         'cpu_limit': 48,
@@ -1141,6 +1147,7 @@ class KubeSpawner(Spawner):
                     }
                 }, {
                     'display_name': 'DataScience - Medium instance (GPUx2)',
+                    'slug': 'datascience-gpu2x',
                     'kubespawner_override': {
                         'image': 'datascience/medium:label',
                         'cpu_limit': 48,
@@ -1897,13 +1904,14 @@ class KubeSpawner(Spawner):
     _profile_list = None
 
     def _render_options_form(self, profile_list):
-        self._profile_list = profile_list
+        self._profile_list = self._init_profile_list(profile_list)
         profile_form_template = Environment(loader=BaseLoader).from_string(self.profile_form_template)
-        return profile_form_template.render(profile_list=profile_list)
+        return profile_form_template.render(profile_list=self._profile_list)
 
     @gen.coroutine
     def _render_options_form_dynamically(self, current_spawner):
         profile_list = yield gen.maybe_future(self.profile_list(current_spawner))
+        profile_list = self._init_profile_list(profile_list)
         return self._render_options_form(profile_list)
 
     @default('options_form')
@@ -1944,22 +1952,16 @@ class KubeSpawner(Spawner):
 
         Returns:
             user_options (dict): the selected profile in the user_options form,
-                e.g. ``{"profile": "8 CPUs"}``
+                e.g. ``{"profile": "cpus-8"}``
         """
         if not self.profile_list or self._profile_list is None:
             return formdata
-        # Default to first profile if somehow none is provided
-        try:
-            selected_profile = int(formdata.get('profile', [0])[0])
-            options = self._profile_list[selected_profile]
-        except (TypeError, IndexError, ValueError):
-            raise web.HTTPError(400, "No such profile: %i", formdata.get('profile', None))
         return {
-            'profile': options['display_name']
+            'profile': formdata.get('profile',[None])[0]
         }
 
     @gen.coroutine
-    def _load_profile(self, profile_name):
+    def _load_profile(self, slug):
         """Load a profile by name
 
         Called by load_user_options
@@ -1972,13 +1974,13 @@ class KubeSpawner(Spawner):
                 # explicit default, not the first
                 default_profile = profile
 
-            if profile['display_name'] == profile_name:
+            if profile['slug'] == slug:
                 break
         else:
-            if profile_name:
+            if slug:
                 # name specified, but not found
                 raise ValueError("No such profile: %s. Options include: %s" % (
-                    profile_name, ', '.join(p['display_name'] for p in self._profile_list)
+                    slug, ', '.join(p['slug'] for p in self._profile_list)
                 ))
             else:
                 # no name specified, use the default
@@ -1998,6 +2000,14 @@ class KubeSpawner(Spawner):
     # used for warning about ignoring unrecognised options
     _user_option_keys = {'profile',}
 
+    def _init_profile_list(self, profile_list):
+        # generate missing slug fields from display_name
+        for i, v in enumerate(profile_list):
+            if 'slug' not in profile_list[i]:
+                profile_list[i]['slug'] = slugify(profile_list[i]['display_name'])
+
+        return profile_list
+
     @gen.coroutine
     def load_user_options(self):
         """Load user options from self.user_options dict
@@ -2007,11 +2017,15 @@ class KubeSpawner(Spawner):
         Only supported argument by default is 'profile'.
         Override in subclasses to support other options.
         """
+
         if self._profile_list is None:
             if callable(self.profile_list):
-                self._profile_list = yield gen.maybe_future(self.profile_list(self))
+                profile_list = yield gen.maybe_future(self.profile_list(self))
             else:
-                self._profile_list = self.profile_list
+                profile_list = self.profile_list
+
+            self._profile_list = self._init_profile_list(profile_list)
+
         selected_profile = self.user_options.get('profile', None)
         if self._profile_list:
             yield self._load_profile(selected_profile)

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=[
         'async_generator>=1.8',
         'escapism',
+        'python-slugify',
         'jupyterhub>=0.8',
         'jinja2',
         'kubernetes>=10.1.0',

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -7,7 +7,6 @@ from kubernetes.client.models import (
 from kubespawner import KubeSpawner
 from traitlets.config import Config
 from unittest.mock import Mock
-from slugify import slugify
 import json
 import os
 import pytest
@@ -235,7 +234,7 @@ async def test_user_options_api():
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = _test_profiles
     # set user_options directly (e.g. via api)
-    spawner.user_options = {'profile': slugify(_test_profiles[1]['slug'])}
+    spawner.user_options = {'profile': _test_profiles[1]['slug']}
 
     # nothing should be loaded yet
     assert spawner.cpu_limit is None

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -7,6 +7,7 @@ from kubernetes.client.models import (
 from kubespawner import KubeSpawner
 from traitlets.config import Config
 from unittest.mock import Mock
+from slugify import slugify
 import json
 import os
 import pytest
@@ -192,6 +193,7 @@ def test_get_pod_manifest_tolerates_mixed_input():
 _test_profiles = [
     {
         'display_name': 'Training Env - Python',
+        'slug': 'training-python',
         'default': True,
         'kubespawner_override': {
             'image': 'training/python:label',
@@ -216,9 +218,9 @@ async def test_user_options_set_from_form():
     spawner.profile_list = _test_profiles
     # render the form
     await spawner.get_options_form()
-    spawner.user_options = spawner.options_from_form({'profile': [1]})
+    spawner.user_options = spawner.options_from_form({'profile': [_test_profiles[1]['slug']]})
     assert spawner.user_options == {
-        'profile': _test_profiles[1]['display_name'],
+        'profile': _test_profiles[1]['slug'],
     }
     # nothing should be loaded yet
     assert spawner.cpu_limit is None
@@ -232,7 +234,7 @@ async def test_user_options_api():
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = _test_profiles
     # set user_options directly (e.g. via api)
-    spawner.user_options = {'profile': _test_profiles[1]['display_name']}
+    spawner.user_options = {'profile': slugify(_test_profiles[1]['slug'])}
 
     # nothing should be loaded yet
     assert spawner.cpu_limit is None

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -203,6 +203,7 @@ _test_profiles = [
     },
     {
         'display_name': 'Training Env - Datascience',
+        'slug': 'training-datascience',
         'kubespawner_override': {
             'image': 'training/datascience:label',
             'cpu_limit': 4,


### PR DESCRIPTION
This PR changes the numeric IDs used by the user_options_form for selecting a profile.

After applying this PR, kubespawner will use short unique identifiers which can either be specified using a new key `slug` in the profile_list or in its absence will be generated from the `display_name` key.

###### Example

```yaml
  - display_name: "[TESA] Technikbasierte Energiesystemanalyse"
    slug: tesa
    kubespawner_override:
      image: registry.git.rwth-aachen.de/jupyter/profiles/tesa:latest
```

The main motivation of this PR is related to #189 and https://github.com/jupyterhub/jupyterhub/pull/3013 and allows the user to spawn profiles by crafting a special URL

###### Example

```
https://jupyter.rwth-aachen.de/hub/spawn?profile=tesa
```