### PR TITLE
Add a unit test for the spawner

### DIFF
--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1812,7 +1812,7 @@ async def test_spawn_pending_pods(kube_ns, kube_client):
     c.KubeSpawner.start_timeout = 5  # Do not wait very long.
     spawner = KubeSpawner(hub=Hub(), user=MockUser(), config=c)
     with pytest.raises(TimeoutError) as te:
-      await spawner.start()
+        await spawner.start()
     assert 'pod/jupyter-fake did not start' in str(te.value)
 
     pods = kube_client.list_namespaced_pod(kube_ns).items
@@ -1838,7 +1838,7 @@ async def test_spawn_watcher_reflector_started_twice(config):
 
     with pytest.raises(ValueError) as ve:
         spawner.pod_reflector.start()
-    assert ('Thread watching for resources is already running' in str(ve.value))
+    assert 'Thread watching for resources is already running' in str(ve.value)
     await spawner.stop()
 
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -17,6 +17,7 @@ from kubernetes_asyncio.client.models import (
     V1Pod,
     V1SecurityContext,
 )
+from kubernetes_asyncio.client.rest import ApiException
 from traitlets.config import Config
 
 from kubespawner import KubeSpawner


### PR DESCRIPTION
This adds a test for the case where a pod is unschedulable and never leaves 'pending'.
Also a test for what happens when the pod reflector is added twice, and a basic test about creating a pvc (I only test the easy bit here where it raises an ApiException; for testing non-exception case would need to use a mock or a fixture that ensures the pvc is deleted afterwards).

I made two changes to the spawner that need review from someone who knows this code -- both are in places where a TimeoutException has been caught, and the spawner prints 'restarting pods'. The original code calls 'raise' right after that, and that seemed odd, so I changed it. If you think that's wrong, please let me know!

This brings coverage to 78.19%.

I've also noticed that proxy.py appears unused -- I wasn't sure of the status of that code though.