### PR TITLE
Add options_from_form as configurable

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2035,7 +2035,8 @@ class KubeSpawner(Spawner):
         else:
             return self._render_options_form(self.profile_list)
 
-    def options_from_form(self, formdata):
+    @default('options_from_form')
+    def _options_from_form(self, formdata):
         """get the option selected by the user on the form
 
         This only constructs the user_options dict,


### PR DESCRIPTION
Without this part as being configurable, it doesn't make sense to
be able to configure the options_form part since you can't easily
get the values back to permute them into options the kubespawner
will understand.  I think this meant to be decorated since it is mentioned
in the documentation in the options_form section.