### PR TITLE
Cleanup JS patch of JupyterHub 0.8 HTML not needed in 0.9+

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1133,13 +1133,6 @@ class KubeSpawner(Spawner):
 
     profile_form_template = Unicode(
         """
-        <script>
-        // JupyterHub 0.8 applied form-control indisciminately to all form elements.
-        // Can be removed once we stop supporting JupyterHub 0.8
-        $(document).ready(function() {
-            $('#kubespawner-profiles-list input[type="radio"]').removeClass('form-control');
-        });
-        </script>
         <style>
         /* The profile description should not be bold, even though it is inside the <label> tag */
         #kubespawner-profiles-list label p {


### PR DESCRIPTION
Closes #225 which was a reminder to do this cleanup.
