### PR TITLE
CI: test k8s 1.18 and require success, publish without test, bump minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,13 +91,13 @@ jobs:
     # 1. Test with pre-releases of kubernetes-client/python and other
     #    python dependencies
     - &allowed_failure_1
-      name: client:pre-release,k8s:1.16
+      name: client:pre-release,k8s:1.16 - allowed failure
       env: PRE_RELEASES=TRUE KUBE_VERSION=1.16.13
 
     # 2. Test with a nightly python build using latest known
     #    supported configuration.
     - &allowed_failure_2
-      name: client:11,k8s:1.15,python:nightly
+      name: client:11,k8s:1.15,python:nightly - allowed failure
       python: nightly
       env: *latest_supported
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
       python: 3.8
       
     - name: client:11,k8s:1.18
-      env: KUBE_PY=11 KUBE_VERSION=1.18.9
+      env: KUBE_PY=11 KUBE_VERSION=1.18.6
       python: 3.8
       before_install:
         # This is required by k8s 1.18 according to minikube error message

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
-language: python
-sudo: required
+os: linux
 dist: bionic
+language: python
+python:
+  - 3.8
+
+stages:
+  - name: test
+    if: tag IS NOT present
+  - name: publish
+    if: tag IS present
 
 # install dependencies
 install:
@@ -33,7 +41,7 @@ after_success:
   - pip install codecov
   - codecov
 
-matrix:
+jobs:
   # NOTE: We may end up updating these set versions with time, when doing that,
   # these links are relevant.
   #
@@ -53,7 +61,6 @@ matrix:
 
     - name: client:9,k8s:1.13
       env: KUBE_PY=9 KUBE_VERSION=1.13.12
-      python: 3.8
       dist: xenial
       # NOTE: TravisCI's linux kernel, has since 2020 or so, when specifying
       #       bionic as a distribution, made minikube fail to start a k8s 1.13
@@ -61,21 +68,19 @@ matrix:
       # Reference - a build failure with bionic:
       #       https://travis-ci.org/jupyterhub/kubespawner/jobs/642305915
 
-    - name: client:10,k8s:1.14
+    - name: client:10,k8s:1.14,py:37
       env: KUBE_PY=10 KUBE_VERSION=1.14.0
       python: 3.7
 
-    - name: client:11,k8s:1.15
+    - name: client:11,k8s:1.15,py:36
       env: &latest_supported KUBE_PY=11 KUBE_VERSION=1.15.12
       python: 3.6
 
     - name: client:11,k8s:1.15,jupyterhub:master
       env: KUBE_PY=11 KUBE_VERSION=1.15.12 JUPYTERHUB_MASTER=TRUE
-      python: 3.8
       
     - name: client:11,k8s:1.18
       env: KUBE_PY=11 KUBE_VERSION=1.18.6
-      python: 3.8
       before_install:
         # This is required by k8s 1.18 according to minikube error message
         # trying to install k8s 1.18 without it.
@@ -87,7 +92,6 @@ matrix:
     #    python dependencies
     - &allowed_failure_1
       name: client:pre-release,k8s:1.16
-      python: 3.8
       env: PRE_RELEASES=TRUE KUBE_VERSION=1.16.13
 
     # 2. Test with a nightly python build using latest known
@@ -98,9 +102,7 @@ matrix:
       env: *latest_supported
 
     # Only deploy if all test jobs passed
-    - stage: deploy
-      if: tag IS present
-      python: 3.7
+    - stage: publish
       # FIXME: We don't want to run tests again here, but I got
       # the following issue when these were commented out...
       # https://travis-ci.org/mapbox/vtvalidate/jobs/492280599

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,11 +103,10 @@ jobs:
 
     # Only deploy if all test jobs passed
     - stage: publish
-      # FIXME: We don't want to run tests again here, but I got
-      # the following issue when these were commented out...
-      # https://travis-ci.org/mapbox/vtvalidate/jobs/492280599
-      #script: []
-      #after_success: []
+      script:
+        - echo "Required dummy override of default 'script' in .travis.yml."
+      after_success:
+        - echo "Required dummy override of default 'after_success' in .travis.yml."
       deploy:
         provider: pypi
         user: __token__

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,13 @@ matrix:
     # version 1.13 and so on.
     - python: 3.8
       env: KUBE_PY=9 KUBE_VERSION=1.13.12
