### PR TITLE
Let uid/gid/fs_gid default to None instead of 0

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -567,6 +567,7 @@ class KubeSpawner(Spawner):
             Integer(),
             Callable(),
         ],
+        default_value=None,
         allow_none=True,
         config=True,
         help="""
@@ -592,6 +593,7 @@ class KubeSpawner(Spawner):
             Integer(),
             Callable(),
         ],
+        default_value=None,
         allow_none=True,
         config=True,
         help="""
@@ -617,6 +619,7 @@ class KubeSpawner(Spawner):
             Integer(),
             Callable(),
         ],
+        default_value=None,
         allow_none=True,
         config=True,
         help="""

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -244,8 +244,8 @@ def test_set_container_uid_and_gid():
         image='jupyter/singleuser:latest',
         cmd=['jupyterhub-singleuser'],
         port=8888,
-        run_as_uid=1000,
-        run_as_gid=2000,
+        run_as_uid=0,
+        run_as_gid=0,
         image_pull_policy='IfNotPresent'
     )) == {
         "metadata": {
@@ -258,8 +258,8 @@ def test_set_container_uid_and_gid():
             "containers": [
                 {
                     "securityContext": {
-                        "runAsUser": 1000,
-                        "runAsGroup": 2000
+                        "runAsUser": 0,
+                        "runAsGroup": 0
                     },
                     "env": [],
                     "name": "notebook",
@@ -294,7 +294,7 @@ def test_set_container_uid_and_pod_fs_gid():
         cmd=['jupyterhub-singleuser'],
         port=8888,
         run_as_uid=1000,
-        fs_gid=1000,
+        fs_gid=0,
         image_pull_policy='IfNotPresent'
     )) == {
         "metadata": {
@@ -327,7 +327,7 @@ def test_set_container_uid_and_pod_fs_gid():
             ],
             'restartPolicy': 'OnFailure',
             'securityContext': {
-                'fsGroup': 1000,
+                'fsGroup': 0,
             },
             'volumes': [],
         },

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -73,6 +73,7 @@ def test_spawner_values():
     def set_id(spawner):
         return 1
 
+    assert spawner.uid == None
     spawner.uid = 10
     assert spawner.uid == 10
     spawner.uid = set_id
@@ -80,6 +81,7 @@ def test_spawner_values():
     spawner.uid = None
     assert spawner.uid == None
 
+    assert spawner.gid == None
     spawner.gid = 20
     assert spawner.gid == 20
     spawner.gid = set_id
@@ -87,6 +89,7 @@ def test_spawner_values():
     spawner.gid = None
     assert spawner.gid == None
 
+    assert spawner.fs_gid == None
     spawner.fs_gid = 30
     assert spawner.fs_gid == 30
     spawner.fs_gid = set_id


### PR DESCRIPTION
This PR will introduce a change for those that use KubeSpawner without configuring .gid, .uid, or .fs_gid. This is because those fields then have default to the value of 0 instead of None, which makes them become set to zero instead of simply not be set.﻿

I think it is sensible to introduce this breaking change, which only will be breaking for those that use the KubeSpawner default for these settings, for two reasons.

1. The KubeSpawner default values are not secure defaults - granting root access by default doesn't seem to make much sense to me.
2. The most sensible default in my mind is to not override the Docker image configuration, no matter if it is secure or not.

## Review notes
- Union traitlets must have an explicit default_value keyword argument passed, we cannot use a positional argument to set the default value.
- I updated the tests for uid/gid/fs_gid to ensure that it does the right thing when it is set to 0 rather than None correctly.

## Breaking changes
- In standalone use of KubeSpawner, the defaults change, which may break users assumptions.
- In z2jh we don't explicitly set `gid` on KubeSpawner, which means that while we previously in Z2JH got `c.KubeSpawner.gid=0` as default, we now get `c.KubeSpawner.gid=None` as default. Users may have relied on `gid=0`.

---

Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1733.
Closes #453.