### PR TITLE
Update ingress models

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -473,9 +473,9 @@ def make_ingress(
     # which are more sensitive to kubernetes version
     # and will change when they move out of beta
     from kubernetes.client.models import (
-        NetworkingV1beta1Ingress, NetworkingV1beta1IngressSpec, NetworkingV1beta1IngressRule,
-        NetworkingV1beta1HTTPIngressRuleValue, NetworkingV1beta1HTTPIngressPath,
-        NetworkingV1beta1IngressBackend,
+        ExtensionsV1beta1Ingress, ExtensionsV1beta1IngressSpec, ExtensionsV1beta1IngressRule,
+        ExtensionsV1beta1HTTPIngressRuleValue, ExtensionsV1beta1HTTPIngressPath,
+        ExtensionsV1beta1IngressBackend,
     )
 
     meta = V1ObjectMeta(
@@ -544,17 +544,17 @@ def make_ingress(
         )
 
     # Make Ingress object
-    ingress = NetworkingV1beta1Ingress(
+    ingress = ExtensionsV1beta1Ingress(
         kind='Ingress',
         metadata=meta,
-        spec=NetworkingV1beta1IngressSpec(
-            rules=[NetworkingV1beta1IngressRule(
+        spec=ExtensionsV1beta1IngressSpec(
+            rules=[ExtensionsV1beta1IngressRule(
                 host=host,
-                http=NetworkingV1beta1HTTPIngressRuleValue(
+                http=ExtensionsV1beta1HTTPIngressRuleValue(
                     paths=[
-                        NetworkingV1beta1HTTPIngressPath(
+                        ExtensionsV1beta1HTTPIngressPath(
                             path=path,
-                            backend=NetworkingV1beta1IngressBackend(
+                            backend=ExtensionsV1beta1IngressBackend(
                                 service_name=name,
                                 service_port=target_port
                             )

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -472,11 +472,23 @@ def make_ingress(
     # move beta imports here,
     # which are more sensitive to kubernetes version
     # and will change when they move out of beta
-    from kubernetes.client.models import (
-        ExtensionsV1beta1Ingress, ExtensionsV1beta1IngressSpec, ExtensionsV1beta1IngressRule,
-        ExtensionsV1beta1HTTPIngressRuleValue, ExtensionsV1beta1HTTPIngressPath,
-        ExtensionsV1beta1IngressBackend,
-    )
+    # because of the API changes in 1.16, the import is tried conditionally
+    # to keep compatibility with older K8S versions
+
+    try:
+        from kubernetes.client.models import (
+            ExtensionsV1beta1Ingress, ExtensionsV1beta1IngressSpec, ExtensionsV1beta1IngressRule,
+            ExtensionsV1beta1HTTPIngressRuleValue, ExtensionsV1beta1HTTPIngressPath,
+            ExtensionsV1beta1IngressBackend,
+        )
+    except ImportError:
+        from kubernetes.client.models import (
+            V1beta1Ingress as ExtensionsV1beta1Ingress, V1beta1IngressSpec as ExtensionsV1beta1IngressSpec,
+            V1beta1IngressRule as ExtensionsV1beta1IngressRule,
+            V1beta1HTTPIngressRuleValue as ExtensionsV1beta1HTTPIngressRuleValue,
+            V1beta1HTTPIngressPath as ExtensionsV1beta1HTTPIngressPath,
+            V1beta1IngressBackend as ExtensionsV1beta1IngressBackend
+        )
 
     meta = V1ObjectMeta(
         name=name,

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -473,9 +473,9 @@ def make_ingress(
     # which are more sensitive to kubernetes version
     # and will change when they move out of beta
     from kubernetes.client.models import (
-        V1beta1Ingress, V1beta1IngressSpec, V1beta1IngressRule,
-        V1beta1HTTPIngressRuleValue, V1beta1HTTPIngressPath,
-        V1beta1IngressBackend,
+        NetworkingV1beta1Ingress, NetworkingV1beta1IngressSpec, NetworkingV1beta1IngressRule,
+        NetworkingV1beta1HTTPIngressRuleValue, NetworkingV1beta1HTTPIngressPath,
+        NetworkingV1beta1IngressBackend,
     )
 
     meta = V1ObjectMeta(
@@ -544,17 +544,17 @@ def make_ingress(
         )
 
     # Make Ingress object
-    ingress = V1beta1Ingress(
+    ingress = NetworkingV1beta1Ingress(
         kind='Ingress',
         metadata=meta,
-        spec=V1beta1IngressSpec(
-            rules=[V1beta1IngressRule(
+        spec=NetworkingV1beta1IngressSpec(
+            rules=[NetworkingV1beta1IngressRule(
                 host=host,
-                http=V1beta1HTTPIngressRuleValue(
+                http=NetworkingV1beta1HTTPIngressRuleValue(
                     paths=[
-                        V1beta1HTTPIngressPath(
+                        NetworkingV1beta1HTTPIngressPath(
                             path=path,
-                            backend=V1beta1IngressBackend(
+                            backend=NetworkingV1beta1IngressBackend(
                                 service_name=name,
                                 service_port=target_port
                             )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'escapism',
         'jupyterhub>=0.8',
         'jinja2',
-        'kubernetes>=8.0',
+        'kubernetes>=10.1.0',
         'pyYAML',
     ],
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ setup(
             'bump2version',
             'flake8',
             'jupyterhub-dummyauthenticator',
-            'pytest>=3.3',
+            'pytest>=5.4',
             'pytest-cov',
-            'pytest-asyncio',
+            'pytest-asyncio>=0.11.0',
         ]
     },
     description='JupyterHub Spawner for Kubernetes',


### PR DESCRIPTION
The KubeIngressProxy depended on deprecated Kubernetes models that have moved from V1beta1 to ExtensionsV1beta1 in python-kubernetes 10 and up.