### PR TITLE
Support internal_ssl

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
   run-pytest:
     name: Run pytest
     runs-on: ubuntu-20.04
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     strategy:
       # Keep running even if one variation of the job fail
@@ -112,7 +112,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest -v --cov kubespawner --color=yes
+          pytest -v --durations 10 --cov kubespawner --color=yes
 
       - name: Submit a codecov report
         run: |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Kubespawner
    spawner
    objects
    reflector
+   ssl.md
    traitlets
    utils
 

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -43,6 +43,8 @@ simultaneous users), Kubernetes is a wonderful way to do it. Features include:
   lock-in. You can even spread out your cluster across
   [multiple clouds at the same time](https://kubernetes.io/docs/concepts/cluster-administration/federation/).
 
+* Internal SSL configuration supported
+
 In general, Kubernetes provides a ton of well thought out, useful features -
 and you can use all of them along with this spawner.
 

--- a/docs/source/ssl.md
+++ b/docs/source/ssl.md
@@ -1,0 +1,13 @@
+# Internal SSL
+
+JupyterHub 1.0 introduces internal_ssl configuration for encryption and authentication of all internal communication.
+
+Kubespawner can mount the internal_ssl certificates as Kubernetes secrets into the jupyter user's pod.
+
+## Setup
+
+```
+c.JupyterHub.internal_ssl = True
+
+c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
+```

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -1,26 +1,33 @@
 """
 Helper methods for generating k8s API objects.
 """
+import base64
 import json
+import os
 import re
 from urllib.parse import urlparse
 
+from kubernetes.client.models import (V1Affinity, V1Container, V1ContainerPort,
+                                      V1EndpointAddress, V1EndpointPort,
+                                      V1Endpoints, V1EndpointSubset, V1EnvVar,
+                                      V1LabelSelector, V1Lifecycle,
+                                      V1LocalObjectReference, V1NodeAffinity,
+                                      V1NodeSelector,
+                                      V1NodeSelectorRequirement,
+                                      V1NodeSelectorTerm, V1ObjectMeta,
+                                      V1OwnerReference,
+                                      V1PersistentVolumeClaim,
+                                      V1PersistentVolumeClaimSpec, V1Pod,
+                                      V1PodAffinity, V1PodAffinityTerm,
+                                      V1PodAntiAffinity, V1PodSecurityContext,
+                                      V1PodSpec, V1PreferredSchedulingTerm,
+                                      V1ResourceRequirements, V1Secret,
+                                      V1SecurityContext, V1Service,
+                                      V1ServicePort, V1ServiceSpec,
+                                      V1Toleration, V1Volume, V1VolumeMount,
+                                      V1WeightedPodAffinityTerm)
 from kubespawner.utils import get_k8s_model, update_k8s_model
 
-from kubernetes.client.models import (
-    V1Pod, V1PodSpec, V1PodSecurityContext,
-    V1ObjectMeta,
-    V1LocalObjectReference,
-    V1Volume, V1VolumeMount,
-    V1Container, V1ContainerPort, V1SecurityContext, V1EnvVar, V1ResourceRequirements, V1Lifecycle,
-    V1PersistentVolumeClaim, V1PersistentVolumeClaimSpec,
-    V1Endpoints, V1EndpointSubset, V1EndpointAddress, V1EndpointPort,
-    V1Service, V1ServiceSpec, V1ServicePort,
-    V1Toleration,
-    V1Affinity,
-    V1NodeAffinity, V1NodeSelector, V1NodeSelectorTerm, V1PreferredSchedulingTerm, V1NodeSelectorRequirement,
-    V1PodAffinity, V1PodAntiAffinity, V1WeightedPodAffinityTerm, V1PodAffinityTerm,
-)
 
 def make_pod(
     name,
@@ -63,6 +70,8 @@ def make_pod(
     pod_anti_affinity_preferred=None,
     pod_anti_affinity_required=None,
     priority_class_name=None,
+    ssl_secret_name=None,
+    ssl_secret_mount_path=None,
     logger=None,
 ):
     """
@@ -220,6 +229,10 @@ def make_pod(
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#podaffinityterm-v1-core
     priority_class_name:
         The name of the PriorityClass to be assigned the pod. This feature is Beta available in K8s 1.11.
+    ssl_secret_name:
+        Specifies the name of the ssl secret
+    ssl_secret_mount_path:
+        Specifies the name of the ssl secret mount path for the pod
     """
 
     pod = V1Pod()
@@ -245,6 +258,25 @@ def make_pod(
             get_k8s_model(V1LocalObjectReference, secret_ref)
             for secret_ref in image_pull_secrets
         ]
+
+    if ssl_secret_name and ssl_secret_mount_path:
+        if not volumes:
+            volumes = []
+        volumes.append({
+            'name':'jupyterhub-internal-certs',
+            'secret': {
+                'secretName': ssl_secret_name,
+                'defaultMode': 511
+            }
+        })
+
+        env['JUPYTERHUB_SSL_KEYFILE'] = ssl_secret_mount_path + "ssl.key"
+        env['JUPYTERHUB_SSL_CERTFILE'] = ssl_secret_mount_path + "ssl.crt"
+        env['JUPYTERHUB_SSL_CLIENT_CA'] = ssl_secret_mount_path + "notebooks-ca_trust.crt"
+
+        if not volume_mounts:
+            volume_mounts = []
+        volume_mounts.append({'name': 'jupyterhub-internal-certs', 'mountPath': ssl_secret_mount_path})
 
     if node_selector:
         pod.spec.node_selector = node_selector
@@ -599,3 +631,123 @@ def make_ingress(
     )
 
     return endpoint, service, ingress
+
+def make_owner_reference(name, uid):
+    """
+    Returns a owner reference object for garbage collection.
+    """
+    return V1OwnerReference(
+            api_version="v1",
+            kind="Pod",
+            name=name,
+            uid=uid,
+            block_owner_deletion=True,
+            controller=False
+           )
+
+def make_secret(
+    name,
+    username,
+    cert_paths,
+    hub_ca,
+    owner_references,
+    labels=None,
+    annotations=None,
+):
+    """
+    Make a k8s secret specification using pre-existing ssl credentials for a given user.
+
+    Parameters
+    ----------
+    name:
+        Name of the secret. Must be unique within the namespace the object is
+        going to be created in.
+    username:
+        The name of the user notebook.
+    cert_paths:
+        JupyterHub spawners cert_paths dictionary container certificate path references
+    hub_ca:
+        Path to the hub certificate authority
+    labels:
+        Labels to add to the secret.
+    annotations:
+        Annotations to add to the secret.
+    """
+
+    secret = V1Secret()
+    secret.kind = "Secret"
+    secret.api_version = "v1"
+    secret.metadata = V1ObjectMeta()
+    secret.metadata.name = name
+    secret.metadata.annotations = (annotations or {}).copy()
+    secret.metadata.labels = (labels or {}).copy()
+    secret.metadata.owner_references=owner_references
+
+    secret.data = {}
+
+    with open(cert_paths['keyfile'], 'r') as file:
+        encoded = base64.b64encode(file.read().encode("utf-8"))
+        secret.data['ssl.key'] = encoded.decode("utf-8")
+
+    with open(cert_paths['certfile'], 'r') as file:
+        encoded = base64.b64encode(file.read().encode("utf-8"))
+        secret.data['ssl.crt'] = encoded.decode("utf-8")
+
+    with open(cert_paths['cafile'], 'r') as file:
+        encoded = base64.b64encode(file.read().encode("utf-8"))
+        secret.data["notebooks-ca_trust.crt"] = encoded.decode("utf-8")
+
+    with open(hub_ca, 'r') as file:
+        encoded = base64.b64encode(file.read().encode("utf-8"))
+        secret.data["notebooks-ca_trust.crt"] = secret.data["notebooks-ca_trust.crt"] + encoded.decode("utf-8")
+
+    return secret
+
+
+def make_service(
+    name,
+    port,
+    servername,
+    owner_references,
+    labels=None,
+    annotations=None,
+):
+    """
+    Make a k8s service specification for using dns to communicate with the notebook.
+
+    Parameters
+    ----------
+    name:
+        Name of the service. Must be unique within the namespace the object is
+        going to be created in.
+    env:
+        Dictionary of environment variables.
+    labels:
+        Labels to add to the service.
+    annotations:
+        Annotations to add to the service.
+
+    """
+
+    metadata = V1ObjectMeta(
+        name=name,
+        annotations=(annotations or {}).copy(),
+        labels=(labels or {}).copy(),
+        owner_references=owner_references,
+    )
+
+    service = V1Service(
+        kind='Service',
+        metadata=metadata,
+        spec=V1ServiceSpec(
+            type='ClusterIP',
+            ports=[V1ServicePort(port=port, target_port=port)],
+            selector={
+                'component': 'singleuser-server',
+                'hub.jupyter.org/servername': servername,
+                'hub.jupyter.org/username': metadata.labels['hub.jupyter.org/username']
+            }
+        )
+    )
+
+    return service

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -7,25 +7,44 @@ import os
 import re
 from urllib.parse import urlparse
 
-from kubernetes.client.models import (V1Affinity, V1Container, V1ContainerPort,
-                                      V1EndpointAddress, V1EndpointPort,
-                                      V1Endpoints, V1EndpointSubset, V1EnvVar,
-                                      V1LabelSelector, V1Lifecycle,
-                                      V1LocalObjectReference, V1NodeAffinity,
-                                      V1NodeSelector,
-                                      V1NodeSelectorRequirement,
-                                      V1NodeSelectorTerm, V1ObjectMeta,
-                                      V1OwnerReference,
-                                      V1PersistentVolumeClaim,
-                                      V1PersistentVolumeClaimSpec, V1Pod,
-                                      V1PodAffinity, V1PodAffinityTerm,
-                                      V1PodAntiAffinity, V1PodSecurityContext,
-                                      V1PodSpec, V1PreferredSchedulingTerm,
-                                      V1ResourceRequirements, V1Secret,
-                                      V1SecurityContext, V1Service,
-                                      V1ServicePort, V1ServiceSpec,
-                                      V1Toleration, V1Volume, V1VolumeMount,
-                                      V1WeightedPodAffinityTerm)
+from kubernetes.client.models import (
+    V1Affinity,
+    V1Container,
+    V1ContainerPort,
+    V1EndpointAddress,
+    V1EndpointPort,
+    V1Endpoints,
+    V1EndpointSubset,
+    V1EnvVar,
+    V1LabelSelector,
+    V1Lifecycle,
+    V1LocalObjectReference,
+    V1NodeAffinity,
+    V1NodeSelector,
+    V1NodeSelectorRequirement,
+    V1NodeSelectorTerm,
+    V1ObjectMeta,
+    V1OwnerReference,
+    V1PersistentVolumeClaim,
+    V1PersistentVolumeClaimSpec,
+    V1Pod,
+    V1PodAffinity,
+    V1PodAffinityTerm,
+    V1PodAntiAffinity,
+    V1PodSecurityContext,
+    V1PodSpec,
+    V1PreferredSchedulingTerm,
+    V1ResourceRequirements,
+    V1Secret,
+    V1SecurityContext,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+    V1Toleration,
+    V1Volume,
+    V1VolumeMount,
+    V1WeightedPodAffinityTerm,
+)
 from kubespawner.utils import get_k8s_model, update_k8s_model
 
 
@@ -262,21 +281,24 @@ def make_pod(
     if ssl_secret_name and ssl_secret_mount_path:
         if not volumes:
             volumes = []
-        volumes.append({
-            'name':'jupyterhub-internal-certs',
-            'secret': {
-                'secretName': ssl_secret_name,
-                'defaultMode': 511
+        volumes.append(
+            {
+                'name': 'jupyterhub-internal-certs',
+                'secret': {'secretName': ssl_secret_name, 'defaultMode': 511},
             }
-        })
+        )
 
         env['JUPYTERHUB_SSL_KEYFILE'] = ssl_secret_mount_path + "ssl.key"
         env['JUPYTERHUB_SSL_CERTFILE'] = ssl_secret_mount_path + "ssl.crt"
-        env['JUPYTERHUB_SSL_CLIENT_CA'] = ssl_secret_mount_path + "notebooks-ca_trust.crt"
+        env['JUPYTERHUB_SSL_CLIENT_CA'] = (
+            ssl_secret_mount_path + "notebooks-ca_trust.crt"
+        )
 
         if not volume_mounts:
             volume_mounts = []
-        volume_mounts.append({'name': 'jupyterhub-internal-certs', 'mountPath': ssl_secret_mount_path})
+        volume_mounts.append(
+            {'name': 'jupyterhub-internal-certs', 'mountPath': ssl_secret_mount_path}
+        )
 
     if node_selector:
         pod.spec.node_selector = node_selector
@@ -632,18 +654,20 @@ def make_ingress(
 
     return endpoint, service, ingress
 
+
 def make_owner_reference(name, uid):
     """
     Returns a owner reference object for garbage collection.
     """
     return V1OwnerReference(
-            api_version="v1",
-            kind="Pod",
-            name=name,
-            uid=uid,
-            block_owner_deletion=True,
-            controller=False
-           )
+        api_version="v1",
+        kind="Pod",
+        name=name,
+        uid=uid,
+        block_owner_deletion=True,
+        controller=False,
+    )
+
 
 def make_secret(
     name,
@@ -681,7 +705,7 @@ def make_secret(
     secret.metadata.name = name
     secret.metadata.annotations = (annotations or {}).copy()
     secret.metadata.labels = (labels or {}).copy()
-    secret.metadata.owner_references=owner_references
+    secret.metadata.owner_references = owner_references
 
     secret.data = {}
 
@@ -699,7 +723,9 @@ def make_secret(
 
     with open(hub_ca, 'r') as file:
         encoded = base64.b64encode(file.read().encode("utf-8"))
-        secret.data["notebooks-ca_trust.crt"] = secret.data["notebooks-ca_trust.crt"] + encoded.decode("utf-8")
+        secret.data["notebooks-ca_trust.crt"] = secret.data[
+            "notebooks-ca_trust.crt"
+        ] + encoded.decode("utf-8")
 
     return secret
 
@@ -745,9 +771,9 @@ def make_service(
             selector={
                 'component': 'singleuser-server',
                 'hub.jupyter.org/servername': servername,
-                'hub.jupyter.org/username': metadata.labels['hub.jupyter.org/username']
-            }
-        )
+                'hub.jupyter.org/username': metadata.labels['hub.jupyter.org/username'],
+            },
+        ),
     )
 
     return service

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,53 @@
 """pytest fixtures for kubespawner"""
 
+import base64
+import inspect
+import io
+import logging
 import os
+import sys
+import tarfile
+import time
+from distutils.version import LooseVersion as V
+from functools import partial
+from threading import Thread
 
-from kubernetes.client import V1Namespace
-from kubernetes.config import load_kube_config
+import kubernetes
 import pytest
+from kubernetes.client import (
+    V1ConfigMap,
+    V1Namespace,
+    V1Pod,
+    V1PodSpec,
+    V1Secret,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+)
+from kubernetes.config import load_kube_config
+from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream
+from kubernetes.watch import Watch
 from traitlets.config import Config
 
+from jupyterhub.app import JupyterHub
+from jupyterhub.objects import Hub
 from kubespawner.clients import shared_client
+
+here = os.path.abspath(os.path.dirname(__file__))
+jupyterhub_config_py = os.path.join(here, "jupyterhub_config.py")
+
+
+@pytest.fixture(autouse=True)
+def traitlets_logging():
+    """Ensure traitlets default logging is enabled
+
+    so KubeSpawner logs are captured by pytest.
+    By default, there is a "NullHandler" so no logs are produced.
+    """
+    logger = logging.getLogger('traitlets')
+    logger.setLevel(logging.DEBUG)
+    logger.handlers = []
 
 
 @pytest.fixture(scope="session")
@@ -25,7 +65,111 @@ def config(kube_ns):
     """
     cfg = Config()
     cfg.KubeSpawner.namespace = kube_ns
+    cfg.KubeSpawner.cmd = ["jupyterhub-singleuser"]
+    cfg.KubeSpawner.start_timeout = 180
+    # prevent spawners from exiting early due to missing env
+    cfg.KubeSpawner.environment = {
+        "JUPYTERHUB_API_TOKEN": "test-secret-token",
+        "JUPYTERHUB_CLIENT_ID": "ignored",
+    }
     return cfg
+
+
+@pytest.fixture(scope="session")
+def ssl_app(tmpdir_factory, kube_ns):
+    """Partially instantiate a JupyterHub instance to generate ssl certificates
+
+    Generates ssl certificates on the host,
+    which will then be staged
+
+    This is not a fully instantiated Hub,
+    but it will have internal_ssl-related attributes such as
+    .internal_trust_bundles and .internal_certs_location initialized.
+    """
+    tmpdir = tmpdir_factory.mktemp("ssl")
+    tmpdir.chdir()
+    config = Config()
+    config.JupyterHub.internal_ssl = True
+    tmpdir.mkdir("internal-ssl")
+    # use relative path for ssl certs
+    config.JupyterHub.internal_certs_location = "internal-ssl"
+    config.JupyterHub.trusted_alt_names = [
+        "DNS:hub-ssl",
+        f"DNS:hub-ssl.{kube_ns}",
+        f"DNS:hub-ssl.{kube_ns}.svc",
+        f"DNS:hub-ssl.{kube_ns}.svc.cluster.local",
+    ]
+    app = JupyterHub(config=config)
+    app.init_internal_ssl()
+    return app
+
+
+def watch_logs(kube_client, pod_info):
+    """Stream a single pod's logs
+
+    pod logs are streamed directly to sys.stderr,
+    so that pytest capture can deal with it.
+
+    Blocking, should be run in a thread.
+
+    Called for each new pod from watch_kubernetes
+    """
+    watch = Watch()
+    while True:
+        try:
+            for event in watch.stream(
+                func=kube_client.read_namespaced_pod_log,
+                namespace=pod_info.namespace,
+                name=pod_info.name,
+            ):
+                print(f"[{pod_info.name}]: {event}")
+        except ApiException as e:
+            if e.status == 400:
+                # 400 can occur if the container is not yet ready
+                # wait and retry
+                time.sleep(1)
+                continue
+            elif e.status == 404:
+                # pod is gone, we are done
+                return
+            else:
+                # unexpeced error
+                print(f"Error watching logs for {pod_info.name}: {e}", file=sys.stderr)
+                raise
+        else:
+            break
+
+
+def watch_kubernetes(kube_client, kube_ns):
+    """Stream kubernetes events to stdout
+
+    so that pytest io capturing can include k8s events and logs
+
+    All events are streamed to stdout
+
+    When a new pod is started, spawn an additional thread to watch its logs
+    """
+    log_threads = {}
+    watch = Watch()
+    for event in watch.stream(
+        func=kube_client.list_namespaced_event,
+        namespace=kube_ns,
+    ):
+
+        resource = event['object']
+        obj = resource.involved_object
+        print(f"k8s event ({event['type']} {obj.kind}/{obj.name}): {resource.message}")
+
+        # new pod appeared, start streaming its logs
+        if (
+            obj.kind == "Pod"
+            and event["type"] == "ADDED"
+            and obj.name not in log_threads
+        ):
+            log_threads[obj.name] = t = Thread(
+                target=watch_logs, args=(kube_client, obj), daemon=True
+            )
+            t.start()
 
 
 @pytest.fixture(scope="session")
@@ -33,18 +177,382 @@ def kube_client(request, kube_ns):
     """fixture for the Kubernetes client object.
 
     skips test that require kubernetes if kubernetes cannot be contacted
+
+    - Ensures kube_ns namespace exists
+    - Hooks up kubernetes events and logs to pytest capture
+    - Cleans up kubernetes namespace on exit
     """
     load_kube_config()
-    client = shared_client('CoreV1Api')
+    client = shared_client("CoreV1Api")
     try:
         namespaces = client.list_namespace(_request_timeout=3)
     except Exception as e:
         pytest.skip("Kubernetes not found: %s" % e)
+
     if not any(ns.metadata.name == kube_ns for ns in namespaces.items):
         print("Creating namespace %s" % kube_ns)
         client.create_namespace(V1Namespace(metadata=dict(name=kube_ns)))
     else:
         print("Using existing namespace %s" % kube_ns)
+
+    # begin streaming all logs and events in our test namespace
+    t = Thread(target=watch_kubernetes, args=(client, kube_ns), daemon=True)
+    t.start()
+
     # delete the test namespace when we finish
-    request.addfinalizer(lambda: client.delete_namespace(kube_ns, body={}))
+    def cleanup_namespace():
+        client.delete_namespace(kube_ns, body={}, grace_period_seconds=0)
+        for i in range(3):
+            try:
+                ns = client.read_namespace(kube_ns)
+            except ApiException as e:
+                if e.status == 404:
+                    return
+                else:
+                    raise
+            else:
+                print("waiting for %s to delete" % kube_ns)
+                time.sleep(1)
+
+    # allow opting out of namespace cleanup, for post-mortem debugging
+    if not os.environ.get("KUBESPAWNER_DEBUG_NAMESPACE"):
+        request.addfinalizer(cleanup_namespace)
     return client
+
+
+def wait_for_pod(kube_client, kube_ns, pod_name, timeout=90):
+    """Wait for a pod to be ready"""
+    conditions = {}
+    for i in range(int(timeout)):
+        pod = kube_client.read_namespaced_pod(namespace=kube_ns, name=pod_name)
+        for condition in pod.status.conditions or []:
+            conditions[condition.type] = condition.status
+
+        if conditions.get("Ready") != "True":
+            print(
+                f"Waiting for pod {kube_ns}/{pod_name}; current status: {pod.status.phase}; {conditions}"
+            )
+            time.sleep(1)
+        else:
+            break
+
+    if conditions.get("Ready") != "True":
+        raise TimeoutError(f"pod {kube_ns}/{pod_name} failed to start: {pod.status}")
+    return pod
+
+
+def ensure_not_exists(kube_client, kube_ns, name, resource_type, timeout=30):
+    """Ensure an object doesn't exist
+
+    Request deletion and wait for it to be gone
+    """
+    delete = getattr(kube_client, "delete_namespaced_{}".format(resource_type))
+    read = getattr(kube_client, "read_namespaced_{}".format(resource_type))
+    try:
+        delete(namespace=kube_ns, name=name)
+    except ApiException as e:
+        if e.status != 404:
+            raise
+
+    while True:
+        # wait for delete
+        try:
+            read(namespace=kube_ns, name=name)
+        except ApiException as e:
+            if e.status == 404:
+                # deleted
+                break
+            else:
+                raise
+        else:
+            print("waiting for {}/{} to delete".format(resource_type, name))
+            time.sleep(1)
+
+
+def create_resource(kube_client, kube_ns, resource_type, manifest, delete_first=True):
+    """Create a kubernetes resource
+
+    handling 409 errors and others that can occur due to rapid startup
+    (typically: default service account doesn't exist yet
+    """
+    name = manifest.metadata["name"]
+    if delete_first:
+        ensure_not_exists(kube_client, kube_ns, name, resource_type)
+    print(f"Creating {resource_type} {name}")
+    create = getattr(kube_client, f"create_namespaced_{resource_type}")
+    error = None
+    for i in range(10):
+        try:
+            create(
+                body=manifest,
+                namespace=kube_ns,
+            )
+        except ApiException as e:
+            if e.status == 409:
+                break
+            error = e
+            # need to retry since this can fail if run too soon after namespace creation
+            print(e, file=sys.stderr)
+            time.sleep(int(e.headers.get("Retry-After", 1)))
+        else:
+            break
+    else:
+        raise error
+
+
+def create_hub_pod(kube_client, kube_ns, pod_name="hub", ssl=False):
+    config_map_name = pod_name + "-config"
+    secret_name = pod_name + "-secret"
+    with open(jupyterhub_config_py) as f:
+        config = f.read()
+
+    config_map_manifest = V1ConfigMap(
+        metadata={"name": config_map_name}, data={"jupyterhub_config.py": config}
+    )
+
+    config_map = create_resource(
+        kube_client,
+        kube_ns,
+        "config_map",
+        config_map_manifest,
+        delete_first=True,
+    )
+
+    volumes = [{"name": "config", "configMap": {"name": config_map_name}}]
+    volume_mounts = [
+        {
+            "mountPath": "/etc/jupyterhub/jupyterhub_config.py",
+            "subPath": "jupyterhub_config.py",
+            "name": "config",
+        }
+    ]
+    if ssl:
+        volumes.append({"name": "secret", "secret": {"secretName": secret_name}})
+        volume_mounts.append(
+            {
+                "mountPath": "/etc/jupyterhub/secret",
+                "name": "secret",
+            }
+        )
+
+    pod_manifest = V1Pod(
+        metadata={
+            "name": pod_name,
+            "labels": {"component": "hub", "hub-name": pod_name},
+        },
+        spec=V1PodSpec(
+            volumes=volumes,
+            containers=[
+                {
+                    "image": "jupyterhub/jupyterhub:1.3",
+                    "name": "hub",
+                    "volumeMounts": volume_mounts,
+                    "args": [
+                        "jupyterhub",
+                        "-f",
+                        "/etc/jupyterhub/jupyterhub_config.py",
+                    ],
+                    "env": [{"name": "PYTHONUNBUFFERED", "value": "1"}],
+                    "readinessProbe": {
+                        "tcpSocket": {
+                            "port": 8081,
+                        },
+                        "periodSeconds": 1,
+                    },
+                }
+            ],
+        ),
+    )
+    pod = create_resource(kube_client, kube_ns, "pod", pod_manifest)
+    return wait_for_pod(kube_client, kube_ns, pod_name)
+
+
+@pytest.fixture(scope="session")
+def hub_pod(kube_client, kube_ns):
+    """Create and return a pod running jupyterhub"""
+    return create_hub_pod(kube_client, kube_ns)
+
+
+@pytest.fixture
+def hub(hub_pod):
+    """Return the jupyterhub Hub object for passing to Spawner constructors
+
+    Ensures the hub_pod is running
+    """
+    return Hub(ip=hub_pod.status.pod_ip, port=8081)
+
+
+@pytest.fixture(scope="session")
+def hub_pod_ssl(kube_client, kube_ns, ssl_app):
+    """Start a hub pod with internal_ssl enabled"""
+    # load ssl dir to tarfile
+    buf = io.BytesIO()
+    tf = tarfile.TarFile(fileobj=buf, mode="w")
+    tf.add(ssl_app.internal_certs_location, arcname="internal-ssl", recursive=True)
+
+    # store tarfile in a secret
+    b64_certs = base64.b64encode(buf.getvalue()).decode("ascii")
+    secret_name = "hub-ssl-secret"
+    secret_manifest = V1Secret(
+        metadata={"name": secret_name}, data={"internal-ssl.tar": b64_certs}
+    )
+    create_resource(kube_client, kube_ns, "secret", secret_manifest)
+
+    name = "hub-ssl"
+
+    service_manifest = V1Service(
+        metadata=dict(name=name),
+        spec=V1ServiceSpec(
+            type="ClusterIP",
+            ports=[V1ServicePort(port=8081, target_port=8081)],
+            selector={"hub-name": name},
+        ),
+    )
+
+    create_resource(kube_client, kube_ns, "service", service_manifest)
+
+    return create_hub_pod(
+        kube_client,
+        kube_ns,
+        pod_name=name,
+        ssl=True,
+    )
+
+
+@pytest.fixture
+def hub_ssl(kube_ns, hub_pod_ssl):
+    """Return the Hub object for connecting to a running hub pod with internal_ssl enabled"""
+    return Hub(
+        proto="https",
+        ip=f"{hub_pod_ssl.metadata.name}.{kube_ns}",
+        port=8081,
+        base_url="/hub/",
+    )
+
+
+class ExecError(Exception):
+    """Error raised when a kubectl exec fails"""
+
+    def __init__(self, exit_code, message="", command="exec"):
+        self.exit_code = exit_code
+        self.message = message
+        self.command = command
+
+    def __str__(self):
+        return "{command} exited with status {exit_code}: {message}".format(
+            command=self.command,
+            exit_code=self.exit_code,
+            message=self.message,
+        )
+
+
+def _exec_python_in_pod(kube_client, kube_ns, pod_name, code, kwargs=None, _retries=0):
+    """Run simple Python code in a pod
+
+    code can be a str of code, or a 'simple' Python function,
+    where source can be extracted (i.e. self-contained imports, etc.)
+
+    kwargs are passed to the function, if it is given.
+    """
+    if V(kubernetes.__version__) < V("11"):
+        pytest.skip(
+            f"exec tests require kubernetes >= 11, got {kubernetes.__version__}"
+        )
+    pod = wait_for_pod(kube_client, kube_ns, pod_name)
+    original_code = code
+    if not isinstance(code, str):
+        # allow simple self-contained (no globals or args) functions
+        func = code
+        code = "\n".join(
+            [
+                inspect.getsource(func),
+                "_kw = %r" % (kwargs or {}),
+                "{}(**_kw)".format(func.__name__),
+                "",
+            ]
+        )
+    elif kwargs:
+        raise ValueError("kwargs can only be passed to functions, not code strings.")
+
+    exec_command = [
+        "python3",
+        "-c",
+        code,
+    ]
+    print("Running {} in {}".format(code, pod_name))
+    # need to create ws client to get returncode,
+    # see https://github.com/kubernetes-client/python/issues/812
+    client = stream(
+        kube_client.connect_get_namespaced_pod_exec,
+        pod_name,
+        namespace=kube_ns,
+        command=exec_command,
+        stderr=True,
+        stdin=False,
+        stdout=True,
+        tty=False,
+        _preload_content=False,
+    )
+    client.run_forever(timeout=60)
+
+    # let pytest capture stderr
+    stderr = client.read_stderr()
+    print(stderr, file=sys.stderr)
+
+    returncode = client.returncode
+    if returncode:
+        print(client.read_stdout())
+        if _retries == 0:
+            raise ExecError(exit_code=returncode, message=stderr, command=code)
+        else:
+            # retry
+            time.sleep(1)
+            return _exec_python_in_pod(
+                kube_client,
+                kube_ns,
+                pod_name,
+                code,
+                _retries=_retries - 1,
+            )
+    else:
+        return client.read_stdout().rstrip()
+
+
+@pytest.fixture
+def exec_python_pod(kube_client, kube_ns):
+    """Fixture to return callable to execute python in a pod by name
+
+    Used as a fixture to contain references to client, namespace
+    """
+    return partial(_exec_python_in_pod, kube_client, kube_ns)
+
+
+@pytest.fixture(scope="session")
+def exec_python(kube_ns, kube_client):
+    """Return a callable to execute Python code in a pod in the test namespace
+
+    This fixture creates a dedicated pod for executing commands
+    """
+
+    # note: this was created when there were only single-user pods running,
+    # but now there's always a hub pod where we could be running,
+    # and the ssl case *must* run from the hub pod for access to certs
+    # Note: we could do without this feature if we always ran
+
+    pod_name = "kubespawner-test-exec"
+    pod_manifest = V1Pod(
+        metadata={"name": pod_name},
+        spec=V1PodSpec(
+            containers=[
+                {
+                    "image": "python:3.8",
+                    "name": "python",
+                    "args": ["/bin/sh", "-c", "while true; do sleep 5; done"],
+                }
+            ],
+            termination_grace_period_seconds=0,
+        ),
+    )
+    pod = create_resource(kube_client, kube_ns, "pod", pod_manifest)
+
+    yield partial(_exec_python_in_pod, kube_client, kube_ns, pod_name)

--- a/tests/jupyterhub_config.py
+++ b/tests/jupyterhub_config.py
@@ -1,0 +1,77 @@
+"""Minimal jupyterhub config for hub pod"""
+import json
+import os
+import socket
+import tarfile
+
+c = get_config()  # noqa
+
+c.JupyterHub.hub_ip = "0.0.0.0"
+c.JupyterHub.hub_connect_ip = socket.gethostname()
+c.JupyterHub.log_level = "DEBUG"
+
+import pprint
+
+pprint.pprint(dict(os.environ))
+
+print("before")
+for root, dirs, files in os.walk("/etc/jupyterhub"):
+    for name in files:
+        print(os.path.join(root, name))
+    for name in dirs:
+        print(os.path.join(root, name) + "/")
+
+ssl_tar_file = "/etc/jupyterhub/secret/internal-ssl.tar"
+if os.path.exists(ssl_tar_file):
+    print("Enabling internal SSL")
+    c.JupyterHub.internal_ssl = True
+    ssl_dir = "/etc/jupyterhub/internal-ssl"
+    c.JupyterHub.internal_certs_location = ssl_dir
+
+    with tarfile.open(ssl_tar_file) as tf:
+        tf.extractall(path="/etc/jupyterhub")
+
+    for root, dirs, files in os.walk("/etc/jupyterhub"):
+        for name in files:
+            print(os.path.join(root, name))
+        for name in dirs:
+            print(os.path.join(root, name) + "/")
+
+    # rewrite paths in certipy config not created here
+    certipy_config = os.path.join(c.JupyterHub.internal_certs_location, "certipy.json")
+    with open(certipy_config) as f:
+        cfg = json.load(f)
+    print("cfg before", cfg)
+    path = cfg["hub-internal"]["files"]["key"]
+    prefix_len = path.index("/hub-internal")
+    prefix = path[:prefix_len]
+    print("relocating certipy {} -> {}".format(prefix, ssl_dir))
+    for name, service in cfg.items():
+        for key in list(service["files"]):
+            path = service["files"][key]
+            if path.startswith(prefix):
+                service["files"][key] = ssl_dir + path[prefix_len:]
+            # path = service["files"][key]
+            # print(name, key, path)
+            # if path:
+            #     new_abs_path = ssl_dir + path[path.index("/" + name):]
+            #     print(path, new_abs_path)
+            #     service["files"][key] = new_abs_path
+
+    print(cfg)
+
+    with open(certipy_config, "w") as f:
+        json.dump(cfg, f)
+
+    # c.JupyterHub.trusted_alt_names = socket.gethostname()
+
+c.JupyterHub.services = [
+    {"name": "test", "admin": True, "api_token": "test-secret-token"},
+]
+
+print("after")
+for root, dirs, files in os.walk("/etc/jupyterhub"):
+    for name in files:
+        print(os.path.join(root, name))
+    for name in dirs:
+        print(os.path.join(root, name) + "/")

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1751,21 +1751,23 @@ def test_make_pod_with_ssl():
     """
     Test specification of a pod with ssl enabled
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='ssl',
-        image='jupyter/singleuser:latest',
-        env={
-            'JUPYTERHUB_SSL_KEYFILE': 'TEST_VALUE',
-            'JUPYTERHUB_SSL_CERTFILE': 'TEST',
-            'JUPYTERHUB_USER': 'TEST',
-        },
-        working_dir='/',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        ssl_secret_name='ssl',
-        ssl_secret_mount_path="/etc/jupyterhub/ssl/"
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='ssl',
+            image='jupyter/singleuser:latest',
+            env={
+                'JUPYTERHUB_SSL_KEYFILE': 'TEST_VALUE',
+                'JUPYTERHUB_SSL_CERTFILE': 'TEST',
+                'JUPYTERHUB_USER': 'TEST',
+            },
+            working_dir='/',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            ssl_secret_name='ssl',
+            ssl_secret_mount_path="/etc/jupyterhub/ssl/",
+        )
+    ) == {
         "metadata": {
             "name": "ssl",
             "annotations": {},
@@ -1776,40 +1778,43 @@ def test_make_pod_with_ssl():
             "containers": [
                 {
                     "env": [
-                        {'name': 'JUPYTERHUB_SSL_KEYFILE', 'value': '/etc/jupyterhub/ssl/ssl.key'},
-                        {'name': 'JUPYTERHUB_SSL_CERTFILE', 'value': '/etc/jupyterhub/ssl/ssl.crt'},
+                        {
+                            'name': 'JUPYTERHUB_SSL_KEYFILE',
+                            'value': '/etc/jupyterhub/ssl/ssl.key',
+                        },
+                        {
+                            'name': 'JUPYTERHUB_SSL_CERTFILE',
+                            'value': '/etc/jupyterhub/ssl/ssl.crt',
+                        },
                         {'name': 'JUPYTERHUB_USER', 'value': 'TEST'},
-                        {'name': 'JUPYTERHUB_SSL_CLIENT_CA', 'value': '/etc/jupyterhub/ssl/notebooks-ca_trust.crt'},
+                        {
+                            'name': 'JUPYTERHUB_SSL_CLIENT_CA',
+                            'value': '/etc/jupyterhub/ssl/notebooks-ca_trust.crt',
+                        },
                     ],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [
-                        {'mountPath': '/etc/jupyterhub/ssl/', 'name': 'jupyterhub-internal-certs'}
+                        {
+                            'mountPath': '/etc/jupyterhub/ssl/',
+                            'name': 'jupyterhub-internal-certs',
+                        }
                     ],
                     'workingDir': '/',
-                    "resources": {
-                        "limits": {
-                        },
-                        "requests": {
-                        }
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [
-                {'name': 'jupyterhub-internal-certs',
-                'secret': {
-                    'defaultMode': 511,
-                    'secretName': 'ssl'
-                }}
+                {
+                    'name': 'jupyterhub-internal-certs',
+                    'secret': {'defaultMode': 511, 'secretName': 'ssl'},
+                }
             ],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,17 @@
 import copy
-from kubespawner.utils import get_k8s_model, update_k8s_model, _get_k8s_model_attribute
+
+import pytest
 from kubernetes.client.models import (
-    V1PodSpec, V1SecurityContext, V1Container, V1Capabilities, V1Lifecycle
+    V1PodSpec,
+    V1SecurityContext,
+    V1Container,
+    V1Capabilities,
+    V1Lifecycle,
 )
+from kubespawner.utils import get_k8s_model, update_k8s_model, _get_k8s_model_attribute
+
+from conftest import ExecError
+
 
 class MockLogger(object):
     """Trivial class to store logs for inspection after a test run."""
@@ -16,10 +25,31 @@ class MockLogger(object):
         self.warning_count += 1
 
 
+def print_hello():
+    print("hello!")
+
+
+def exec_error():
+    1 / 0
+
+
+def test_exec(exec_python):
+    """Test the exec fixture itself"""
+    r = exec_python(print_hello)
+    print("result: %r" % r)
+
+
+def test_exec_error(exec_python):
+    """Test the exec fixture error handling"""
+    with pytest.raises(ExecError) as e:
+        exec_python(exec_error)
+
+
 def test__get_k8s_model_attribute():
     """Verifies fundamental behavior"""
     assert _get_k8s_model_attribute(V1PodSpec, "service_account") == "service_account"
     assert _get_k8s_model_attribute(V1PodSpec, "serviceAccount") == "service_account"
+
 
 def test_update_k8s_model():
     """Ensure update_k8s_model does what it should. The test is first updating


### PR DESCRIPTION
Continuing @sstarcher's great work in #386 to hopefully get this finished (thanks for working on it!)

todo:

- [x] implement move_certs to make sure secret mount matches load path
- [x] double-check that the hub CA needs to be added to the secret (according to spec, it shouldn't, I think)
- [x] (maybe) consolidate some repeated retry logic that's getting pretty long
- [x] test that dns_name routing is correct when internal-ssl is not enabled (maybe pull in get_pod_url from #408)
- [x] add a couple integration tests that
  - [x] launch
  - [x] and talk to pods with ssl

cc @consideRatio who mentioned an intention to pick this up, but is focused on the CI/CD rework at the moment. I'm hoping to help get this ready and also use it to test the CI/CD update PR so we can land it soon.