### PR TITLE
Support pod IP template

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -355,6 +355,24 @@ class KubeSpawner(Spawner):
         """
     )
 
+    pod_ip_template = Unicode(
+        config=True,
+        help="""
+        Template to use to form The IP address (or hostname) of user's pods.
+
+        e.g. 'jupyter-{username}--{servername}.notebooks.jupyterhub.svc.cluster.local',
+
+        `{username}` is expanded to the escaped, dns-label-safe username.
+        `{servername}` is expanded to the escaped, dns-label-safe server name, if any.
+
+        Trailing `-` characters in each domain level are stripped for safe handling of empty server names (user default servers).
+
+        This must be unique within the namespace the pods are being spawned
+        in, so if you are running multiple jupyterhubs spawning in the
+        same namespace, consider setting this to be something more unique.
+        """
+    )
+
     storage_pvc_ensure = Bool(
         False,
         config=True,
@@ -1955,7 +1973,13 @@ class KubeSpawner(Spawner):
                     ]
                 ),
             )
-        return (pod["status"]["podIP"], self.port)
+
+        if self.pod_ip_template:
+            ip = ".".join([s.rstrip("-") for s in self._expand_user_properties(self.pod_ip_template).split(".")])
+        else:
+            ip = pod["status"]["podIP"]
+
+        return (ip, self.port)
 
     async def _make_delete_pod_request(self, pod_name, delete_options, grace_seconds, request_timeout):
         """

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -358,7 +358,8 @@ class KubeSpawner(Spawner):
     pod_connect_ip = Unicode(
         config=True,
         help="""
-        Template to use to form The IP address (or hostname) of user's pods.
+        The IP address (or hostname) of user's pods which KubeSpawner connects to.
+        If you do not specify the value, KubeSpawner will use the pod IP.
 
         e.g. 'jupyter-{username}--{servername}.notebooks.jupyterhub.svc.cluster.local',
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -355,7 +355,7 @@ class KubeSpawner(Spawner):
         """
     )
 
-    pod_ip_template = Unicode(
+    pod_connect_ip = Unicode(
         config=True,
         help="""
         Template to use to form The IP address (or hostname) of user's pods.
@@ -1974,9 +1974,9 @@ class KubeSpawner(Spawner):
                 ),
             )
 
-        if self.pod_ip_template:
+        if self.pod_connect_ip:
             # Strip trailing `-` of empty server names in each domain level.
-            ip = ".".join([s.rstrip("-") for s in self._expand_user_properties(self.pod_ip_template).split(".")])
+            ip = ".".join([s.rstrip("-") for s in self._expand_user_properties(self.pod_connect_ip).split(".")])
         else:
             ip = pod["status"]["podIP"]
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1975,6 +1975,7 @@ class KubeSpawner(Spawner):
             )
 
         if self.pod_ip_template:
+            # Strip trailing `-` of empty server names in each domain level.
             ip = ".".join([s.rstrip("-") for s in self._expand_user_properties(self.pod_ip_template).split(".")])
         else:
             ip = pod["status"]["podIP"]

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -359,8 +359,8 @@ def test_spawner_can_use_list_of_image_pull_secrets():
 
 
 @pytest.mark.asyncio
-async def test_pod_ip_template(kube_ns, kube_client, config):
-    config.KubeSpawner.pod_ip_template = "jupyter-{username}--{servername}.foo.example.com"
+async def test_pod_connect_ip(kube_ns, kube_client, config):
+    config.KubeSpawner.pod_connect_ip = "jupyter-{username}--{servername}.foo.example.com"
 
     # w/o servername
     spawner = KubeSpawner(hub=Hub(), user=MockUser(), config=config)


### PR DESCRIPTION
My notebook pods in calico-installed EKS with Amazon VPC networking changes the IP address when it's restarted on failure. Then, JupyterHub will lose the connection and cannot find the pod although it knows the pod is running by Kubernetes API.

I tried to make a workaround by using a headless service and pod subdomain, but it was not possible to customize the pod IP, so I'm sending this PR.

I will use the following manifest and `jupyterhub_config.py` to utilize this feature.

```yaml
apiVersion: v1
kind: Service
metadata:
  name: notebooks
  namespace: jupyterhub
spec:
  selector:
    app: jupyterhub
    component: singleuser-server
  clusterIP: None
  ports: []
```

```python
c.KubeSpawner.pod_ip = "jupyter-{username}--{servername}.notebooks.jupyterhub"

def modify_pod_hook(spawner, pod):
    pod.spec.subdomain = "notebooks"
    pod.spec.hostname = spawner._expand_user_properties("jupyter-{username}--{servername}")
    return pod

c.KubeSpawner.modify_pod_hook = modify_pod_hook
```

Could you consider merging this change?