### PR TITLE
Allow image_pull_secrets config to be specified the k8s native way

### DIFF
--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -40,6 +40,7 @@ def test_deprecated_config():
         c.KubeSpawner.hub_connect_ip = '10.0.1.1'
         c.KubeSpawner.singleuser_extra_pod_config = extra_pod_config = {"key": "value"}
         c.KubeSpawner.image_spec = 'abc:123'
+        c.KubeSpawner.image_pull_secrets = 'k8s-secret-a'
         spawner = KubeSpawner(hub=Hub(), config=c, _mock=True)
         assert spawner.hub.connect_ip == '10.0.1.1'
         assert spawner.fs_gid == 10
@@ -48,6 +49,7 @@ def test_deprecated_config():
         assert spawner.singleuser_fs_gid == spawner.fs_gid
         assert spawner.singleuser_extra_pod_config == spawner.extra_pod_config
         assert spawner.image == 'abc:123'
+        assert spawner.image_pull_secrets[0]["name"] == 'k8s-secret-a'
 
 
 def test_deprecated_runtime_access():
@@ -65,6 +67,8 @@ def test_deprecated_runtime_access():
     spawner.image = 'abc:123'
     assert spawner.image_spec == 'abc:123'
     assert spawner.image == 'abc:123'
+    spawner.image_pull_secrets = 'k8s-secret-a'
+    assert spawner.image_pull_secrets[0]["name"] == 'k8s-secret-a'
 
 
 def test_spawner_values():


### PR DESCRIPTION
## Motivation

I'm working on [a feature in jupyterhub/zero-to-jupyterhub-k8s](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1794) to configure all
the Helm chart's pods' `spec.imagePullSecrets` configurations at once while also
being able to configure it for individual pods. The chart global configuration
should be allowed to combine with the pod specific configuration, which require
KubeSpawner to support the Kubernetes matching variant where a list of strings
rather than a single string can be provided.

To conclude, `c.KubeSpawner.image_pull_secrets` passed a string will get a soft
deprecation, and passing a list of either strings or dicts like `{"name": "string"}` is
the new recommended syntax, the latter represent the k8s native syntax.

## Overview

- [x] Add support for KubeSpawner configuration `image_pull_secrets` to accept a
  list of Kubernetes Secret references. Either as strings with Secret names, or
  dicts like `{"name": "secret-name"}`, where the latter mimics the k8s
  configuration available in a Pod.
- [x] Add a _soft deprecation_ of passing a string to `image_pull_secrets`,
  providing a warning while automatically adjusting the set value to a single
  entry in a list in the k8s native format.
  - [x] Add a test of the soft deprecation's indirect configuration.
- [x] Make a **breaking change** where `make_pod` in objects.py no longer can accept
  `image_pull_secret` (singular), and instead expects `image_pull_secrets`
  (plural), that assumes a list is passed.

## Related

- https://github.com/jupyterhub/kubespawner/issues/221 - An old discussion about KubeSpawner's k8s mismatching image_pull_secrets configuration.
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1794 - The z2jh PR that depends on this PR.