-    # NOTE: TravisCI's linux kernel, has since 2020 or so, when specifying
-    #       bionic as a distribution, made minikube fail to start a k8s 1.13
-    #       cluster. This is why we use xenial here.
-    # Reference - a build failure with bionic:
-    #       https://travis-ci.org/jupyterhub/kubespawner/jobs/642305915
-    - dist: xenial
-      python: 3.7
+      # NOTE: TravisCI's linux kernel, has since 2020 or so, when specifying
+      #       bionic as a distribution, made minikube fail to start a k8s 1.13
+      #       cluster. This is why we use xenial here.
+      # Reference - a build failure with bionic:
+      #       https://travis-ci.org/jupyterhub/kubespawner/jobs/642305915
+      dist: xenial
+    - python: 3.7
       env: KUBE_PY=10 KUBE_VERSION=1.14.0
     - python: 3.6
       env: &latest_supported KUBE_PY=11 KUBE_VERSION=1.15.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
     # version 8 supports k8s API version 1.12, and version 9 supports k8s API
     # version 1.13 and so on.
     - python: 3.8
-      env: KUBE_PY=8 KUBE_VERSION=1.12.10
+      env: KUBE_PY=9 KUBE_VERSION=1.13.12
     # NOTE: TravisCI's linux kernel, has since 2020 or so, when specifying
     #       bionic as a distribution, made minikube fail to start a k8s 1.13
     #       cluster. This is why we use xenial here.
@@ -56,11 +56,11 @@ matrix:
     #       https://travis-ci.org/jupyterhub/kubespawner/jobs/642305915
     - dist: xenial
       python: 3.7
-      env: KUBE_PY=9 KUBE_VERSION=1.13.12
+      env: KUBE_PY=10 KUBE_VERSION=1.14.0
     - python: 3.6
-      env: &latest_supported KUBE_PY=10 KUBE_VERSION=1.14.9
+      env: &latest_supported KUBE_PY=11 KUBE_VERSION=1.15.12
     - python: 3.6
-      env: KUBE_PY=10 KUBE_VERSION=1.14.9 JUPYTERHUB_MASTER=TRUE
+      env: KUBE_PY=11 KUBE_VERSION=1.15.12 JUPYTERHUB_MASTER=TRUE
 
     # Allowed failure tests:
     # ----------------------
@@ -69,13 +69,13 @@ matrix:
     #    python dependencies
     - &allowed_failure_1
       python: 3.8
-      env: PRE_RELEASES=TRUE KUBE_VERSION=1.15.9
+      env: PRE_RELEASES=TRUE KUBE_VERSION=1.16.13
 
     # 2. Test with latest stable kubernetes client along with the latest
     #    kubernetes cluster version
     - &allowed_failure_2
       python: 3.8
-      env: KUBE_PY=10 KUBE_VERSION=1.17.2
+      env: KUBE_PY=11 KUBE_VERSION=1.18.6
 
     # 3. Test with a nightly python build using latest known
     #    supported configuration.

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,12 +86,14 @@ matrix:
     # 1. Test with pre-releases of kubernetes-client/python and other
     #    python dependencies
     - &allowed_failure_1
+      name: client:pre-release,k8s:1.16
       python: 3.8
       env: PRE_RELEASES=TRUE KUBE_VERSION=1.16.13
 
     # 2. Test with a nightly python build using latest known
     #    supported configuration.
     - &allowed_failure_2
+      name: client:11,k8s:1.15,python:nightly
       python: nightly
       env: *latest_supported
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,18 @@ dist: bionic
 
 # install dependencies
 install:
-  - pip install --upgrade setuptools pip
   # Only add the --pre flag if $PRE_RELEASES is specified to test pre-releases
   # of dependencies, and only pin kubernetes if $KUBE_PY is specified.
+  - pip install --upgrade setuptools pip
   - pip install -e ".[test]" ${PRE_RELEASES:+--pre} ${KUBE_PY:+kubernetes==${KUBE_PY}}
+
   # Allow for testing against the jupyterhub master branch as well
   - |
       if [ "$JUPYTERHUB_MASTER" == "TRUE" ]; then
         pip install https://github.com/jupyterhub/jupyterhub/archive/master.zip
       fi
+  
+  # Log installed python packages' versions
   - pip freeze
 
 # run tests
@@ -47,21 +50,36 @@ matrix:
     # KUBE_PY represent the version of kubernetes-client/python, and client
     # version 8 supports k8s API version 1.12, and version 9 supports k8s API
     # version 1.13 and so on.
-    - python: 3.8
+
+    - name: client:9,k8s:1.13
       env: KUBE_PY=9 KUBE_VERSION=1.13.12
