### PR TITLE
changelog: preparations for 0.14.0

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,19 +4,21 @@
 
 ## [0.14]
 
-### Bugs fixed
+## Bugs fixed
 * Access containerStatuses key with get() [#441](https://github.com/jupyterhub/kubespawner/pull/441) ([@rmoe](https://github.com/rmoe))
 * Allow pod to spawn if the PVC specified already exists [#438](https://github.com/jupyterhub/kubespawner/pull/438) ([@gravenimage](https://github.com/gravenimage))
 * Add timeout and retry to create_namespaced_pod [#433](https://github.com/jupyterhub/kubespawner/pull/433) ([@gravenimage](https://github.com/gravenimage))
 * Fix KubeIngressProxy.get_all_routes for 0.13 [#430](https://github.com/jupyterhub/kubespawner/pull/430) ([@remche](https://github.com/remche))
 
-### Maintenance and upkeep improvements
+## Maintenance and upkeep improvements
+* Manage regexp syntax deprecation [#445](https://github.com/jupyterhub/kubespawner/pull/445) ([@consideRatio](https://github.com/consideRatio))
 * Add an explicit dependency on urllib3 [#437](https://github.com/jupyterhub/kubespawner/pull/437) ([@yuvipanda](https://github.com/yuvipanda))
+* Delete remnant now unused parts in spawner.py [#382](https://github.com/jupyterhub/kubespawner/pull/382) ([@bitnik](https://github.com/bitnik))
 
-### Contributors to this release
+## Contributors to this release
 ([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2020-09-04&to=2020-10-04&type=c))
 
-[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2020-09-04..2020-10-04&type=Issues) | [@gravenimage](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Agravenimage+updated%3A2020-09-04..2020-10-04&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2020-09-04..2020-10-04&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2020-09-04..2020-10-04&type=Issues) | [@remche](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aremche+updated%3A2020-09-04..2020-10-04&type=Issues) | [@rmoe](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Armoe+updated%3A2020-09-04..2020-10-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Awelcome+updated%3A2020-09-04..2020-10-04&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ayuvipanda+updated%3A2020-09-04..2020-10-04&type=Issues)
+[@bitnik](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Abitnik+updated%3A2020-09-04..2020-10-04&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2020-09-04..2020-10-04&type=Issues) | [@gravenimage](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Agravenimage+updated%3A2020-09-04..2020-10-04&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2020-09-04..2020-10-04&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2020-09-04..2020-10-04&type=Issues) | [@remche](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aremche+updated%3A2020-09-04..2020-10-04&type=Issues) | [@rmoe](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Armoe+updated%3A2020-09-04..2020-10-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Awelcome+updated%3A2020-09-04..2020-10-04&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ayuvipanda+updated%3A2020-09-04..2020-10-04&type=Issues)
 
 ## [0.13]
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,21 +4,22 @@
 
 ## [0.14]
 
-## Bugs fixed
+### [0.14.0] - 2020-10-05
+
+#### Enhancements made
+* Allow image_pull_secrets config to be specified the k8s native way [#442](https://github.com/jupyterhub/kubespawner/pull/442) ([@consideRatio](https://github.com/consideRatio))
+
+#### Bugs fixed
 * Access containerStatuses key with get() [#441](https://github.com/jupyterhub/kubespawner/pull/441) ([@rmoe](https://github.com/rmoe))
 * Allow pod to spawn if the PVC specified already exists [#438](https://github.com/jupyterhub/kubespawner/pull/438) ([@gravenimage](https://github.com/gravenimage))
 * Add timeout and retry to create_namespaced_pod [#433](https://github.com/jupyterhub/kubespawner/pull/433) ([@gravenimage](https://github.com/gravenimage))
 * Fix KubeIngressProxy.get_all_routes for 0.13 [#430](https://github.com/jupyterhub/kubespawner/pull/430) ([@remche](https://github.com/remche))
 
-## Maintenance and upkeep improvements
+#### Maintenance and upkeep improvements
 * Manage regexp syntax deprecation [#445](https://github.com/jupyterhub/kubespawner/pull/445) ([@consideRatio](https://github.com/consideRatio))
+* Python 3.6+ migration: async in 3.5 and async with yeild in 3.6 [#444](https://github.com/jupyterhub/kubespawner/pull/444) ([@consideRatio](https://github.com/consideRatio))
 * Add an explicit dependency on urllib3 [#437](https://github.com/jupyterhub/kubespawner/pull/437) ([@yuvipanda](https://github.com/yuvipanda))
 * Delete remnant now unused parts in spawner.py [#382](https://github.com/jupyterhub/kubespawner/pull/382) ([@bitnik](https://github.com/bitnik))
-
-## Contributors to this release
-([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2020-09-04&to=2020-10-04&type=c))
-
-[@bitnik](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Abitnik+updated%3A2020-09-04..2020-10-04&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2020-09-04..2020-10-04&type=Issues) | [@gravenimage](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Agravenimage+updated%3A2020-09-04..2020-10-04&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2020-09-04..2020-10-04&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2020-09-04..2020-10-04&type=Issues) | [@remche](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aremche+updated%3A2020-09-04..2020-10-04&type=Issues) | [@rmoe](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Armoe+updated%3A2020-09-04..2020-10-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Awelcome+updated%3A2020-09-04..2020-10-04&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ayuvipanda+updated%3A2020-09-04..2020-10-04&type=Issues)
 
 ## [0.13]
 
@@ -26,7 +27,7 @@
 
 Noteworthy for this release are: performance improvements, Kubernetes native environment variable specification, the possibility to run multiple JupyterHub's in the same namespace.
 
-### Breaking changes
+#### Breaking changes
 
 The following changes probably won't break typical usage of KubeSpawner, but could for example break logic to customized the progress page JupyerHub displays while spawning a Kubernetes pod for the user.
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -2,6 +2,22 @@
 
 <!-- PR link template: - [#](https://github.com/jupyterhub/kubespawner/pull/) ([@](https://github.com/)) -->
 
+## [0.14]
+
+### Bugs fixed
+* Access containerStatuses key with get() [#441](https://github.com/jupyterhub/kubespawner/pull/441) ([@rmoe](https://github.com/rmoe))
+* Allow pod to spawn if the PVC specified already exists [#438](https://github.com/jupyterhub/kubespawner/pull/438) ([@gravenimage](https://github.com/gravenimage))
+* Add timeout and retry to create_namespaced_pod [#433](https://github.com/jupyterhub/kubespawner/pull/433) ([@gravenimage](https://github.com/gravenimage))
+* Fix KubeIngressProxy.get_all_routes for 0.13 [#430](https://github.com/jupyterhub/kubespawner/pull/430) ([@remche](https://github.com/remche))
+
+### Maintenance and upkeep improvements
+* Add an explicit dependency on urllib3 [#437](https://github.com/jupyterhub/kubespawner/pull/437) ([@yuvipanda](https://github.com/yuvipanda))
+
+### Contributors to this release
+([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2020-09-04&to=2020-10-04&type=c))
+
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2020-09-04..2020-10-04&type=Issues) | [@gravenimage](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Agravenimage+updated%3A2020-09-04..2020-10-04&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2020-09-04..2020-10-04&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2020-09-04..2020-10-04&type=Issues) | [@remche](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aremche+updated%3A2020-09-04..2020-10-04&type=Issues) | [@rmoe](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Armoe+updated%3A2020-09-04..2020-10-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Awelcome+updated%3A2020-09-04..2020-10-04&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ayuvipanda+updated%3A2020-09-04..2020-10-04&type=Issues)
+
 ## [0.13]
 
 ### [0.13.0] - 2020-09-XX


### PR DESCRIPTION
AKS doesn't work well without recent fixes to make it more reliable, so this release is quite urgent due to that.

## Generating the changelog

If we want to update this changelog, we can in just re-run the github-activity tool after having labeled the PRs that have arrived, and then copy paste into the changelog in the docs/ folder.

```shell
pip install -U git+https://github.com/executablebooks/github-activity
github-activity jupyterhub/kubespawner --output changelog-prs.md
```

## Related
- KubeSpawner 0.14.0 changelog PR - https://github.com/jupyterhub/kubespawner/pull/443
- JupyterHub 1.2.0b1 changelog PR - https://github.com/jupyterhub/jupyterhub/pull/3192
- Z2JH 0.10.0-beta.1 changelog PR - https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1795