### PR TITLE
Add component_label property to support multiple hub instances in the…

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -463,6 +463,7 @@ def make_ingress(
         name,
         routespec,
         target,
+        labels,
         data
 ):
     """
@@ -497,11 +498,7 @@ def make_ingress(
             'hub.jupyter.org/proxy-routespec': routespec,
             'hub.jupyter.org/proxy-target': target
         },
-        labels={
-            'heritage': 'jupyterhub',
-            'component': 'singleuser-server',
-            'hub.jupyter.org/proxy-route': 'true'
-        }
+        labels=labels,
     )
 
     if routespec.startswith('/'):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1535,10 +1535,16 @@ def test_make_ingress():
     """
     Test specification of the ingress objects
     """
+    labels={
+        'heritage': 'jupyterhub',
+        'component': 'singleuser-server',
+        'hub.jupyter.org/proxy-route': 'true'
+    }
     endpoint, service, ingress = api_client.sanitize_for_serialization(make_ingress(
         name='jupyter-test',
         routespec='/my-path',
         target='http://192.168.1.10:9000',
+        labels=labels,
         data={"mykey": "myvalue"}
     ))
 


### PR DESCRIPTION
… same namespace
When multiple jupyterhub instances are run the same namespace, the spawner reflector is hard-wired to listen for `singleuser-server` events. This makes every JH instance listen to events for pods that are not managed by that JH. The change is to ensure that the spawner could be configured to listen to pods as specified in the config rather than hard-code it. The change is backwards compatible. 

Addresses #413 