+      python: 3.8
+      dist: xenial
       # NOTE: TravisCI's linux kernel, has since 2020 or so, when specifying
       #       bionic as a distribution, made minikube fail to start a k8s 1.13
       #       cluster. This is why we use xenial here.
       # Reference - a build failure with bionic:
       #       https://travis-ci.org/jupyterhub/kubespawner/jobs/642305915
-      dist: xenial
-    - python: 3.7
-      env: KUBE_PY=10 KUBE_VERSION=1.14.0
-    - python: 3.6
-      env: &latest_supported KUBE_PY=11 KUBE_VERSION=1.15.12
-    - python: 3.6
-      env: KUBE_PY=11 KUBE_VERSION=1.15.12 JUPYTERHUB_MASTER=TRUE
 
+    - name: client:10,k8s:1.14
+      env: KUBE_PY=10 KUBE_VERSION=1.14.0
+      python: 3.7
+
+    - name: client:11,k8s:1.15
+      env: &latest_supported KUBE_PY=11 KUBE_VERSION=1.15.12
+      python: 3.6
+
+    - name: client:11,k8s:1.15,jupyterhub:master
+      env: KUBE_PY=11 KUBE_VERSION=1.15.12 JUPYTERHUB_MASTER=TRUE
+      python: 3.8
+      
+    - name: client:11,k8s:1.18
+      env: KUBE_PY=11 KUBE_VERSION=1.18.9
+      python: 3.8
+      before_install:
+        # This is required by k8s 1.18 according to minikube error message
+        # trying to install k8s 1.18 without it.
+        - sudo apt-get -q -y install conntrack
     # Allowed failure tests:
     # ----------------------
 
@@ -71,15 +89,9 @@ matrix:
       python: 3.8
       env: PRE_RELEASES=TRUE KUBE_VERSION=1.16.13
 
-    # 2. Test with latest stable kubernetes client along with the latest
-    #    kubernetes cluster version
-    - &allowed_failure_2
-      python: 3.8
-      env: KUBE_PY=11 KUBE_VERSION=1.18.6
-
-    # 3. Test with a nightly python build using latest known
+    # 2. Test with a nightly python build using latest known
     #    supported configuration.
-    - &allowed_failure_3
+    - &allowed_failure_2
       python: nightly
       env: *latest_supported
 
@@ -106,5 +118,4 @@ matrix:
   allow_failures:
     - *allowed_failure_1
     - *allowed_failure_2
-    - *allowed_failure_3
   fast_finish: true

--- a/ci/install-kube.sh
+++ b/ci/install-kube.sh
@@ -27,11 +27,6 @@ minikube update-context
 # can be used to check a condition of nodes and pods
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
 
-echo "waiting for kube-addon-manager"
-until kubectl -n kube-system get pods -l component=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
-  sleep 1
-done
-
 echo "waiting for kube-dns"
 until kubectl -n kube-system get pods -l k8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
   sleep 1

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -6,9 +6,6 @@ export KUBE_VERSION=${KUBE_VERSION:-1.18.6}
 # ref: https://github.com/kubernetes/minikube/releases
 export MINIKUBE_VERSION=${MINIKUBE_VERSION:-1.12.0}
 
-# ref: https://github.com/helm/helm/releases
-export HELM_VERSION=${HELM_VERSION:-2.16.9}
-
 # ref: https://github.com/LiliC/travis-minikube/blob/master/.travis.yml
 export CHANGE_MINIKUBE_NONE_USER=true
 export MINIKUBE_WANTUPDATENOTIFICATION=false

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -1,13 +1,13 @@
 # default values for relevant environment variables
 
 # ref: https://github.com/kubernetes/kubernetes/releases
-export KUBE_VERSION=${KUBE_VERSION:-1.17.2}
+export KUBE_VERSION=${KUBE_VERSION:-1.18.6}
 
 # ref: https://github.com/kubernetes/minikube/releases
-export MINIKUBE_VERSION=${MINIKUBE_VERSION:-1.6.2}
+export MINIKUBE_VERSION=${MINIKUBE_VERSION:-1.12.0}
 
 # ref: https://github.com/helm/helm/releases
-export HELM_VERSION=${HELM_VERSION:-2.16.1}
+export HELM_VERSION=${HELM_VERSION:-2.16.9}
 
 # ref: https://github.com/LiliC/travis-minikube/blob/master/.travis.yml
 export CHANGE_MINIKUBE_NONE_USER=true


### PR DESCRIPTION
We stop testing the python library `kubernetes` version 8 and start testing version 11 (10 and 9 remain).

We also start testing newer versions of k8s, like 1.18.

