### PR TITLE
Add timeout and retry to create_namespaced_pod

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -14,10 +14,6 @@ c.JupyterHub.cleanup_servers = False
 # First pulls can be really slow, so let's give it a big timeout
 c.KubeSpawner.start_timeout = 60 * 5
 
-# Used only for the create_namespaced_pod call.  Azure AKS (<=1.17.9)
-# doesn't respond sometimes to these requests
-c.KubeSpawner.k8s_api_request_timeout = 5
-
 # Our simplest user image! Optimized to just... start, and be small!
 c.KubeSpawner.image = 'jupyterhub/singleuser:1.0'
 

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -14,6 +14,10 @@ c.JupyterHub.cleanup_servers = False
 # First pulls can be really slow, so let's give it a big timeout
 c.KubeSpawner.start_timeout = 60 * 5
 
+# Used only for the create_namespaced_pod call.  Azure AKS (<=1.17.9)
+# doesn't respond sometimes to these requests
+c.KubeSpawner.k8s_post_timeout = 5
+
 # Our simplest user image! Optimized to just... start, and be small!
 c.KubeSpawner.image = 'jupyterhub/singleuser:1.0'
 

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -16,7 +16,7 @@ c.KubeSpawner.start_timeout = 60 * 5
 
 # Used only for the create_namespaced_pod call.  Azure AKS (<=1.17.9)
 # doesn't respond sometimes to these requests
