### PR TITLE
Python 3.6+ migration: async in 3.5 and async with yeild in 3.6

### DIFF
--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -11,11 +11,6 @@ import json
 import os
 import pytest
 
-def sync_wait(future):
-    loop = get_event_loop()
-    loop.run_until_complete(future)
-    return future.result()
-
 
 class MockUser(Mock):
     name = 'fake'
@@ -153,7 +148,8 @@ async def test_spawn_progress(kube_ns, kube_client, config):
     await spawner.stop()
 
 
-def test_get_pod_manifest_tolerates_mixed_input():
+@pytest.mark.asyncio
+async def test_get_pod_manifest_tolerates_mixed_input():
     """
     Test that the get_pod_manifest function can handle a either a dictionary or
     an object both representing V1Container objects and that the function
@@ -181,7 +177,7 @@ def test_get_pod_manifest_tolerates_mixed_input():
     spawner = KubeSpawner(config=c, _mock=True)
 
     # this test ensures the following line doesn't raise an error
-    manifest = sync_wait(spawner.get_pod_manifest())
+    manifest = await spawner.get_pod_manifest()
 
     # and tests the return value's types
     assert isinstance(manifest, V1Pod)


### PR DESCRIPTION
Since KubeSpawner already require Python 3.6+ according to setup.py, and async support was introduced in Python 3.5 and augmented for generators using yeild in Python 3.6, this is plausible to do at this point.

Review greatly appreciated!

## Notes
- [x] @gen.coroutine is replaced by appending `async` to the function definition
- [x] At times where `yield` is used not to return a value, but as something to wait for in the old system with `@gen.coroutine`, then I've replaced it with `await`.
- [x] At times where `gen.yield_` is used to actually return a value as a async generator, then I've replaced it with `yield`
- [x] I've made use of `async.ensure_future(...)` on functions where situations like `my_resp = my_async_func()` occur, in order to ensure the `my_resp` becomes a [`Task` object](https://docs.python.org/3/library/asyncio-task.html#task-object) which behaves like a [`Future` object](https://www.tornadoweb.org/en/stable/concurrent.html#tornado.concurrent.Future) which has the functions `.done()` and `.result()` for example, while the response of a `my_async_func()` is a [`coroutine` object](https://docs.python.org/3/glossary.html#term-coroutine) that won't have `.done` etc.

## Review questions
- [ ] Does it make sense that the `start()` function isn't async, but the `stop()` function is?