### PR TITLE
[Feature] Add AllowPrivilegeEscalation to container's securityContext

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -280,6 +280,8 @@ def make_pod(
         container_security_context.run_as_group = int(run_as_gid)
     if run_privileged:
         container_security_context.privileged = True
+    if allow_privilege_escalation:
+        container_security_context.allow_privilege_escalation = True
     if not allow_privilege_escalation:
         container_security_context.allow_privilege_escalation = False
     # Only clutter container spec with actual content

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -35,7 +35,7 @@ def make_pod(
     fs_gid=None,
     supplemental_gids=None,
     run_privileged=False,
-    run_allow_privilege_escalation=True,
+    allow_privilege_escalation=True,
     env=None,
     working_dir=None,
     volumes=None,
@@ -118,7 +118,7 @@ def make_pod(
         to, as group writable.
     run_privileged:
         Whether the container should be run in privileged mode.
-    run_allow_privilege_escalation:
+    allow_privilege_escalation:
         Controls whether a process can gain more privileges than its parent process.
     env:
         Dictionary of environment variables.
@@ -280,7 +280,7 @@ def make_pod(
         container_security_context.run_as_group = int(run_as_gid)
     if run_privileged:
         container_security_context.privileged = True
-    if not run_allow_privilege_escalation:
+    if not allow_privilege_escalation:
         container_security_context.allow_privilege_escalation = False
     # Only clutter container spec with actual content
     if all([e is None for e in container_security_context.to_dict().values()]):

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -35,6 +35,7 @@ def make_pod(
     fs_gid=None,
     supplemental_gids=None,
     run_privileged=False,
+    run_allow_privilege_escalation=True,
     env=None,
     working_dir=None,
     volumes=None,
@@ -117,6 +118,8 @@ def make_pod(
         to, as group writable.
     run_privileged:
         Whether the container should be run in privileged mode.
+    run_allow_privilege_escalation:
+        Controls whether a process can gain more privileges than its parent process.
     env:
         Dictionary of environment variables.
     volumes:
@@ -277,6 +280,8 @@ def make_pod(
         container_security_context.run_as_group = int(run_as_gid)
     if run_privileged:
         container_security_context.privileged = True
+    if not run_allow_privilege_escalation:
+        container_security_context.allow_privilege_escalation = False
     # Only clutter container spec with actual content
     if all([e is None for e in container_security_context.to_dict().values()]):
         container_security_context = None

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -280,8 +280,6 @@ def make_pod(
         container_security_context.run_as_group = int(run_as_gid)
     if run_privileged:
         container_security_context.privileged = True
-    if allow_privilege_escalation and not run_privileged:
-        container_security_context.allow_privilege_escalation = True
     if not allow_privilege_escalation:
         container_security_context.allow_privilege_escalation = False
     # Only clutter container spec with actual content

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -280,7 +280,7 @@ def make_pod(
         container_security_context.run_as_group = int(run_as_gid)
     if run_privileged:
         container_security_context.privileged = True
-    if allow_privilege_escalation:
+    if allow_privilege_escalation and not run_privileged:
         container_security_context.allow_privilege_escalation = True
     if not allow_privilege_escalation:
         container_security_context.allow_privilege_escalation = False

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -679,6 +679,20 @@ class KubeSpawner(Spawner):
         """
     )
 
+    allow_privilege_escalation = Bool(
+        True,
+        config=True,
+        help="""
+        Controls whether a process can gain more privileges than its parent process.
+        
+        This bool directly controls whether the no_new_privs flag gets set on the container 
+        process.
+
+        AllowPrivilegeEscalation is true always when the container is: 
+        1) run as Privileged OR 2) has CAP_SYS_ADMIN.
+        """
+    )
+
     modify_pod_hook = Callable(
         None,
         allow_none=True,
@@ -1276,6 +1290,7 @@ class KubeSpawner(Spawner):
         "singleuser_fs_gid",
         "singleuser_supplemental_gids",
         "singleuser_privileged",
+        "singleuser_allow_privilege_escalation"
         "singleuser_lifecycle_hooks",
         "singleuser_extra_pod_config",
         "singleuser_init_containers",
@@ -1482,6 +1497,7 @@ class KubeSpawner(Spawner):
             fs_gid=fs_gid,
             supplemental_gids=supplemental_gids,
             run_privileged=self.privileged,
+            run_allow_privilege_escalation=self.allow_privilege_escalation
             env=self.get_env(),
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1497,7 +1497,7 @@ class KubeSpawner(Spawner):
             fs_gid=fs_gid,
             supplemental_gids=supplemental_gids,
             run_privileged=self.privileged,
-            run_allow_privilege_escalation=self.allow_privilege_escalation
+            allow_privilege_escalation=self.allow_privilege_escalation
             env=self.get_env(),
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1497,7 +1497,7 @@ class KubeSpawner(Spawner):
             fs_gid=fs_gid,
             supplemental_gids=supplemental_gids,
             run_privileged=self.privileged,
-            allow_privilege_escalation=self.allow_privilege_escalation
+            allow_privilege_escalation=self.allow_privilege_escalation,
             env=self.get_env(),
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def config(kube_ns):
     """
     cfg = Config()
     cfg.KubeSpawner.namespace = kube_ns
+    cfb.KubeSpawner.start_timeout = 120
     return cfg
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def config(kube_ns):
     """
     cfg = Config()
     cfg.KubeSpawner.namespace = kube_ns
-    cfb.KubeSpawner.start_timeout = 120
+    cfg.KubeSpawner.start_timeout = 120
     return cfg
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ def config(kube_ns):
     """
     cfg = Config()
     cfg.KubeSpawner.namespace = kube_ns
-    cfg.KubeSpawner.start_timeout = 120
     return cfg
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -433,7 +433,7 @@ def test_run_privileged_container():
         "apiVersion": "v1"
     }
 
-def test_run_allow_privilege_escalation_container():
+def test_allow_privilege_escalation_container():
     """
     Test specification of the container to run without privilege escalation (AllowPrivilegeEscalation=False).
     """
@@ -442,7 +442,7 @@ def test_run_allow_privilege_escalation_container():
         image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
-        run_allow_privilege_escalation=False,
+        allow_privilege_escalation=False,
         image_pull_policy='IfNotPresent'
     )) == {
         "metadata": {

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -433,6 +433,54 @@ def test_run_privileged_container():
         "apiVersion": "v1"
     }
 
+def test_run_allow_privilege_escalation_container():
+    """
+    Test specification of the container to run without privilege escalation (AllowPrivilegeEscalation=False).
+    """
+    assert api_client.sanitize_for_serialization(make_pod(
+        name='test',
+        image='jupyter/singleuser:latest',
+        cmd=['jupyterhub-singleuser'],
+        port=8888,
+        run_allow_privilege_escalation=False,
+        image_pull_policy='IfNotPresent'
+    )) == {
+        "metadata": {
+            "name": "test",
+            "annotations": {},
+            "labels": {},
+        },
+        "spec": {
+            'automountServiceAccountToken': False,
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{
+                        "name": "notebook-port",
+                        "containerPort": 8888
+                    }],
+                    "resources": {
+                        "limits": {},
+                        "requests": {}
+                    },
+                    "securityContext": {
+                        "allowPrivilegeEscalation": False
+                    },
+                    'volumeMounts': [],
+                }
+            ],
+            'restartPolicy': 'OnFailure',
+            'volumes': [],
+        },
+        "kind": "Pod",
+        "apiVersion": "v1"
+    }
+
+
 def test_make_pod_resources_all():
     """
     Test specifying all possible resource limits & guarantees


### PR DESCRIPTION
### PR summary

KubeSpawner can spawn pods and container's with a securityContext field set.

The notebook container can only be set with the following security features:

- `run_as_uid`
- `run_as_gid`
- `fs_gid`
- `supplemental_gids`
- `run_privileged`

But in some restrained security context, we need to disable privilege escalation for the notebook container.
By default, `AllowPrivilegeEscalation` is kept as True. We need a way to set it to `False` if needed.

### Proposed change

Add `allow_privilege_escalation` flag to be able to set it to `False`.

The target flags will be:

- `run_as_uid`
- `run_as_gid`
- `fs_gid`
- `supplemental_gids`
- `run_privileged`
- `allow_privilege_escalation`

### Who would use this feature?

People with restrained security context, even for notebook container.