-c.KubeSpawner.k8s_post_timeout = 5
+c.KubeSpawner.k8s_api_request_timeout = 5
 
 # Our simplest user image! Optimized to just... start, and be small!
 c.KubeSpawner.image = 'jupyterhub/singleuser:1.0'

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -208,7 +208,7 @@ class KubeSpawner(Spawner):
     )
 
     k8s_api_request_timeout = Integer(
-        1,
+        3,
         config=True,
         help="""
         API request timeout (in seconds) for all k8s API calls.

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1853,7 +1853,7 @@ class KubeSpawner(Spawner):
                 self.log.info('Killed pod %s, will try starting singleuser pod again', self.pod_name)
             except ReadTimeoutError:
                 if i < (retry_times - 1):
-                    self.log.warn(f'create_namespaced_pod read timeout on attempt {i+1} of {retry_times}')
+                    self.log.warn(f'create_namespaced_pod for {self.user.name} timeout on attempt {i+1} of {retry_times}')
                 else:
                     raise
         else:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1602,6 +1602,7 @@ class KubeSpawner(Spawner):
 
     @run_on_executor
     def asynchronize(self, method, *args, **kwargs):
+        self.log.info(f"Asynchronously calling {method} with {args} and {kwargs}")
         return method(*args, **kwargs)
 
     @property
@@ -1834,6 +1835,7 @@ class KubeSpawner(Spawner):
             pod = yield gen.maybe_future(self.modify_pod_hook(self, pod))
         for i in range(retry_times):
             try:
+                self.log.info(f"Attempting to create pod {pod['metadata']['name']}, with timeout {self.k8s_api_request_timeout}")
                 yield self.asynchronize(
                     self.api.create_namespaced_pod,
                     self.namespace,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -225,7 +225,7 @@ class KubeSpawner(Spawner):
         30,
         config=True,
         help="""
-        Total timeout, includign retry timeout, for kubernetes API calls
+        Total timeout, including retry timeout, for kubernetes API calls
 
         When a k8s API request connection times out, we retry it while backing
         off exponentially. This lets you configure the total amount of time

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1835,12 +1835,12 @@ class KubeSpawner(Spawner):
         def create_pod():
             try:
                 self.log.info(f"Attempting to create pod {pod.metadata.name}, with timeout {self.k8s_api_request_timeout}")
-                yield self.asynchronize(
+                # Use tornado's timeout, _request_timeout seems unreliable?
+                yield gen.with_timeout(self.k8s_api_request_timeout, self.asynchronize(
                     self.api.create_namespaced_pod,
                     self.namespace,
                     pod,
-                    _request_timeout=self.k8s_api_request_timeout
-                )
+                ))
                 return True
             except ApiException as e:
                 if e.status != 409:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -20,7 +20,6 @@ from tornado.ioloop import IOLoop
 from tornado.concurrent import run_on_executor
 from tornado import web
 from traitlets import (
-    Float,
     Bool,
     Dict,
     Integer,
@@ -209,7 +208,7 @@ class KubeSpawner(Spawner):
         """
     )
 
-    k8s_api_request_timeout = Float(
+    k8s_api_request_timeout = Integer(
         5,
         config=True,
         help="""

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -34,7 +34,6 @@ from jupyterhub.spawner import Spawner
 from jupyterhub.utils import exponential_backoff
 from jupyterhub.traitlets import Command
 from kubernetes.client.rest import ApiException
-from urllib3.exceptions import ReadTimeoutError
 from kubernetes import client
 import escapism
 from jinja2 import Environment, BaseLoader

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1791,7 +1791,7 @@ class KubeSpawner(Spawner):
         True / False on success / failure
         """
         try:
-            self.log.info(f"Attempting to create pod {pod.metadata.name}, with timeout {self.k8s_api_request_timeout}")
+            self.log.info(f"Attempting to create pod {pod.metadata.name}, with timeout {request_timeout}")
             # Use tornado's timeout, _request_timeout seems unreliable?
             yield gen.with_timeout(timedelta(seconds=request_timeout), self.asynchronize(
                 self.api.create_namespaced_pod,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1825,6 +1825,7 @@ class KubeSpawner(Spawner):
                     self.api.create_namespaced_pod,
                     self.namespace,
                     pod,
+                    _request_timeout=self.k8s_post_timeout
                 )
                 break
             except ApiException as e:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1841,6 +1841,7 @@ class KubeSpawner(Spawner):
                     pod,
                     _request_timeout=self.k8s_api_request_timeout
                 )
+                return True
             except ApiException as e:
                 if e.status != 409:
                     # We only want to handle 409 conflict errors
@@ -1852,7 +1853,7 @@ class KubeSpawner(Spawner):
 
                 self.log.info('Killed pod %s, will try starting singleuser pod again', self.pod_name)
                 # Raise an exception to signal to exponential_backoff to keep going
-                raise ValueError(f'Killed pod {self.pod_name}, will try creating it again')
+                return False
         
         # If there's a timeout, just let it propagate
         yield exponential_backoff(

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1614,7 +1614,6 @@ class KubeSpawner(Spawner):
 
     @run_on_executor
     def asynchronize(self, method, *args, **kwargs):
-        self.log.info(f"Asynchronously calling {method} with {args} and {kwargs}")
         return method(*args, **kwargs)
 
     @property

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1835,7 +1835,7 @@ class KubeSpawner(Spawner):
             pod = yield gen.maybe_future(self.modify_pod_hook(self, pod))
         for i in range(retry_times):
             try:
-                self.log.info(f"Attempting to create pod {pod['metadata']['name']}, with timeout {self.k8s_api_request_timeout}")
+                self.log.info(f"Attempting to create pod {pod.metadata.name}, with timeout {self.k8s_api_request_timeout}")
                 yield self.asynchronize(
                     self.api.create_namespaced_pod,
                     self.namespace,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1842,6 +1842,9 @@ class KubeSpawner(Spawner):
                     pod,
                 ))
                 return True
+            except tornado.util.TimeoutError:
+                # Just try again
+                return False
             except ApiException as e:
                 if e.status != 409:
                     # We only want to handle 409 conflict errors

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1838,6 +1838,13 @@ class KubeSpawner(Spawner):
                 yield self.stop(True)
 
                 self.log.info('Killed pod %s, will try starting singleuser pod again', self.pod_name)
+            except Exception as ex:
+                # look at __name__ to avoid adding dependency on urllib3
+                # (full exception is urllib3.exceptions.ReadTimeoutError)
+                if "ReadTimeoutError" in ex.__class__.__name__ and i < (retry_times - 1):
+                    self.log.warn(f'create_namespaced_pod read timeout on attempt {i+1} of {retry_times}')
+                else:
+                    raise
         else:
             raise Exception(
                 'Can not create user pod %s already exists & could not be deleted' % self.pod_name)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1842,7 +1842,7 @@ class KubeSpawner(Spawner):
                     pod,
                 ))
                 return True
-            except tornado.util.TimeoutError:
+            except gen.TimeoutError:
                 # Just try again
                 return False
             except ApiException as e:
@@ -1929,7 +1929,7 @@ class KubeSpawner(Spawner):
                     grace_period_seconds=grace_seconds,
                 ))
                 return True
-            except tornado.util.TimeoutError:
+            except gen.TimeoutError:
                 return False
             except ApiException as e:
                 if e.status == 404:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1937,6 +1937,8 @@ class KubeSpawner(Spawner):
                         "No pod %s to delete. Assuming already deleted.",
                         self.pod_name,
                     )
+                    # If there isn't already a pod, that's ok too!
+                    return True
                 else:
                     raise
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -20,6 +20,7 @@ from tornado.ioloop import IOLoop
 from tornado.concurrent import run_on_executor
 from tornado import web
 from traitlets import (
+    Float,
     Bool,
     Dict,
     Integer,
@@ -204,6 +205,17 @@ class KubeSpawner(Spawner):
         Increase this if you are dealing with a very large number of users.
 
         Defaults to `5 * cpu_cores`, which is the default for `ThreadPoolExecutor`.
+        """
+    )
+
+    k8s_api_request_timeout = Float(
+        5,
+        config=True,
+        help="""
+        API request timeout (in seconds) for all k8s API calls.
+
+        This is the total amount of time a request might take before the connection
+        is killed. This includes connection time and reading the response.
         """
     )
 
@@ -1825,7 +1837,7 @@ class KubeSpawner(Spawner):
                     self.api.create_namespaced_pod,
                     self.namespace,
                     pod,
-                    _request_timeout=self.k8s_post_timeout
+                    _request_timeout=self.k8s_api_request_timeout
                 )
                 break
             except ApiException as e:


### PR DESCRIPTION
We've found persistent intermittent failures to spawn on Azure AKS (multiple k8s versions).   On a rancher cluster created on Azure VMs (k8s 1.18) we do not see this.   It appears that this particular POST call to the create_namespaced_pod API occasionally just doesn't return (within 5 minutes at least).   Adding a timeout and using the existing retry logic fixes this.  

Improvements that could be made:
 - explaining why k8s fails sometimes! 
 - could this happen on other k8s APIs? 
 - should this use a better backoff mechanism
 - how to avoid pulling in urllib3 dependency (used by kubernetes package) - or just accept it.