### PR TITLE
Fix KubeIngressProxy.get_all_routes for 0.13

### DIFF
--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -252,11 +252,11 @@ class KubeIngressProxy(Proxy):
         # FIXME: Validate that this shallow copy *is* thread safe
         ingress_copy = dict(self.ingress_reflector.ingresses)
         routes = {
-            ingress.metadata.annotations['hub.jupyter.org/proxy-routespec']:
+            ingress["metadata"]["annotations"]['hub.jupyter.org/proxy-routespec']:
             {
-                'routespec': ingress.metadata.annotations['hub.jupyter.org/proxy-routespec'],
-                'target': ingress.metadata.annotations['hub.jupyter.org/proxy-target'],
-                'data': json.loads(ingress.metadata.annotations['hub.jupyter.org/proxy-data'])
+                'routespec': ingress["metadata"]["annotations"]['hub.jupyter.org/proxy-routespec'],
+                'target': ingress["metadata"]["annotations"]['hub.jupyter.org/proxy-target'],
+                'data': json.loads(ingress["metadata"]["annotations"]['hub.jupyter.org/proxy-data'])
             }
             for ingress in ingress_copy.values()
         }


### PR DESCRIPTION
`KubeIngressProxy.get_all_routes` was not update to reflect 0.13 reflector changes.