### PR TITLE
KubeSpawner.image_pull_secrets malfunctions in 0.14.0 - this fixes it

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -547,6 +547,8 @@ class KubeSpawner(Spawner):
             )
             return [{"name": proposal['value']}]
 
+        return proposal['value']
+
     node_selector = Dict(
         config=True,
         help="""

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -330,3 +330,21 @@ def test_pod_name_collision():
     assert spawner.pod_name != named_spawner.pod_name
     assert named_spawner.pvc_name == "claim-user-2dhas--2ddash"
     assert spawner.pvc_name != named_spawner.pvc_name
+
+
+def test_spawner_can_use_list_of_image_pull_secrets():
+    secrets = ["ecr", "regcred", "artifactory"]
+
+    c = Config()
+    c.KubeSpawner.image_spec = "private.docker.registry/jupyter:1.2.3"
+    c.KubeSpawner.image_pull_secrets = secrets
+    spawner = KubeSpawner(hub=Hub(), config=c, _mock=True)
+    assert spawner.image_pull_secrets == secrets
+
+    secrets = [dict(name=secret) for secret in secrets]
+    c = Config()
+    c.KubeSpawner.image_spec = "private.docker.registry/jupyter:1.2.3"
+    c.KubeSpawner.image_pull_secrets = secrets
+    spawner = KubeSpawner(hub=Hub(), config=c, _mock=True)
+    assert spawner.image_pull_secrets == secrets
+


### PR DESCRIPTION
The existing KubeSpawner.image_pull_secrets doesn't seem to be working. The validation method returns `None` when the input type is not a string e.g. a list causes errors. The existing help text claims that a list is the supported type but passing a list will result in image_pull_secrets being `NoneType` . From the traitlets docs `If this function does not have any return statement, then the returned value will be None, instead of what we wanted (which is proposal['value']).` https://traitlets.readthedocs.io/en/stable/using_traitlets.html#validation-and-coercion

I made a `help` change to `KubeSpawner.image_pull_secrets` to constrain the input type to a list of strings. I'm not sure if this is the right thing. The existing help section claims that is should be `A list of references to Kubernetes Secret resources with credentials to pull images from image registries`. This is somewhat unclear so I'm not sure how to correct this. Was the intention for this to be a list of `V1LocalObjectReference`?