### PR TITLE
read env from secrets

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -6,7 +6,6 @@ import json
 import os
 import re
 from urllib.parse import urlparse
-
 from kubernetes.client.models import (
     V1Affinity,
     V1Container,
@@ -36,6 +35,8 @@ from kubernetes.client.models import (
     V1PreferredSchedulingTerm,
     V1ResourceRequirements,
     V1Secret,
+    V1EnvFromSource, 
+    V1SecretEnvSource,
     V1SecurityContext,
     V1Service,
     V1ServicePort,
@@ -62,7 +63,7 @@ def make_pod(
     supplemental_gids=None,
     run_privileged=False,
     allow_privilege_escalation=True,
-    env=None,
+    env_from=None,
     working_dir=None,
     volumes=None,
     volume_mounts=None,
@@ -266,6 +267,7 @@ def make_pod(
 
     pod.spec = V1PodSpec(containers=[])
     pod.spec.restart_policy = 'OnFailure'
+    
 
     if image_pull_secrets is not None:
         # image_pull_secrets as received by the make_pod function should always
@@ -286,12 +288,6 @@ def make_pod(
                 'name': 'jupyterhub-internal-certs',
                 'secret': {'secretName': ssl_secret_name, 'defaultMode': 511},
             }
-        )
-
-        env['JUPYTERHUB_SSL_KEYFILE'] = ssl_secret_mount_path + "ssl.key"
-        env['JUPYTERHUB_SSL_CERTFILE'] = ssl_secret_mount_path + "ssl.crt"
-        env['JUPYTERHUB_SSL_CLIENT_CA'] = (
-            ssl_secret_mount_path + "notebooks-ca_trust.crt"
         )
 
         if not volume_mounts:
@@ -340,24 +336,12 @@ def make_pod(
     if all([e is None for e in container_security_context.to_dict().values()]):
         container_security_context = None
 
-    # Transform a dict into valid Kubernetes EnvVar Python representations. This
-    # representation shall always have a "name" field as well as either a
-    # "value" field or "value_from" field. For examples see the
-    # test_make_pod_with_env function.
-    prepared_env = []
-    for k, v in (env or {}).items():
-        if type(v) == dict:
-            if not "name" in v:
-                v["name"] = k
-            prepared_env.append(get_k8s_model(V1EnvVar, v))
-        else:
-            prepared_env.append(V1EnvVar(name=k, value=v))
     notebook_container = V1Container(
         name='notebook',
         image=image,
         working_dir=working_dir,
         ports=[V1ContainerPort(name='notebook-port', container_port=port)],
-        env=prepared_env,
+        env_from=[V1EnvFromSource(secret_ref=V1SecretEnvSource(env_from))],
         args=cmd,
         image_pull_policy=image_pull_policy,
         lifecycle=lifecycle_hooks,
@@ -671,9 +655,8 @@ def make_owner_reference(name, uid):
 
 def make_secret(
     name,
+    str_data,
     username,
-    cert_paths,
-    hub_ca,
     owner_references,
     labels=None,
     annotations=None,
@@ -706,26 +689,7 @@ def make_secret(
     secret.metadata.annotations = (annotations or {}).copy()
     secret.metadata.labels = (labels or {}).copy()
     secret.metadata.owner_references = owner_references
-
-    secret.data = {}
-
-    with open(cert_paths['keyfile'], 'r') as file:
-        encoded = base64.b64encode(file.read().encode("utf-8"))
-        secret.data['ssl.key'] = encoded.decode("utf-8")
-
-    with open(cert_paths['certfile'], 'r') as file:
-        encoded = base64.b64encode(file.read().encode("utf-8"))
-        secret.data['ssl.crt'] = encoded.decode("utf-8")
-
-    with open(cert_paths['cafile'], 'r') as file:
-        encoded = base64.b64encode(file.read().encode("utf-8"))
-        secret.data["notebooks-ca_trust.crt"] = encoded.decode("utf-8")
-
-    with open(hub_ca, 'r') as file:
-        encoded = base64.b64encode(file.read().encode("utf-8"))
-        secret.data["notebooks-ca_trust.crt"] = secret.data[
-            "notebooks-ca_trust.crt"
-        ] + encoded.decode("utf-8")
+    secret.string_data = str_data
 
     return secret
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2,7 +2,7 @@
 Test functions used to create k8s objects
 """
 from kubernetes.client import ApiClient
-from kubespawner.objects import make_ingress, make_pod, make_pvc
+from kubespawner.objects import make_ingress, make_pod, make_pvc, make_secret
 
 api_client = ApiClient()
 
@@ -26,7 +26,7 @@ def test_make_simplest_pod():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -70,7 +70,7 @@ def test_make_labeled_pod():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -114,7 +114,7 @@ def test_make_annotated_pod():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -162,7 +162,7 @@ def test_make_pod_with_image_pull_secrets_simplified_format():
             ],
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -211,7 +211,7 @@ def test_make_pod_with_image_pull_secrets_k8s_native_format():
             ],
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -261,7 +261,7 @@ def test_set_container_uid_and_gid():
                         "runAsUser": 0,
                         "runAsGroup": 0
                     },
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -309,7 +309,7 @@ def test_set_container_uid_and_pod_fs_gid():
                     "securityContext": {
                         "runAsUser": 1000,
                     },
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -360,7 +360,7 @@ def test_set_pod_supplemental_gids():
                     "securityContext": {
                         "runAsUser": 1000,
                     },
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -407,7 +407,7 @@ def test_run_privileged_container():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -454,7 +454,7 @@ def test_allow_privilege_escalation_container():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -507,7 +507,7 @@ def test_make_pod_resources_all():
             "nodeSelector": {"disk": "ssd"},
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -537,33 +537,14 @@ def test_make_pod_resources_all():
     }
 
 
-def test_make_pod_with_env():
+def test_make_pod_with_env_from():
     """
     Test specification of a pod with custom environment variables.
     """
     assert api_client.sanitize_for_serialization(make_pod(
         name='test',
         image='jupyter/singleuser:latest',
-        env={
-            'TEST_KEY_1': 'TEST_VALUE',
-            'TEST_KEY_2': {
-                'valueFrom': {
-                    'secretKeyRef': {
-                        'name': 'my-k8s-secret',
-                        'key': 'password',
-                    },
-                },
-            },
-            'TEST_KEY_NAME_IGNORED': {
-                'name': 'TEST_KEY_3',
-                'valueFrom': {
-                    'secretKeyRef': {
-                        'name': 'my-k8s-secret',
-                        'key': 'password',
-                    },
-                },
-            },
-        },
+        env_from='my-k8s-secret',
         cmd=['jupyterhub-singleuser'],
         port=8888,
         image_pull_policy='IfNotPresent'
@@ -577,29 +558,12 @@ def test_make_pod_with_env():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [
+                    "envFrom": [
                         {
-                            'name': 'TEST_KEY_1',
-                            'value': 'TEST_VALUE',
-                        },
-                        {
-                            'name': 'TEST_KEY_2',
-                            'valueFrom': {
-                                'secretKeyRef': {
-                                    'name': 'my-k8s-secret',
-                                    'key': 'password',
-                                },
-                            },
-                        },
-                        {
-                            'name': 'TEST_KEY_3',
-                            'valueFrom': {
-                                'secretKeyRef': {
-                                    'name': 'my-k8s-secret',
-                                    'key': 'password',
-                                },
-                            },
-                        },
+                            'secretRef': {
+                                'name': 'my-k8s-secret'
+                            }
+                        }
                     ],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
@@ -652,7 +616,7 @@ def test_make_pod_with_lifecycle():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -717,7 +681,7 @@ def test_make_pod_with_init_containers():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -785,7 +749,7 @@ def test_make_pod_with_extra_container_config():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -851,7 +815,7 @@ def test_make_pod_with_extra_pod_config():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -912,7 +876,7 @@ def test_make_pod_with_extra_containers():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -970,7 +934,7 @@ def test_make_pod_with_extra_resources():
             "nodeSelector": {"disk": "ssd"},
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1001,6 +965,51 @@ def test_make_pod_with_extra_resources():
         "kind": "Pod",
         "apiVersion": "v1"
     }
+
+def test_make_secret_simple():
+    """
+    Test specification of the simplest possible secret specification
+    """
+    assert api_client.sanitize_for_serialization(make_secret(
+        name='my-k8s-secret',
+        str_data={},
+        username='test',
+        owner_references=[],
+        labels={}    
+    )) == {
+        'kind': 'Secret',
+        'apiVersion': 'v1',
+        'metadata': {
+            'name': 'my-k8s-secret',
+            'annotations': {},
+            'labels': {},
+            'ownerReferences': []
+        },
+        'stringData': {}
+    }
+
+def test_make_secret_with_data():
+    """
+    Test specification of the simplest possible secret specification
+    """
+    assert api_client.sanitize_for_serialization(make_secret(
+        name='my-k8s-secret',
+        str_data={"TEST1": "VALUE1"},
+        username='test',
+        owner_references=[],
+        labels={}    
+    )) == {
+        'kind': 'Secret',
+        'apiVersion': 'v1',
+        'metadata': {
+            'name': 'my-k8s-secret',
+            'ownerReferences': [],
+            'annotations': {},
+            'labels': {}
+        },
+        'stringData': {"TEST1": "VALUE1"}
+    }
+
 
 def test_make_pvc_simple():
     """
@@ -1125,7 +1134,7 @@ def test_make_pod_with_service_account():
         "spec": {
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1171,7 +1180,7 @@ def test_make_pod_with_scheduler_name():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1230,7 +1239,7 @@ def test_make_pod_with_tolerations():
             "automountServiceAccountToken": False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1286,7 +1295,7 @@ def test_make_pod_with_node_affinity_preferred():
             "automountServiceAccountToken": False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1343,7 +1352,7 @@ def test_make_pod_with_node_affinity_required():
             "automountServiceAccountToken": False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1408,7 +1417,7 @@ def test_make_pod_with_pod_affinity_preferred():
             "automountServiceAccountToken": False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1468,7 +1477,7 @@ def test_make_pod_with_pod_affinity_required():
             "automountServiceAccountToken": False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1531,7 +1540,7 @@ def test_make_pod_with_pod_anti_affinity_preferred():
             "automountServiceAccountToken": False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1591,7 +1600,7 @@ def test_make_pod_with_pod_anti_affinity_required():
             "automountServiceAccountToken": False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1641,7 +1650,7 @@ def test_make_pod_with_priority_class_name():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [],
+                    "envFrom": [{'secretRef': {}}],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
@@ -1755,11 +1764,7 @@ def test_make_pod_with_ssl():
         make_pod(
             name='ssl',
             image='jupyter/singleuser:latest',
-            env={
-                'JUPYTERHUB_SSL_KEYFILE': 'TEST_VALUE',
-                'JUPYTERHUB_SSL_CERTFILE': 'TEST',
-                'JUPYTERHUB_USER': 'TEST',
-            },
+            env_from='ssl',
             working_dir='/',
             cmd=['jupyterhub-singleuser'],
             port=8888,
@@ -1777,19 +1782,11 @@ def test_make_pod_with_ssl():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "env": [
+                    "envFrom": [
                         {
-                            'name': 'JUPYTERHUB_SSL_KEYFILE',
-                            'value': '/etc/jupyterhub/ssl/ssl.key',
-                        },
-                        {
-                            'name': 'JUPYTERHUB_SSL_CERTFILE',
-                            'value': '/etc/jupyterhub/ssl/ssl.crt',
-                        },
-                        {'name': 'JUPYTERHUB_USER', 'value': 'TEST'},
-                        {
-                            'name': 'JUPYTERHUB_SSL_CLIENT_CA',
-                            'value': '/etc/jupyterhub/ssl/notebooks-ca_trust.crt',
+                            'secretRef': {
+                                'name': 'ssl'
+                            }
                         },
                     ],
                     "name": "notebook",


### PR DESCRIPTION
what
---

- Create a secret with all the env. variables and bind this to the pod 

why
---

- Currently single user pod manifest show all the env. variables in plain text. To fix this issue and to follow the security standards and best practices all the env. variables are pulled into a secret which gives more flexibility for access policies.

references
---
See #398 for details.