### PR TITLE
Support EnvVar's with 'valueFrom' as well as with 'value'

### DIFF
--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -443,13 +443,30 @@ def test_make_pod_resources_all():
 
 def test_make_pod_with_env():
     """
-    Test specification of a pod with custom environment variables
+    Test specification of a pod with custom environment variables.
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
         image='jupyter/singleuser:latest',
         env={
-            'TEST_KEY': 'TEST_VALUE'
+            'TEST_KEY_1': 'TEST_VALUE',
+            'TEST_KEY_2': {
+                'valueFrom': {
+                    'secretKeyRef': {
+                        'name': 'my-k8s-secret',
+                        'key': 'password',
+                    },
+                },
+            },
+            'TEST_KEY_NAME_IGNORED': {
+                'name': 'TEST_KEY_3',
+                'valueFrom': {
+                    'secretKeyRef': {
+                        'name': 'my-k8s-secret',
+                        'key': 'password',
+                    },
+                },
+            },
         },
         cmd=['jupyterhub-singleuser'],
         port=8888,
@@ -464,7 +481,30 @@ def test_make_pod_with_env():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [{'name': 'TEST_KEY', 'value': 'TEST_VALUE'}],
+                    "env": [
+                        {
+                            'name': 'TEST_KEY_1',
+                            'value': 'TEST_VALUE',
+                        },
+                        {
+                            'name': 'TEST_KEY_2',
+                            'valueFrom': {
+                                'secretKeyRef': {
+                                    'name': 'my-k8s-secret',
+                                    'key': 'password',
+                                },
+                            },
+                        },
+                        {
+                            'name': 'TEST_KEY_3',
+                            'valueFrom': {
+                                'secretKeyRef': {
+                                    'name': 'my-k8s-secret',
+                                    'key': 'password',
+                                },
+                            },
+                        },
+                    ],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",


### PR DESCRIPTION
## Background

The c.KubeSpawner.environment configuration can only accept a dictionary with keys and values being strings, because they will be passed as name and value to the name and value parameters of the EnvVar resource. But, Kubernetes EnvVar resources can have a name / valueFrom combo as well.

Due to this limitation, users ended up forced to do something very obscure like described https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1103#issuecomment-546139103.

## Solution

In this PR I enable users to pass other kinds of structures as well that will allow for any kind of valid k8s EnvVar structure to be passed. The format is best documented in the test currently.

## References
- Z2JH PR that relies on this PR to work: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1757
- Issue in Z2JH related to this limitation: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1103
- Issues in KubeSpawner related to this limitation: https://github.com/jupyterhub/kubespawner/issues/306#issuecomment-474934945 (Closes #306)
- [The base class definition of the `environment` traitlet](https://github.com/jupyterhub/jupyterhub/blob/cc8e7806530466dce8968567d1bbd2b39a7afa26/jupyterhub/spawner.py#L453) that KubeSpawner leaves untouched.
