### PR TITLE
adopt black (via pre-commit) for code formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,18 @@
 [flake8]
-select = F
-ignore = E,W,C,F401,F841
-exclude = __init__.py
-
+# Ignore style and complexity
+# E: style errors
+# W: style warnings
+# C: complexity
+# F401: module imported but unused
+# F403: import *
+# F811: redefinition of unused `name` from line `N`
+# F841: local variable assigned but never used
+# E402: module level import not at top of file
+# I100: Import statements are in the wrong order
+# I101: Imported names are in the wrong order. Should be
+ignore = E, C, W, F401, F403, F811, F841, E402, I100, I101, D400
+builtins = c, get_config
+exclude =
+    .cache,
+    .github,
+    docs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,30 @@ defaults:
     shell: bash
 
 jobs:
+  # Run "pre-commit run --all-files"
+  pre-commit:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 2
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      # ref: https://github.com/pre-commit/action
+      - uses: pre-commit/action@v2.0.0
+      - name: Help message if pre-commit fail
+        if: ${{ failure() }}
+        run: |
+          echo "You can install pre-commit hooks to automatically run formatting"
+          echo "on each commit with:"
+          echo "    pre-commit install"
+          echo "or you can run by hand on staged files with"
+          echo "    pre-commit run"
+          echo "or after-the-fact on already committed files with"
+          echo "    pre-commit run --all-files"
+
   run-pytest:
     name: Run pytest
     runs-on: ubuntu-20.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v1.9.0
+  hooks:
+  - id: reorder-python-imports
+- repo: https://github.com/psf/black
+  rev: 20.8b1
+  hooks:
+  - id: black
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: check-json
+  - id: check-yaml
+  - id: check-case-conflict
+  - id: check-executables-have-shebangs
+  - id: requirements-txt-fixer
+  - id: flake8

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
+pyyaml
+recommonmark==0.4.0
+setuptools
+sphinx-copybutton
 sphinx>=1.7
 sphinx_rtd_theme
 traitlets>=4.1
-recommonmark==0.4.0
-pyyaml
-sphinx-copybutton
-setuptools

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,19 +12,18 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
 import sys
+from os.path import dirname
 
-# For conversion from markdown to html
 import recommonmark.parser
 
+# For conversion from markdown to html
 # set paths
-from os.path import dirname
 docs = dirname(dirname(__file__))
 root = dirname(docs)
 sys.path.insert(0, root)
@@ -76,6 +75,7 @@ author = 'Project Jupyter'
 # built documents.
 #
 import pkg_resources
+
 # The full version, including alpha/beta/rc tags.
 release = pkg_resources.get_distribution("jupyterhub-kubespawner").version
 # The short X.Y version.
@@ -131,15 +131,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -149,8 +146,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Kubespawner.tex', 'Kubespawner Documentation',
-     'Project Jupyter', 'manual'),
+    (
+        master_doc,
+        'Kubespawner.tex',
+        'Kubespawner Documentation',
+        'Project Jupyter',
+        'manual',
+    ),
 ]
 
 
@@ -158,10 +160,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'kubespawner', 'Kubespawner Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, 'kubespawner', 'Kubespawner Documentation', [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -170,9 +169,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Kubespawner', 'Kubespawner Documentation',
-     author, 'Kubespawner', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        'Kubespawner',
+        'Kubespawner Documentation',
+        author,
+        'Kubespawner',
+        'One line description of project.',
+        'Miscellaneous',
+    ),
 ]
 
 

--- a/docs/sphinxext/autodoc_traits.py
+++ b/docs/sphinxext/autodoc_traits.py
@@ -1,20 +1,25 @@
 """autodoc extension for configurable traits"""
-
-from traitlets import TraitType, Undefined
 from sphinx.domains.python import PyClassmember
-from sphinx.ext.autodoc import ClassDocumenter, AttributeDocumenter
+from sphinx.ext.autodoc import AttributeDocumenter
+from sphinx.ext.autodoc import ClassDocumenter
+from traitlets import TraitType
+from traitlets import Undefined
 
 
 class ConfigurableDocumenter(ClassDocumenter):
     """Specialized Documenter subclass for traits with config=True"""
+
     objtype = 'configurable'
     directivetype = 'class'
 
     def get_object_members(self, want_all):
         """Add traits with .tag(config=True) to members list"""
         check, members = super().get_object_members(want_all)
-        get_traits = self.object.class_own_traits if self.options.inherited_members \
-                     else self.object.class_traits
+        get_traits = (
+            self.object.class_own_traits
+            if self.options.inherited_members
+            else self.object.class_traits
+        )
         trait_members = []
         for name, trait in sorted(get_traits(config=True).items()):
             # put help in __doc__ where autodoc will look for it

--- a/kubespawner/__init__.py
+++ b/kubespawner/__init__.py
@@ -7,12 +7,10 @@ After installation, you can enable it by adding::
 
 in your `jupyterhub_config.py` file.
 """
-
 # We export KubeSpawner specifically here. This simplifies import for users.
 # Users can simply import kubespawner.KubeSpawner in their applications
 # instead of the more verbose import kubespawner.spawner.KubeSpawner.
-
 from kubespawner.spawner import KubeSpawner
 
 __version__ = '0.15.1.dev'
-__all__ = [KubeSpawner]
+__all__ = ["KubeSpawner"]

--- a/kubespawner/clients.py
+++ b/kubespawner/clients.py
@@ -3,9 +3,8 @@
 avoids creating multiple kubernetes client objects,
 each of which spawns an unused max-size thread pool
 """
-
-from unittest.mock import Mock
 import weakref
+from unittest.mock import Mock
 
 import kubernetes.client
 from kubernetes.client import api_client

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -7,46 +7,46 @@ import os
 import re
 from urllib.parse import urlparse
 
-from kubernetes.client.models import (
-    V1Affinity,
-    V1Container,
-    V1ContainerPort,
-    V1EndpointAddress,
-    V1EndpointPort,
-    V1Endpoints,
-    V1EndpointSubset,
-    V1EnvVar,
-    V1LabelSelector,
-    V1Lifecycle,
-    V1LocalObjectReference,
-    V1Namespace,
-    V1NodeAffinity,
-    V1NodeSelector,
-    V1NodeSelectorRequirement,
-    V1NodeSelectorTerm,
-    V1ObjectMeta,
-    V1OwnerReference,
-    V1PersistentVolumeClaim,
-    V1PersistentVolumeClaimSpec,
-    V1Pod,
-    V1PodAffinity,
-    V1PodAffinityTerm,
-    V1PodAntiAffinity,
-    V1PodSecurityContext,
-    V1PodSpec,
-    V1PreferredSchedulingTerm,
-    V1ResourceRequirements,
-    V1Secret,
-    V1SecurityContext,
-    V1Service,
-    V1ServicePort,
-    V1ServiceSpec,
-    V1Toleration,
-    V1WeightedPodAffinityTerm,
-    V1Volume,
-    V1VolumeMount,
-)
-from kubespawner.utils import get_k8s_model, update_k8s_model
+from kubernetes.client.models import V1Affinity
+from kubernetes.client.models import V1Container
+from kubernetes.client.models import V1ContainerPort
+from kubernetes.client.models import V1EndpointAddress
+from kubernetes.client.models import V1EndpointPort
+from kubernetes.client.models import V1Endpoints
+from kubernetes.client.models import V1EndpointSubset
+from kubernetes.client.models import V1EnvVar
+from kubernetes.client.models import V1LabelSelector
+from kubernetes.client.models import V1Lifecycle
+from kubernetes.client.models import V1LocalObjectReference
+from kubernetes.client.models import V1Namespace
+from kubernetes.client.models import V1NodeAffinity
+from kubernetes.client.models import V1NodeSelector
+from kubernetes.client.models import V1NodeSelectorRequirement
+from kubernetes.client.models import V1NodeSelectorTerm
+from kubernetes.client.models import V1ObjectMeta
+from kubernetes.client.models import V1OwnerReference
+from kubernetes.client.models import V1PersistentVolumeClaim
+from kubernetes.client.models import V1PersistentVolumeClaimSpec
+from kubernetes.client.models import V1Pod
+from kubernetes.client.models import V1PodAffinity
+from kubernetes.client.models import V1PodAffinityTerm
+from kubernetes.client.models import V1PodAntiAffinity
+from kubernetes.client.models import V1PodSecurityContext
+from kubernetes.client.models import V1PodSpec
+from kubernetes.client.models import V1PreferredSchedulingTerm
+from kubernetes.client.models import V1ResourceRequirements
+from kubernetes.client.models import V1Secret
+from kubernetes.client.models import V1SecurityContext
+from kubernetes.client.models import V1Service
+from kubernetes.client.models import V1ServicePort
+from kubernetes.client.models import V1ServiceSpec
+from kubernetes.client.models import V1Toleration
+from kubernetes.client.models import V1Volume
+from kubernetes.client.models import V1VolumeMount
+from kubernetes.client.models import V1WeightedPodAffinityTerm
+
+from kubespawner.utils import get_k8s_model
+from kubespawner.utils import update_k8s_model
 
 
 def make_pod(
@@ -305,7 +305,7 @@ def make_pod(
     pod.metadata = V1ObjectMeta(
         name=name,
         labels=(labels or {}).copy(),
-        annotations=(annotations or {}).copy()
+        annotations=(annotations or {}).copy(),
     )
 
     pod.spec = V1PodSpec(containers=[])
@@ -317,8 +317,8 @@ def make_pod(
         # "a-string"} elements.
         pod.spec.image_pull_secrets = [
             V1LocalObjectReference(name=secret_ref)
-            if type(secret_ref) == str else
-            get_k8s_model(V1LocalObjectReference, secret_ref)
+            if type(secret_ref) == str
+            else get_k8s_model(V1LocalObjectReference, secret_ref)
             for secret_ref in image_pull_secrets
         ]
 
@@ -341,8 +341,10 @@ def make_pod(
         if not volume_mounts:
             volume_mounts = []
         volume_mounts.append(
-            {'name': 'jupyterhub-internal-certs',
-                'mountPath': ssl_secret_mount_path}
+            {
+                'name': 'jupyterhub-internal-certs',
+                'mountPath': ssl_secret_mount_path,
+            }
         )
 
     if node_selector:
@@ -368,7 +370,8 @@ def make_pod(
         pod_security_context.fs_group = int(fs_gid)
     if supplemental_gids is not None and supplemental_gids:
         pod_security_context.supplemental_groups = [
-            int(gid) for gid in supplemental_gids]
+            int(gid) for gid in supplemental_gids
+        ]
     # Only clutter pod spec with actual content
     if not all([e is None for e in pod_security_context.to_dict().values()]):
         pod.spec.security_context = pod_security_context
@@ -408,8 +411,9 @@ def make_pod(
         image_pull_policy=image_pull_policy,
         lifecycle=lifecycle_hooks,
         resources=V1ResourceRequirements(),
-        volume_mounts=[get_k8s_model(V1VolumeMount, obj)
-                       for obj in (volume_mounts or [])],
+        volume_mounts=[
+            get_k8s_model(V1VolumeMount, obj) for obj in (volume_mounts or [])
+        ],
         security_context=container_security_context,
     )
 
@@ -449,13 +453,14 @@ def make_pod(
 
     if extra_containers:
         pod.spec.containers.extend(
-            [get_k8s_model(V1Container, obj) for obj in extra_containers])
+            [get_k8s_model(V1Container, obj) for obj in extra_containers]
+        )
     if tolerations:
-        pod.spec.tolerations = [get_k8s_model(
-            V1Toleration, obj) for obj in tolerations]
+        pod.spec.tolerations = [get_k8s_model(V1Toleration, obj) for obj in tolerations]
     if init_containers:
-        pod.spec.init_containers = [get_k8s_model(
-            V1Container, obj) for obj in init_containers]
+        pod.spec.init_containers = [
+            get_k8s_model(V1Container, obj) for obj in init_containers
+        ]
     if volumes:
         pod.spec.volumes = [get_k8s_model(V1Volume, obj) for obj in volumes]
     else:
@@ -470,14 +475,18 @@ def make_pod(
         node_selector = None
         if node_affinity_required:
             node_selector = V1NodeSelector(
-                node_selector_terms=[get_k8s_model(
-                    V1NodeSelectorTerm, obj) for obj in node_affinity_required],
+                node_selector_terms=[
+                    get_k8s_model(V1NodeSelectorTerm, obj)
+                    for obj in node_affinity_required
+                ],
             )
 
         preferred_scheduling_terms = None
         if node_affinity_preferred:
-            preferred_scheduling_terms = [get_k8s_model(
-                V1PreferredSchedulingTerm, obj) for obj in node_affinity_preferred]
+            preferred_scheduling_terms = [
+                get_k8s_model(V1PreferredSchedulingTerm, obj)
+                for obj in node_affinity_preferred
+            ]
 
         node_affinity = V1NodeAffinity(
             preferred_during_scheduling_ignored_during_execution=preferred_scheduling_terms,
@@ -488,13 +497,16 @@ def make_pod(
     if pod_affinity_preferred or pod_affinity_required:
         weighted_pod_affinity_terms = None
         if pod_affinity_preferred:
-            weighted_pod_affinity_terms = [get_k8s_model(
-                V1WeightedPodAffinityTerm, obj) for obj in pod_affinity_preferred]
+            weighted_pod_affinity_terms = [
+                get_k8s_model(V1WeightedPodAffinityTerm, obj)
+                for obj in pod_affinity_preferred
+            ]
 
         pod_affinity_terms = None
         if pod_affinity_required:
-            pod_affinity_terms = [get_k8s_model(
-                V1PodAffinityTerm, obj) for obj in pod_affinity_required]
+            pod_affinity_terms = [
+                get_k8s_model(V1PodAffinityTerm, obj) for obj in pod_affinity_required
+            ]
 
         pod_affinity = V1PodAffinity(
             preferred_during_scheduling_ignored_during_execution=weighted_pod_affinity_terms,
@@ -505,13 +517,17 @@ def make_pod(
     if pod_anti_affinity_preferred or pod_anti_affinity_required:
         weighted_pod_affinity_terms = None
         if pod_anti_affinity_preferred:
-            weighted_pod_affinity_terms = [get_k8s_model(
-                V1WeightedPodAffinityTerm, obj) for obj in pod_anti_affinity_preferred]
+            weighted_pod_affinity_terms = [
+                get_k8s_model(V1WeightedPodAffinityTerm, obj)
+                for obj in pod_anti_affinity_preferred
+            ]
 
         pod_affinity_terms = None
         if pod_anti_affinity_required:
-            pod_affinity_terms = [get_k8s_model(
-                V1PodAffinityTerm, obj) for obj in pod_anti_affinity_required]
+            pod_affinity_terms = [
+                get_k8s_model(V1PodAffinityTerm, obj)
+                for obj in pod_anti_affinity_required
+            ]
 
         pod_anti_affinity = V1PodAffinity(
             preferred_during_scheduling_ignored_during_execution=weighted_pod_affinity_terms,
@@ -519,7 +535,7 @@ def make_pod(
         )
 
     affinity = None
-    if (node_affinity or pod_affinity or pod_anti_affinity):
+    if node_affinity or pod_affinity or pod_anti_affinity:
         affinity = V1Affinity(
             node_affinity=node_affinity,
             pod_affinity=pod_affinity,
@@ -585,7 +601,8 @@ def make_pvc(
 
     if storage_class is not None:
         pvc.metadata.annotations.update(
-            {"volume.beta.kubernetes.io/storage-class": storage_class})
+            {"volume.beta.kubernetes.io/storage-class": storage_class}
+        )
         pvc.spec.storage_class_name = storage_class
 
     if selector:
@@ -594,13 +611,7 @@ def make_pvc(
     return pvc
 
 
-def make_ingress(
-        name,
-        routespec,
-        target,
-        labels,
-        data
-):
+def make_ingress(name, routespec, target, labels, data):
     """
     Returns an ingress, service, endpoint object that'll work for this service
     """
@@ -613,17 +624,21 @@ def make_ingress(
 
     try:
         from kubernetes.client.models import (
-            ExtensionsV1beta1Ingress, ExtensionsV1beta1IngressSpec, ExtensionsV1beta1IngressRule,
-            ExtensionsV1beta1HTTPIngressRuleValue, ExtensionsV1beta1HTTPIngressPath,
+            ExtensionsV1beta1Ingress,
+            ExtensionsV1beta1IngressSpec,
+            ExtensionsV1beta1IngressRule,
+            ExtensionsV1beta1HTTPIngressRuleValue,
+            ExtensionsV1beta1HTTPIngressPath,
             ExtensionsV1beta1IngressBackend,
         )
     except ImportError:
         from kubernetes.client.models import (
-            V1beta1Ingress as ExtensionsV1beta1Ingress, V1beta1IngressSpec as ExtensionsV1beta1IngressSpec,
+            V1beta1Ingress as ExtensionsV1beta1Ingress,
+            V1beta1IngressSpec as ExtensionsV1beta1IngressSpec,
             V1beta1IngressRule as ExtensionsV1beta1IngressRule,
             V1beta1HTTPIngressRuleValue as ExtensionsV1beta1HTTPIngressRuleValue,
             V1beta1HTTPIngressPath as ExtensionsV1beta1HTTPIngressPath,
-            V1beta1IngressBackend as ExtensionsV1beta1IngressBackend
+            V1beta1IngressBackend as ExtensionsV1beta1IngressBackend,
         )
 
     meta = V1ObjectMeta(
@@ -631,7 +646,7 @@ def make_ingress(
         annotations={
             'hub.jupyter.org/proxy-data': json.dumps(data),
             'hub.jupyter.org/proxy-routespec': routespec,
-            'hub.jupyter.org/proxy-target': target
+            'hub.jupyter.org/proxy-target': target,
         },
         labels=labels,
     )
@@ -647,8 +662,9 @@ def make_ingress(
     target_ip = target_parts.hostname
     target_port = target_parts.port
 
-    target_is_ip = re.match(
-        r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', target_ip) is not None
+    target_is_ip = (
+        re.match(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', target_ip) is not None
+    )
 
     # Make endpoint object
     if target_is_ip:
@@ -658,9 +674,9 @@ def make_ingress(
             subsets=[
                 V1EndpointSubset(
                     addresses=[V1EndpointAddress(ip=target_ip)],
-                    ports=[V1EndpointPort(port=target_port)]
+                    ports=[V1EndpointPort(port=target_port)],
                 )
-            ]
+            ],
         )
     else:
         endpoint = None
@@ -673,9 +689,8 @@ def make_ingress(
             spec=V1ServiceSpec(
                 type='ClusterIP',
                 external_name='',
-                ports=[V1ServicePort(
-                    port=target_port, target_port=target_port)]
-            )
+                ports=[V1ServicePort(port=target_port, target_port=target_port)],
+            ),
         )
     else:
         service = V1Service(
@@ -685,8 +700,7 @@ def make_ingress(
                 type='ExternalName',
                 external_name=target_ip,
                 cluster_ip='',
-                ports=[V1ServicePort(
-                    port=target_port, target_port=target_port)],
+                ports=[V1ServicePort(port=target_port, target_port=target_port)],
             ),
         )
 
@@ -695,21 +709,23 @@ def make_ingress(
         kind='Ingress',
         metadata=meta,
         spec=ExtensionsV1beta1IngressSpec(
-            rules=[ExtensionsV1beta1IngressRule(
-                host=host,
-                http=ExtensionsV1beta1HTTPIngressRuleValue(
-                    paths=[
-                        ExtensionsV1beta1HTTPIngressPath(
-                            path=path,
-                            backend=ExtensionsV1beta1IngressBackend(
-                                service_name=name,
-                                service_port=target_port
+            rules=[
+                ExtensionsV1beta1IngressRule(
+                    host=host,
+                    http=ExtensionsV1beta1HTTPIngressRuleValue(
+                        paths=[
+                            ExtensionsV1beta1HTTPIngressPath(
+                                path=path,
+                                backend=ExtensionsV1beta1IngressBackend(
+                                    service_name=name,
+                                    service_port=target_port,
+                                ),
                             )
-                        )
-                    ]
+                        ]
+                    ),
                 )
-            )]
-        )
+            ]
+        ),
     )
 
     return endpoint, service, ingress
@@ -845,9 +861,7 @@ def make_namespace(name, labels=None, annotations=None):
     """
 
     metadata = V1ObjectMeta(
-        name=name,
-        labels=(labels or {}).copy(),
-        annotations=(annotations or {}).copy()
+        name=name, labels=(labels or {}).copy(), annotations=(annotations or {}).copy()
     )
 
     return V1Namespace(metadata=metadata)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -4,7 +4,6 @@ JupyterHub Spawner to spawn user notebooks on a Kubernetes cluster.
 This module exports `KubeSpawner` class, which is the actual spawner
 implementation that should be used by JupyterHub.
 """
-
 import asyncio
 import json
 import multiprocessing
@@ -14,44 +13,42 @@ import sys
 import warnings
 from asyncio import sleep
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from functools import partial  # noqa
 
-from jinja2 import BaseLoader, Environment
-from tornado import gen, web
-from tornado.concurrent import run_on_executor
-from tornado.ioloop import IOLoop
-
 import escapism
-from async_generator import async_generator, yield_
+from async_generator import async_generator
+from async_generator import yield_
+from jinja2 import BaseLoader
+from jinja2 import Environment
 from jupyterhub.spawner import Spawner
 from jupyterhub.traitlets import Command
 from jupyterhub.utils import exponential_backoff
 from kubernetes import client
 from kubernetes.client.rest import ApiException
 from slugify import slugify
+from tornado import gen
+from tornado import web
+from tornado.concurrent import run_on_executor
+from tornado.ioloop import IOLoop
+from traitlets import Bool
+from traitlets import default
+from traitlets import Dict
+from traitlets import Integer
+from traitlets import List
+from traitlets import observe
+from traitlets import Unicode
+from traitlets import Union
+from traitlets import validate
 
 from .clients import shared_client
-from traitlets import (
-    Bool,
-    Dict,
-    Integer,
-    List,
-    Unicode,
-    Union,
-    default,
-    observe,
-    validate,
-)
-
-from .objects import (
-    make_owner_reference,
-    make_pod,
-    make_pvc,
-    make_secret,
-    make_service,
-    make_namespace,
-)
+from .objects import make_namespace
+from .objects import make_owner_reference
+from .objects import make_pod
+from .objects import make_pvc
+from .objects import make_secret
+from .objects import make_service
 from .reflector import ResourceReflector
 from .traitlets import Callable
 
@@ -63,6 +60,7 @@ class PodReflector(ResourceReflector):
     ResourceReflector keeps an updated list of the resource defined by
     the `kind` field and the `list_method_name` field.
     """
+
     kind = "pods"
 
     # The default component label can be over-ridden by specifying the component_label property
@@ -89,6 +87,7 @@ class EventReflector(ResourceReflector):
     the ResourceReflector keeps an updated list of the resource
     defined by the `kind` field and the `list_method_name` field.
     """
+
     kind = "events"
 
     @property
@@ -189,16 +188,17 @@ class KubeSpawner(Spawner):
         # compute other attributes
 
         if self.enable_user_namespaces:
-            self.namespace = self._expand_user_properties(
-                self.user_namespace_template)
+            self.namespace = self._expand_user_properties(self.user_namespace_template)
             self.log.info("Using user namespace: {}".format(self.namespace))
 
         if not _mock:
             # runs during normal execution only
 
             if self.__class__.executor is None:
-                self.log.debug('Starting executor thread pool with %d workers',
-                               self.k8s_api_threadpool_workers)
+                self.log.debug(
+                    'Starting executor thread pool with %d workers',
+                    self.k8s_api_threadpool_workers,
+                )
                 self.__class__.executor = ThreadPoolExecutor(
                     max_workers=self.k8s_api_threadpool_workers
                 )
@@ -216,8 +216,7 @@ class KubeSpawner(Spawner):
         self.dns_name = self.dns_name_template.format(
             namespace=self.namespace, name=self.pod_name
         )
-        self.secret_name = self._expand_user_properties(
-            self.secret_name_template)
+        self.secret_name = self._expand_user_properties(self.secret_name_template)
 
         self.pvc_name = self._expand_user_properties(self.pvc_name_template)
         if self.working_dir:
@@ -237,7 +236,7 @@ class KubeSpawner(Spawner):
         Increase this if you are dealing with a very large number of users.
 
         Defaults to `5 * cpu_cores`, which is the default for `ThreadPoolExecutor`.
-        """
+        """,
     )
 
     k8s_api_request_timeout = Integer(
@@ -251,7 +250,7 @@ class KubeSpawner(Spawner):
 
         NOTE: This is currently only implemented for creation and deletion of pods,
         and creation of PVCs.
-        """
+        """,
     )
 
     k8s_api_request_retry_timeout = Integer(
@@ -264,7 +263,7 @@ class KubeSpawner(Spawner):
         off exponentially. This lets you configure the total amount of time
         we will spend trying an API request - including retries - before
         giving up.
-        """
+        """,
     )
 
     events_enabled = Bool(
@@ -275,7 +274,7 @@ class KubeSpawner(Spawner):
 
         Disable if these events are not desirable
         or to save some performance cost.
-        """
+        """,
     )
 
     enable_user_namespaces = Bool(
@@ -350,7 +349,7 @@ class KubeSpawner(Spawner):
         The IP address (or hostname) the single-user server should listen on.
         We override this from the parent so we can set a more sane default for
         the Kubernetes setup.
-        """
+        """,
     )
 
     cmd = Command(
@@ -371,7 +370,7 @@ class KubeSpawner(Spawner):
         Most, including the default, do not. Consult the documentation for your spawner to verify!
 
         If set to `None`, Kubernetes will start the `CMD` that is specified in the Docker image being started.
-        """
+        """,
     )
 
     # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
@@ -384,7 +383,7 @@ class KubeSpawner(Spawner):
         Defaults to `None` so the working directory will be the one defined in the Dockerfile.
 
         `{username}` is expanded to the escaped, dns-label safe username.
-        """
+        """,
     )
 
     # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
@@ -411,7 +410,7 @@ class KubeSpawner(Spawner):
         config=True,
         help="""
         Template to use to form the dns name for the pod.
-        """
+        """,
     )
 
     pod_name_template = Unicode(
@@ -434,7 +433,7 @@ class KubeSpawner(Spawner):
             where it was implicitly added to the `servername` field before.
             Additionally, `username--servername` delimiter was `-` instead of `--`,
             allowing collisions in certain circumstances.
-        """
+        """,
     )
 
     pod_connect_ip = Unicode(
@@ -453,7 +452,7 @@ class KubeSpawner(Spawner):
         This must be unique within the namespace the pods are being spawned
         in, so if you are running multiple jupyterhubs spawning in the
         same namespace, consider setting this to be something more unique.
-        """
+        """,
     )
 
     storage_pvc_ensure = Bool(
@@ -464,7 +463,7 @@ class KubeSpawner(Spawner):
 
         Set to true to create a PVC named with `pvc_name_template` if it does
         not exist for the user when their pod is spawning.
-        """
+        """,
     )
 
     pvc_name_template = Unicode(
@@ -487,7 +486,7 @@ class KubeSpawner(Spawner):
             where it was implicitly added to the `servername` field before.
             Additionally, `username--servername` delimiter was `-` instead of `--`,
             allowing collisions in certain circumstances.
-        """
+        """,
     )
 
     component_label = Unicode(
@@ -520,28 +519,31 @@ class KubeSpawner(Spawner):
         config=True,
         help="""
         Location to mount the spawned pod's certificates needed for internal_ssl functionality.
-        """
+        """,
     )
 
     # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     hub_connect_ip = Unicode(
         allow_none=True,
         config=True,
-        help="""DEPRECATED. Use c.JupyterHub.hub_connect_ip"""
+        help="""DEPRECATED. Use c.JupyterHub.hub_connect_ip""",
     )
 
     hub_connect_port = Integer(
-        config=True,
-        help="""DEPRECATED. Use c.JupyterHub.hub_connect_url"""
+        config=True, help="""DEPRECATED. Use c.JupyterHub.hub_connect_url"""
     )
 
     @observe('hub_connect_ip', 'hub_connect_port')
     def _deprecated_changed(self, change):
-        warnings.warn("""
+        warnings.warn(
+            """
             KubeSpawner.{0} is deprecated with JupyterHub >= 0.8.
             Use JupyterHub.{0}
-            """.format(change.name),
-                      DeprecationWarning)
+            """.format(
+                change.name
+            ),
+            DeprecationWarning,
+        )
         setattr(self.hub, change.name.split('_', 1)[1], change.new)
 
     common_labels = Dict(
@@ -556,7 +558,7 @@ class KubeSpawner(Spawner):
 
         Note that these are only set when the Pods and PVCs are created, not
         later when this setting is updated.
-        """
+        """,
     )
 
     extra_labels = Dict(
@@ -572,7 +574,7 @@ class KubeSpawner(Spawner):
         for more info on what labels are and why you might want to use them!
 
         `{username}` is expanded to the escaped, dns-label safe username.
-        """
+        """,
     )
 
     extra_annotations = Dict(
@@ -587,7 +589,7 @@ class KubeSpawner(Spawner):
         for more info on what annotations are and why you might want to use them!
 
         `{username}` is expanded to the escaped, dns-label safe username.
-        """
+        """,
     )
 
     image = Unicode(
@@ -615,7 +617,7 @@ class KubeSpawner(Spawner):
 
            c.KubeSpawner.start_timeout = 60 * 5  # Up to 5 minutes
 
-        """
+        """,
     )
 
     image_pull_policy = Unicode(
@@ -634,7 +636,7 @@ class KubeSpawner(Spawner):
         This configuration is primarily used in development if you are
         actively changing the `image_spec` and would like to pull the image
         whenever a user container is spawned.
-        """
+        """,
     )
 
     image_pull_secrets = Union(
@@ -655,7 +657,7 @@ class KubeSpawner(Spawner):
         <https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod>`__
         for more information on when and why this might need to be set, and what
         it should be set to.
-        """
+        """,
     )
 
     @validate('image_pull_secrets')
@@ -683,7 +685,7 @@ class KubeSpawner(Spawner):
         For example to match the Nodes that have a label of `disktype: ssd` use::
 
            c.KubeSpawner.node_selector = {'disktype': 'ssd'}
-        """
+        """,
     )
 
     uid = Union(
@@ -709,7 +711,7 @@ class KubeSpawner(Spawner):
 
         If set to `None`, the user specified with the `USER` directive in the
         container metadata is used.
-        """
+        """,
     )
 
     gid = Union(
@@ -735,7 +737,7 @@ class KubeSpawner(Spawner):
 
         If set to `None`, the group of the user specified with the `USER` directive
         in the container metadata is used.
-        """
+        """,
     )
 
     fs_gid = Union(
@@ -771,7 +773,7 @@ class KubeSpawner(Spawner):
         You'll *have* to set this if you are using auto-provisioned volumes with most
         cloud providers. See `fsGroup <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core>`__
         for more details.
-        """
+        """,
     )
 
     supplemental_gids = Union(
@@ -797,7 +799,7 @@ class KubeSpawner(Spawner):
         the corresponding group ID of the user ID the image normally would run as. The
         image must setup all directories/files any application needs access to, as group
         writable.
-        """
+        """,
     )
 
     privileged = Bool(
@@ -805,7 +807,7 @@ class KubeSpawner(Spawner):
         config=True,
         help="""
         Whether to run the pod with a privileged security context.
-        """
+        """,
     )
 
     allow_privilege_escalation = Bool(
@@ -819,7 +821,7 @@ class KubeSpawner(Spawner):
 
         AllowPrivilegeEscalation is true always when the container is:
         1) run as Privileged OR 2) has CAP_SYS_ADMIN.
-        """
+        """,
     )
 
     modify_pod_hook = Callable(
@@ -841,7 +843,7 @@ class KubeSpawner(Spawner):
         This is very useful if you want to modify the pod being launched dynamically.
         Note that the spawner object can change between versions of KubeSpawner and JupyterHub,
         so be careful relying on this!
-        """
+        """,
     )
 
     volumes = List(
@@ -867,7 +869,7 @@ class KubeSpawner(Spawner):
         Your kubernetes cluster must already be configured to support the volume types you want to use.
 
         `{username}` is expanded to the escaped, dns-label safe username.
-        """
+        """,
     )
 
     volume_mounts = List(
@@ -886,7 +888,7 @@ class KubeSpawner(Spawner):
         for more information on how the `volumeMount` item works.
 
         `{username}` is expanded to the escaped, dns-label safe username.
-        """
+        """,
     )
 
     # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
@@ -910,7 +912,7 @@ class KubeSpawner(Spawner):
         integers with one of these SI suffices (`E, P, T, G, M, K, m`) or their power-of-two
         equivalents (`Ei, Pi, Ti, Gi, Mi, Ki`). For example, the following represent roughly
         the same value: `128974848`, `129e6`, `129M`, `123Mi`.
-        """
+        """,
     )
 
     storage_extra_labels = Dict(
@@ -926,7 +928,7 @@ class KubeSpawner(Spawner):
         for more info on what labels are and why you might want to use them!
 
         `{username}` is expanded to the escaped, dns-label safe username.
-        """
+        """,
     )
 
     # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
@@ -951,7 +953,7 @@ class KubeSpawner(Spawner):
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/storage/storage-classes/>`__
         for more information on how StorageClasses work.
 
-        """
+        """,
     )
 
     storage_access_modes = List(
@@ -968,7 +970,7 @@ class KubeSpawner(Spawner):
 
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`__
         for more information on how access modes work.
-        """
+        """,
     )
 
     storage_selector = Dict(
@@ -984,7 +986,7 @@ class KubeSpawner(Spawner):
            c.KubeSpawner.storage_selector = {'matchLabels':{'content': 'jupyter'}}
 
         `{username}` is expanded to the escaped, dns-label safe username.
-        """
+        """,
     )
 
     lifecycle_hooks = Dict(
@@ -1014,7 +1016,7 @@ class KubeSpawner(Spawner):
 
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/>`__
         for more info on what lifecycle hooks are and why you might want to use them!
-        """
+        """,
     )
 
     init_containers = List(
@@ -1045,7 +1047,7 @@ class KubeSpawner(Spawner):
         for more info on what init containers are and why you might want to use them!
 
         To user this feature, Kubernetes version must greater than 1.6.
-        """
+        """,
     )
 
     extra_container_config = Dict(
@@ -1071,7 +1073,7 @@ class KubeSpawner(Spawner):
         The key could be either a camelCase word (used by Kubernetes yaml, e.g.
         ``envFrom``) or a snake_case word (used by Kubernetes Python client,
         e.g. ``env_from``).
-        """
+        """,
     )
 
     extra_pod_config = Dict(
@@ -1094,7 +1096,7 @@ class KubeSpawner(Spawner):
         The `key` could be either a camelCase word (used by Kubernetes yaml,
         e.g. `restartPolicy`) or a snake_case word (used by Kubernetes Python
         client, e.g. `dns_policy`).
-        """
+        """,
     )
 
     extra_containers = List(
@@ -1116,7 +1118,7 @@ class KubeSpawner(Spawner):
             }]
 
         `{username}` is expanded to the escaped, dns-label safe username.
-        """
+        """,
     )
 
     # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
@@ -1127,7 +1129,7 @@ class KubeSpawner(Spawner):
         help="""
         Set the pod's scheduler explicitly by name. See `the Kubernetes documentation <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core>`__
         for more information.
-        """
+        """,
     )
 
     tolerations = List(
@@ -1156,7 +1158,7 @@ class KubeSpawner(Spawner):
                 }
             ]
 
-        """
+        """,
     )
 
     node_affinity_preferred = List(
@@ -1170,7 +1172,7 @@ class KubeSpawner(Spawner):
         Pass this field an array of "PreferredSchedulingTerm" objects.*
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#preferredschedulingterm-v1-core
 
-        """
+        """,
     )
     node_affinity_required = List(
         config=True,
@@ -1183,7 +1185,7 @@ class KubeSpawner(Spawner):
         Pass this field an array of "NodeSelectorTerm" objects.*
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#nodeselectorterm-v1-core
 
-        """
+        """,
     )
     pod_affinity_preferred = List(
         config=True,
@@ -1196,7 +1198,7 @@ class KubeSpawner(Spawner):
         Pass this field an array of "WeightedPodAffinityTerm" objects.*
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#weightedpodaffinityterm-v1-core
 
-        """
+        """,
     )
     pod_affinity_required = List(
         config=True,
@@ -1209,7 +1211,7 @@ class KubeSpawner(Spawner):
         Pass this field an array of "PodAffinityTerm" objects.*
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podaffinityterm-v1-core
 
-        """
+        """,
     )
     pod_anti_affinity_preferred = List(
         config=True,
@@ -1221,7 +1223,7 @@ class KubeSpawner(Spawner):
 
         Pass this field an array of "WeightedPodAffinityTerm" objects.*
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#weightedpodaffinityterm-v1-core
-        """
+        """,
     )
     pod_anti_affinity_required = List(
         config=True,
@@ -1233,7 +1235,7 @@ class KubeSpawner(Spawner):
 
         Pass this field an array of "PodAffinityTerm" objects.*
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podaffinityterm-v1-core
-        """
+        """,
     )
 
     extra_resource_guarantees = Dict(
@@ -1244,7 +1246,7 @@ class KubeSpawner(Spawner):
         For example, to request 1 Nvidia GPUs::
 
             c.KubeSpawner.extra_resource_guarantees = {"nvidia.com/gpu": "1"}
-        """
+        """,
     )
 
     extra_resource_limits = Dict(
@@ -1255,7 +1257,7 @@ class KubeSpawner(Spawner):
         For example, to add a limit of 3 Nvidia GPUs::
 
             c.KubeSpawner.extra_resource_limits = {"nvidia.com/gpu": "3"}
-        """
+        """,
     )
 
     delete_stopped_pods = Bool(
@@ -1265,7 +1267,7 @@ class KubeSpawner(Spawner):
         Whether to delete pods that have stopped themselves.
         Set to False to leave stopped pods in the completed state,
         allowing for easier debugging of why they may have stopped.
-        """
+        """,
     )
 
     profile_form_template = Unicode(
@@ -1303,14 +1305,11 @@ class KubeSpawner(Spawner):
         This should be used to construct the contents of a HTML form. When
         posted, this form is expected to have an item with name `profile` and
         the value the index of the profile in `profile_list`.
-        """
+        """,
     )
 
     profile_list = Union(
-        trait_types=[
-            List(trait=Dict()),
-            Callable()
-        ],
+        trait_types=[List(trait=Dict()), Callable()],
         config=True,
         help="""
         List of profiles to offer for selection by the user.
@@ -1380,7 +1379,7 @@ class KubeSpawner(Spawner):
         a list. Note that the interface of the spawner class is not deemed stable
         across versions, so using this functionality might cause your JupyterHub
         or kubespawner upgrades to break.
-        """
+        """,
     )
 
     priority_class_name = Unicode(
@@ -1390,7 +1389,7 @@ class KubeSpawner(Spawner):
 
         See https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption for
         more information on how pod priority works.
-        """
+        """,
     )
 
     delete_grace_period = Integer(
@@ -1405,7 +1404,7 @@ class KubeSpawner(Spawner):
         more information on how pod termination works.
 
         Defaults to `1`.
-        """
+        """,
     )
 
     # deprecate redundant and inconsistent singleuser_ and user_ prefixes:
@@ -1422,8 +1421,7 @@ class KubeSpawner(Spawner):
         "singleuser_fs_gid",
         "singleuser_supplemental_gids",
         "singleuser_privileged",
-        "singleuser_allow_privilege_escalation"
-        "singleuser_lifecycle_hooks",
+        "singleuser_allow_privilege_escalation" "singleuser_lifecycle_hooks",
         "singleuser_extra_pod_config",
         "singleuser_init_containers",
         "singleuser_extra_container_config",
@@ -1533,16 +1531,19 @@ class KubeSpawner(Spawner):
 
         raw_servername = self.name or ''
         safe_servername = escapism.escape(
-            raw_servername, safe=safe_chars, escape_char='-').lower()
+            raw_servername, safe=safe_chars, escape_char='-'
+        ).lower()
 
         hub_namespace = self._namespace_default()
         if hub_namespace == "default":
             hub_namespace = "user"
 
         legacy_escaped_username = ''.join(
-            [s if s in safe_chars else '-' for s in self.user.name.lower()])
+            [s if s in safe_chars else '-' for s in self.user.name.lower()]
+        )
         safe_username = escapism.escape(
-            self.user.name, safe=safe_chars, escape_char='-').lower()
+            self.user.name, safe=safe_chars, escape_char='-'
+        ).lower()
         rendered = template.format(
             userid=self.user.id,
             username=safe_username,
@@ -1590,9 +1591,7 @@ class KubeSpawner(Spawner):
 
     def _build_common_annotations(self, extra_annotations):
         # Annotations don't need to be escaped
-        annotations = {
-            'hub.jupyter.org/username': self.user.name
-        }
+        annotations = {'hub.jupyter.org/username': self.user.name}
         if self.name:
             annotations['hub.jupyter.org/servername'] = self.name
 
@@ -1688,7 +1687,8 @@ class KubeSpawner(Spawner):
 
         labels = self._build_pod_labels(self._expand_all(self.extra_labels))
         annotations = self._build_common_annotations(
-            self._expand_all(self.extra_annotations))
+            self._expand_all(self.extra_annotations)
+        )
 
         return make_pod(
             name=self.pod_name,
@@ -1780,11 +1780,8 @@ class KubeSpawner(Spawner):
         """
         Make a pvc manifest that will spawn current user's pvc.
         """
-        labels = self._build_common_labels(
-            self._expand_all(self.storage_extra_labels))
-        labels.update({
-            'component': 'singleuser-storage'
-        })
+        labels = self._build_common_labels(self._expand_all(self.storage_extra_labels))
+        labels.update({'component': 'singleuser-storage'})
 
         annotations = self._build_common_annotations({})
 
@@ -1797,7 +1794,7 @@ class KubeSpawner(Spawner):
             selector=storage_selector,
             storage=self.storage_capacity,
             labels=labels,
-            annotations=annotations
+            annotations=annotations,
         )
 
     def is_pod_running(self, pod):
@@ -1808,11 +1805,11 @@ class KubeSpawner(Spawner):
         """
         # FIXME: Validate if this is really the best way
         is_running = (
-            pod is not None and
-            pod["status"]["phase"] == 'Running' and
-            pod["status"]["podIP"] is not None and
-            "deletionTimestamp" not in pod["metadata"] and
-            all([cs["ready"] for cs in pod["status"]["containerStatuses"]])
+            pod is not None
+            and pod["status"]["phase"] == 'Running'
+            and pod["status"]["podIP"] is not None
+            and "deletionTimestamp" not in pod["metadata"]
+            and all([cs["ready"] for cs in pod["status"]["containerStatuses"]])
         )
         return is_running
 
@@ -1824,8 +1821,7 @@ class KubeSpawner(Spawner):
         """
 
         return bool(
-            pod and pod.get("metadata") and pod["metadata"].get(
-                "uid") is not None
+            pod and pod.get("metadata") and pod["metadata"].get("uid") is not None
         )
 
     def get_state(self):
@@ -1977,11 +1973,12 @@ class KubeSpawner(Spawner):
                     yield {
                         'progress': int(progress),
                         'raw_event': event,
-                        'message':  "%s [%s] %s" % (
+                        'message': "%s [%s] %s"
+                        % (
                             event["lastTimestamp"] or event["eventTime"],
                             event["type"],
                             event["message"],
-                        )
+                        ),
                     }
                 next_event = len_events
 
@@ -2095,13 +2092,17 @@ class KubeSpawner(Spawner):
         """
         try:
             self.log.info(
-                f"Attempting to create pod {pod.metadata.name}, with timeout {request_timeout}")
+                f"Attempting to create pod {pod.metadata.name}, with timeout {request_timeout}"
+            )
             # Use tornado's timeout, _request_timeout seems unreliable?
-            await gen.with_timeout(timedelta(seconds=request_timeout), self.asynchronize(
-                self.api.create_namespaced_pod,
-                self.namespace,
-                pod,
-            ))
+            await gen.with_timeout(
+                timedelta(seconds=request_timeout),
+                self.asynchronize(
+                    self.api.create_namespaced_pod,
+                    self.namespace,
+                    pod,
+                ),
+            )
             return True
         except gen.TimeoutError:
             # Just try again
@@ -2117,7 +2118,8 @@ class KubeSpawner(Spawner):
             await self.stop(True)
 
             self.log.info(
-                f'Killed pod {pod_name}, will try starting singleuser pod again')
+                f'Killed pod {pod_name}, will try starting singleuser pod again'
+            )
             # We tell exponential_backoff to retry
             return False
 
@@ -2132,20 +2134,25 @@ class KubeSpawner(Spawner):
         pvc_name = pvc.metadata.name
         try:
             self.log.info(
-                f"Attempting to create pvc {pvc.metadata.name}, with timeout {request_timeout}")
-            await gen.with_timeout(timedelta(seconds=request_timeout), self.asynchronize(
-                self.api.create_namespaced_persistent_volume_claim,
-                namespace=self.namespace,
-                body=pvc
-            ))
+                f"Attempting to create pvc {pvc.metadata.name}, with timeout {request_timeout}"
+            )
+            await gen.with_timeout(
+                timedelta(seconds=request_timeout),
+                self.asynchronize(
+                    self.api.create_namespaced_persistent_volume_claim,
+                    namespace=self.namespace,
+                    body=pvc,
+                ),
+            )
             return True
         except gen.TimeoutError:
             # Just try again
             return False
         except ApiException as e:
             if e.status == 409:
-                self.log.info("PVC " + pvc_name +
-                              " already exists, so did not create new pvc.")
+                self.log.info(
+                    "PVC " + pvc_name + " already exists, so did not create new pvc."
+                )
                 return True
             elif e.status == 403:
                 t, v, tb = sys.exc_info()
@@ -2154,13 +2161,17 @@ class KubeSpawner(Spawner):
                     await self.asynchronize(
                         self.api.read_namespaced_persistent_volume_claim,
                         name=pvc_name,
-                        namespace=self.namespace)
+                        namespace=self.namespace,
+                    )
 
                 except ApiException as e:
                     raise v.with_traceback(tb)
 
                 self.log.info(
-                    "PVC " + self.pvc_name + " already exists, possibly have reached quota though.")
+                    "PVC "
+                    + self.pvc_name
+                    + " already exists, possibly have reached quota though."
+                )
                 return True
             else:
                 raise
@@ -2269,11 +2280,12 @@ class KubeSpawner(Spawner):
 
             # If there's a timeout, just let it propagate
             await exponential_backoff(
-                partial(self._make_create_pvc_request,
-                        pvc, self.k8s_api_request_timeout),
+                partial(
+                    self._make_create_pvc_request, pvc, self.k8s_api_request_timeout
+                ),
                 f'Could not create pod {self.pvc_name}',
                 # Each req should be given k8s_api_request_timeout seconds.
-                timeout=self.k8s_api_request_retry_timeout
+                timeout=self.k8s_api_request_retry_timeout,
             )
 
         # If we run into a 409 Conflict error, it means a pod with the
@@ -2286,10 +2298,9 @@ class KubeSpawner(Spawner):
         ref_key = "{}/{}".format(self.namespace, self.pod_name)
         # If there's a timeout, just let it propagate
         await exponential_backoff(
-            partial(self._make_create_pod_request,
-                    pod, self.k8s_api_request_timeout),
+            partial(self._make_create_pod_request, pod, self.k8s_api_request_timeout),
             f'Could not create pod {ref_key}',
-            timeout=self.k8s_api_request_retry_timeout
+            timeout=self.k8s_api_request_retry_timeout,
         )
 
         if self.internal_ssl:
@@ -2317,15 +2328,18 @@ class KubeSpawner(Spawner):
                     f"Failed to delete secret {secret_manifest.metadata.name}",
                 )
                 await exponential_backoff(
-                    partial(self._make_create_resource_request,
-                            "secret", secret_manifest),
+                    partial(
+                        self._make_create_resource_request, "secret", secret_manifest
+                    ),
                     f"Failed to create secret {secret_manifest.metadata.name}",
                 )
 
                 service_manifest = self.get_service_manifest(owner_reference)
                 await exponential_backoff(
                     partial(
-                        self._ensure_not_exists, "service", service_manifest.metadata.name
+                        self._ensure_not_exists,
+                        "service",
+                        service_manifest.metadata.name,
                     ),
                     f"Failed to delete service {service_manifest.metadata.name}",
                 )
@@ -2348,10 +2362,8 @@ class KubeSpawner(Spawner):
         # start_timeout, starting from a slightly earlier point.
         try:
             await exponential_backoff(
-                lambda: self.is_pod_running(
-                    self.pod_reflector.pods.get(ref_key, None)),
-                'pod %s did not start in %s seconds!' % (
-                    ref_key, self.start_timeout),
+                lambda: self.is_pod_running(self.pod_reflector.pods.get(ref_key, None)),
+                'pod %s did not start in %s seconds!' % (ref_key, self.start_timeout),
                 timeout=self.start_timeout,
             )
         except TimeoutError:
@@ -2374,8 +2386,12 @@ class KubeSpawner(Spawner):
                 ref_key,
                 "\n".join(
                     [
-                        "%s [%s] %s" % (
-                            event["lastTimestamp"] or event["eventTime"], event["type"], event["message"])
+                        "%s [%s] %s"
+                        % (
+                            event["lastTimestamp"] or event["eventTime"],
+                            event["type"],
+                            event["message"],
+                        )
                         for event in self.events
                     ]
                 ),
@@ -2383,7 +2399,9 @@ class KubeSpawner(Spawner):
 
         return self._get_pod_url(pod)
 
-    async def _make_delete_pod_request(self, pod_name, delete_options, grace_seconds, request_timeout):
+    async def _make_delete_pod_request(
+        self, pod_name, delete_options, grace_seconds, request_timeout
+    ):
         """
         Make an HTTP request to delete the given pod
 
@@ -2393,13 +2411,16 @@ class KubeSpawner(Spawner):
         ref_key = "{}/{}".format(self.namespace, pod_name)
         self.log.info("Deleting pod %s", ref_key)
         try:
-            await gen.with_timeout(timedelta(seconds=request_timeout), self.asynchronize(
-                self.api.delete_namespaced_pod,
-                name=pod_name,
-                namespace=self.namespace,
-                body=delete_options,
-                grace_period_seconds=grace_seconds,
-            ))
+            await gen.with_timeout(
+                timedelta(seconds=request_timeout),
+                self.asynchronize(
+                    self.api.delete_namespaced_pod,
+                    name=pod_name,
+                    namespace=self.namespace,
+                    body=delete_options,
+                    grace_period_seconds=grace_seconds,
+                ),
+            )
             return True
         except gen.TimeoutError:
             return False
@@ -2426,23 +2447,28 @@ class KubeSpawner(Spawner):
 
         ref_key = "{}/{}".format(self.namespace, self.pod_name)
         await exponential_backoff(
-            partial(self._make_delete_pod_request, self.pod_name,
-                    delete_options, grace_seconds, self.k8s_api_request_timeout),
+            partial(
+                self._make_delete_pod_request,
+                self.pod_name,
+                delete_options,
+                grace_seconds,
+                self.k8s_api_request_timeout,
+            ),
             f'Could not delete pod {ref_key}',
-            timeout=self.k8s_api_request_retry_timeout
+            timeout=self.k8s_api_request_retry_timeout,
         )
 
         try:
             await exponential_backoff(
-                lambda: self.pod_reflector.pods.get(
-                    ref_key, None) is None,
-                'pod %s did not disappear in %s seconds!' % (
-                    ref_key, self.start_timeout),
+                lambda: self.pod_reflector.pods.get(ref_key, None) is None,
+                'pod %s did not disappear in %s seconds!'
+                % (ref_key, self.start_timeout),
                 timeout=self.start_timeout,
             )
         except TimeoutError:
             self.log.error(
-                "Pod %s did not disappear, restarting pod reflector", ref_key)
+                "Pod %s did not disappear, restarting pod reflector", ref_key
+            )
             self._start_watching_pods(replace=True)
             raise
 
@@ -2454,8 +2480,9 @@ class KubeSpawner(Spawner):
 
     def _render_options_form(self, profile_list):
         self._profile_list = self._init_profile_list(profile_list)
-        profile_form_template = Environment(
-            loader=BaseLoader).from_string(self.profile_form_template)
+        profile_form_template = Environment(loader=BaseLoader).from_string(
+            self.profile_form_template
+        )
         return profile_form_template.render(profile_list=self._profile_list)
 
     async def _render_options_form_dynamically(self, current_spawner):
@@ -2465,13 +2492,13 @@ class KubeSpawner(Spawner):
 
     @default('options_form')
     def _options_form_default(self):
-        '''
+        """
         Build the form template according to the `profile_list` setting.
 
         Returns:
             '' when no `profile_list` has been defined
             The rendered template (using jinja2) when `profile_list` is defined.
-        '''
+        """
         if not self.profile_list:
             return ''
         if callable(self.profile_list):
@@ -2503,9 +2530,7 @@ class KubeSpawner(Spawner):
             user_options (dict): the selected profile in the user_options form,
                 e.g. ``{"profile": "cpus-8"}``
         """
-        return {
-            'profile': formdata.get('profile', [None])[0]
-        }
+        return {'profile': formdata.get('profile', [None])[0]}
 
     async def _load_profile(self, slug):
         """Load a profile by name
@@ -2525,28 +2550,33 @@ class KubeSpawner(Spawner):
         else:
             if slug:
                 # name specified, but not found
-                raise ValueError("No such profile: %s. Options include: %s" % (
-                    slug, ', '.join(p['slug'] for p in self._profile_list)
-                ))
+                raise ValueError(
+                    "No such profile: %s. Options include: %s"
+                    % (slug, ', '.join(p['slug'] for p in self._profile_list))
+                )
             else:
                 # no name specified, use the default
                 profile = default_profile
 
         self.log.debug(
-            "Applying KubeSpawner override for profile '%s'", profile['display_name'])
+            "Applying KubeSpawner override for profile '%s'", profile['display_name']
+        )
         kubespawner_override = profile.get('kubespawner_override', {})
         for k, v in kubespawner_override.items():
             if callable(v):
                 v = v(self)
                 self.log.debug(
-                    ".. overriding KubeSpawner value %s=%s (callable result)", k, v)
+                    ".. overriding KubeSpawner value %s=%s (callable result)", k, v
+                )
             else:
                 self.log.debug(".. overriding KubeSpawner value %s=%s", k, v)
             setattr(self, k, v)
 
     # set of recognised user option keys
     # used for warning about ignoring unrecognised options
-    _user_option_keys = {'profile', }
+    _user_option_keys = {
+        'profile',
+    }
 
     def _init_profile_list(self, profile_list):
         # generate missing slug fields from display_name
@@ -2578,7 +2608,8 @@ class KubeSpawner(Spawner):
             await self._load_profile(selected_profile)
         elif selected_profile:
             self.log.warning(
-                "Profile %r requested, but profiles are not enabled", selected_profile)
+                "Profile %r requested, but profiles are not enabled", selected_profile
+            )
 
         # help debugging by logging any option fields that are not recognized
         option_keys = set(self.user_options)
@@ -2586,12 +2617,7 @@ class KubeSpawner(Spawner):
         if unrecognized_keys:
             self.log.warning(
                 "Ignoring unrecognized KubeSpawner user_options: %s",
-                ", ".join(
-                    map(
-                        str,
-                        sorted(unrecognized_keys)
-                    )
-                )
+                ", ".join(map(str, sorted(unrecognized_keys))),
             )
 
     async def _ensure_namespace(self):
@@ -2605,6 +2631,5 @@ class KubeSpawner(Spawner):
         except ApiException as e:
             if e.status != 409:
                 # It's fine if it already exists
-                self.log.exception("Failed to create namespace %s",
-                                   self.namespace)
+                self.log.exception("Failed to create namespace %s", self.namespace)
                 raise

--- a/kubespawner/utils.py
+++ b/kubespawner/utils.py
@@ -1,8 +1,9 @@
 """
 Misc. general utility functions, not tied to Kubespawner directly
 """
-import hashlib
 import copy
+import hashlib
+
 
 def generate_hashed_slug(slug, limit=63, hash_length=6):
     """
@@ -24,7 +25,7 @@ def generate_hashed_slug(slug, limit=63, hash_length=6):
     slug_hash = hashlib.sha256(slug.encode('utf-8')).hexdigest()
 
     return '{prefix}-{hash}'.format(
-        prefix=slug[:limit - hash_length - 1],
+        prefix=slug[: limit - hash_length - 1],
         hash=slug_hash[:hash_length],
     ).lower()
 
@@ -41,15 +42,26 @@ def update_k8s_model(target, changes, logger=None, target_name=None, changes_nam
     """
     model_type = type(target)
     if not hasattr(target, 'attribute_map'):
-        raise AttributeError("Attribute 'target' ({}) must be an object (such as 'V1PodSpec') with an attribute 'attribute_map'.".format(model_type.__name__))
+        raise AttributeError(
+            "Attribute 'target' ({}) must be an object (such as 'V1PodSpec') with an attribute 'attribute_map'.".format(
+                model_type.__name__
+            )
+        )
     if not isinstance(changes, model_type) and not isinstance(changes, dict):
-        raise AttributeError("Attribute 'changes' ({}) must be an object of the same type as 'target' ({}) or a 'dict'.".format(type(changes).__name__, model_type.__name__))
+        raise AttributeError(
+            "Attribute 'changes' ({}) must be an object of the same type as 'target' ({}) or a 'dict'.".format(
+                type(changes).__name__, model_type.__name__
+            )
+        )
 
     changes_dict = _get_k8s_model_dict(model_type, changes)
     for key, value in changes_dict.items():
         if key not in target.attribute_map:
-            raise ValueError("The attribute 'changes' ({}) contained '{}' not modeled by '{}'.".format(type(changes).__name__, key, model_type.__name__))
-        
+            raise ValueError(
+                "The attribute 'changes' ({}) contained '{}' not modeled by '{}'.".format(
+                    type(changes).__name__, key, model_type.__name__
+                )
+            )
 
         # If changes are passed as a dict, they will only have a few keys/value
         # pairs representing the specific changes. If the changes parameter is a
@@ -60,17 +72,13 @@ def update_k8s_model(target, changes, logger=None, target_name=None, changes_nam
             if getattr(target, key):
                 if logger and changes_name:
                     warning = "'{}.{}' current value: '{}' is overridden with '{}', which is the value of '{}.{}'.".format(
-                        target_name,
-                        key,
-                        getattr(target, key),
-                        value,
-                        changes_name,
-                        key
+                        target_name, key, getattr(target, key), value, changes_name, key
                     )
                     logger.warning(warning)
             setattr(target, key, value)
 
     return target
+
 
 def get_k8s_model(model_type, model_dict):
     """
@@ -87,7 +95,12 @@ def get_k8s_model(model_type, model_dict):
         # use the dictionary keys to initialize a model of given type
         return model_type(**model_dict)
     else:
-        raise AttributeError("Expected object of type 'dict' (or '{}') but got '{}'.".format(model_type.__name__, type(model_dict).__name__))
+        raise AttributeError(
+            "Expected object of type 'dict' (or '{}') but got '{}'.".format(
+                model_type.__name__, type(model_dict).__name__
+            )
+        )
+
 
 def _get_k8s_model_dict(model_type, model):
     """
@@ -100,7 +113,12 @@ def _get_k8s_model_dict(model_type, model):
     elif isinstance(model, dict):
         return _map_dict_keys_to_model_attributes(model_type, model)
     else:
-        raise AttributeError("Expected object of type '{}' (or 'dict') but got '{}'.".format(model_type.__name__, type(model).__name__))
+        raise AttributeError(
+            "Expected object of type '{}' (or 'dict') but got '{}'.".format(
+                model_type.__name__, type(model).__name__
+            )
+        )
+
 
 def _map_dict_keys_to_model_attributes(model_type, model_dict):
     """
@@ -114,6 +132,7 @@ def _map_dict_keys_to_model_attributes(model_type, model_dict):
         new_dict[_get_k8s_model_attribute(model_type, key)] = value
 
     return new_dict
+
 
 def _get_k8s_model_attribute(model_type, field_name):
     """
@@ -162,4 +181,8 @@ def _get_k8s_model_attribute(model_type, field_name):
         if value == field_name:
             return key
     else:
-        raise ValueError("'{}' did not have an attribute matching '{}'".format(model_type.__name__, field_name))
+        raise ValueError(
+            "'{}' did not have an attribute matching '{}'".format(
+                model_type.__name__, field_name
+            )
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+skip-string-normalization = true
+target_version = [
+    "py36",
+    "py37",
+    "py38",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
-from setuptools import setup, find_packages
+
 import sys
+
+from setuptools import find_packages
+from setuptools import setup
 
 v = sys.version_info
 if v[:2] < (3, 6):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """pytest fixtures for kubespawner"""
-
 import base64
 import inspect
 import io
@@ -14,24 +13,22 @@ from threading import Thread
 
 import kubernetes
 import pytest
-from kubernetes.client import (
-    V1ConfigMap,
-    V1Namespace,
-    V1Pod,
-    V1PodSpec,
-    V1Secret,
-    V1Service,
-    V1ServicePort,
-    V1ServiceSpec,
-)
-from kubernetes.config import load_kube_config
+from jupyterhub.app import JupyterHub
+from jupyterhub.objects import Hub
+from kubernetes.client import V1ConfigMap
+from kubernetes.client import V1Namespace
+from kubernetes.client import V1Pod
+from kubernetes.client import V1PodSpec
+from kubernetes.client import V1Secret
+from kubernetes.client import V1Service
+from kubernetes.client import V1ServicePort
+from kubernetes.client import V1ServiceSpec
 from kubernetes.client.rest import ApiException
+from kubernetes.config import load_kube_config
 from kubernetes.stream import stream
 from kubernetes.watch import Watch
 from traitlets.config import Config
 
-from jupyterhub.app import JupyterHub
-from jupyterhub.objects import Hub
 from kubespawner.clients import shared_client
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_multi_namespace_spawner.py
+++ b/tests/test_multi_namespace_spawner.py
@@ -1,21 +1,22 @@
-from asyncio import get_event_loop
-from jupyterhub.objects import Hub, Server
-from jupyterhub.orm import Spawner
-from kubernetes.client.models import (
-    V1SecurityContext, V1Container, V1Capabilities, V1Pod
-)
-from kubespawner import KubeSpawner
-from kubernetes.client import V1Namespace
-from kubernetes.config import load_kube_config
-import pytest
-
-from kubespawner.clients import shared_client
-
-from traitlets.config import Config
-
-from unittest.mock import Mock
 import json
 import os
+from asyncio import get_event_loop
+from unittest.mock import Mock
+
+import pytest
+from jupyterhub.objects import Hub
+from jupyterhub.objects import Server
+from jupyterhub.orm import Spawner
+from kubernetes.client import V1Namespace
+from kubernetes.client.models import V1Capabilities
+from kubernetes.client.models import V1Container
+from kubernetes.client.models import V1Pod
+from kubernetes.client.models import V1SecurityContext
+from kubernetes.config import load_kube_config
+from traitlets.config import Config
+
+from kubespawner import KubeSpawner
+from kubespawner.clients import shared_client
 
 
 class MockUser(Mock):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,11 +1,12 @@
 """
 Test functions used to create k8s objects
 """
-from kubespawner.objects import (make_pod,
-                                 make_pvc,
-                                 make_ingress,
-                                 make_namespace)
 from kubernetes.client import ApiClient
+
+from kubespawner.objects import make_ingress
+from kubespawner.objects import make_namespace
+from kubespawner.objects import make_pod
+from kubespawner.objects import make_pvc
 
 api_client = ApiClient()
 
@@ -14,18 +15,16 @@ def test_make_simplest_pod():
     """
     Test specification of the simplest possible pod specification
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent'
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             'automountServiceAccountToken': False,
             "containers": [
@@ -35,22 +34,16 @@ def test_make_simplest_pod():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -58,19 +51,17 @@ def test_make_labeled_pod():
     """
     Test specification of the simplest possible pod specification with labels
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        labels={"test": "true"}
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {"test": "true"},
-            "annotations": {}
-        },
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            labels={"test": "true"},
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {"test": "true"}, "annotations": {}},
         "spec": {
             'automountServiceAccountToken': False,
             "containers": [
@@ -80,22 +71,16 @@ def test_make_labeled_pod():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -103,14 +88,16 @@ def test_make_annotated_pod():
     """
     Test specification of the simplest possible pod specification with annotations
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        annotations={"test": "true"}
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            annotations={"test": "true"},
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {"test": "true"},
@@ -125,22 +112,16 @@ def test_make_annotated_pod():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -148,14 +129,16 @@ def test_make_pod_with_image_pull_secrets_simplified_format():
     """
     Test specification of the simplest possible pod specification
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        image_pull_secrets=["k8s-secret-a", "k8s-secret-b"],
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            image_pull_secrets=["k8s-secret-a", "k8s-secret-b"],
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -163,10 +146,7 @@ def test_make_pod_with_image_pull_secrets_simplified_format():
         },
         "spec": {
             'automountServiceAccountToken': False,
-            "imagePullSecrets": [
-                {"name": "k8s-secret-a"},
-                {"name": "k8s-secret-b"}
-            ],
+            "imagePullSecrets": [{"name": "k8s-secret-a"}, {"name": "k8s-secret-b"}],
             "containers": [
                 {
                     "env": [],
@@ -174,22 +154,16 @@ def test_make_pod_with_image_pull_secrets_simplified_format():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -197,15 +171,16 @@ def test_make_pod_with_image_pull_secrets_k8s_native_format():
     """
     Test specification of the simplest possible pod specification
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        image_pull_secrets=[{"name": "k8s-secret-a"},
-                            {"name": "k8s-secret-b"}],
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            image_pull_secrets=[{"name": "k8s-secret-a"}, {"name": "k8s-secret-b"}],
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -213,10 +188,7 @@ def test_make_pod_with_image_pull_secrets_k8s_native_format():
         },
         "spec": {
             'automountServiceAccountToken': False,
-            "imagePullSecrets": [
-                {"name": "k8s-secret-a"},
-                {"name": "k8s-secret-b"}
-            ],
+            "imagePullSecrets": [{"name": "k8s-secret-a"}, {"name": "k8s-secret-b"}],
             "containers": [
                 {
                     "env": [],
@@ -224,22 +196,16 @@ def test_make_pod_with_image_pull_secrets_k8s_native_format():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -247,15 +213,17 @@ def test_set_container_uid_and_gid():
     """
     Test specification of the simplest possible pod specification
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        run_as_uid=0,
-        run_as_gid=0,
-        image_pull_policy='IfNotPresent'
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            run_as_uid=0,
+            run_as_gid=0,
+            image_pull_policy='IfNotPresent',
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -265,31 +233,22 @@ def test_set_container_uid_and_gid():
             'automountServiceAccountToken': False,
             "containers": [
                 {
-                    "securityContext": {
-                        "runAsUser": 0,
-                        "runAsGroup": 0
-                    },
+                    "securityContext": {"runAsUser": 0, "runAsGroup": 0},
                     "env": [],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -297,15 +256,17 @@ def test_set_container_uid_and_pod_fs_gid():
     """
     Test specification of the simplest possible pod specification
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        run_as_uid=1000,
-        fs_gid=0,
-        image_pull_policy='IfNotPresent'
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            run_as_uid=1000,
+            fs_gid=0,
+            image_pull_policy='IfNotPresent',
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -323,15 +284,9 @@ def test_set_container_uid_and_pod_fs_gid():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -341,7 +296,7 @@ def test_set_container_uid_and_pod_fs_gid():
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -349,15 +304,17 @@ def test_set_pod_supplemental_gids():
     """
     Test specification of the simplest possible pod specification
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        run_as_uid=1000,
-        supplemental_gids=[100],
-        image_pull_policy='IfNotPresent'
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            run_as_uid=1000,
+            supplemental_gids=[100],
+            image_pull_policy='IfNotPresent',
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -375,15 +332,9 @@ def test_set_pod_supplemental_gids():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -393,7 +344,7 @@ def test_set_pod_supplemental_gids():
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -401,14 +352,16 @@ def test_run_privileged_container():
     """
     Test specification of the container to run as privileged
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        run_privileged=True,
-        image_pull_policy='IfNotPresent'
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            run_privileged=True,
+            image_pull_policy='IfNotPresent',
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -423,14 +376,8 @@ def test_run_privileged_container():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    },
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
+                    "resources": {"limits": {}, "requests": {}},
                     "securityContext": {
                         "privileged": True,
                     },
@@ -441,7 +388,7 @@ def test_run_privileged_container():
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -449,14 +396,16 @@ def test_allow_privilege_escalation_container():
     """
     Test specification of the container to run without privilege escalation (AllowPrivilegeEscalation=False).
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        allow_privilege_escalation=False,
-        image_pull_policy='IfNotPresent'
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            allow_privilege_escalation=False,
+            image_pull_policy='IfNotPresent',
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -471,17 +420,9 @@ def test_allow_privilege_escalation_container():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    },
-                    "securityContext": {
-                        "allowPrivilegeEscalation": False
-                    },
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
+                    "resources": {"limits": {}, "requests": {}},
+                    "securityContext": {"allowPrivilegeEscalation": False},
                     'volumeMounts': [],
                 }
             ],
@@ -489,7 +430,7 @@ def test_allow_privilege_escalation_container():
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -497,18 +438,20 @@ def test_make_pod_resources_all():
     """
     Test specifying all possible resource limits & guarantees
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cpu_limit=2,
-        cpu_guarantee=1,
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        mem_limit='1Gi',
-        mem_guarantee='512Mi',
-        image_pull_policy='IfNotPresent',
-        node_selector={"disk": "ssd"}
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cpu_limit=2,
+            cpu_guarantee=1,
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            mem_limit='1Gi',
+            mem_guarantee='512Mi',
+            image_pull_policy='IfNotPresent',
+            node_selector={"disk": "ssd"},
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -524,28 +467,19 @@ def test_make_pod_resources_all():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
                     "resources": {
-                        "limits": {
-                            "cpu": 2,
-                            "memory": '1Gi'
-                        },
-                        "requests": {
-                            "cpu": 1,
-                            "memory": '512Mi'
-                        }
-                    }
+                        "limits": {"cpu": 2, "memory": '1Gi'},
+                        "requests": {"cpu": 1, "memory": '512Mi'},
+                    },
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -553,33 +487,35 @@ def test_make_pod_with_env():
     """
     Test specification of a pod with custom environment variables.
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        env={
-            'TEST_KEY_1': 'TEST_VALUE',
-            'TEST_KEY_2': {
-                'valueFrom': {
-                    'secretKeyRef': {
-                        'name': 'my-k8s-secret',
-                        'key': 'password',
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            env={
+                'TEST_KEY_1': 'TEST_VALUE',
+                'TEST_KEY_2': {
+                    'valueFrom': {
+                        'secretKeyRef': {
+                            'name': 'my-k8s-secret',
+                            'key': 'password',
+                        },
+                    },
+                },
+                'TEST_KEY_NAME_IGNORED': {
+                    'name': 'TEST_KEY_3',
+                    'valueFrom': {
+                        'secretKeyRef': {
+                            'name': 'my-k8s-secret',
+                            'key': 'password',
+                        },
                     },
                 },
             },
-            'TEST_KEY_NAME_IGNORED': {
-                'name': 'TEST_KEY_3',
-                'valueFrom': {
-                    'secretKeyRef': {
-                        'name': 'my-k8s-secret',
-                        'key': 'password',
-                    },
-                },
-            },
-        },
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent'
-    )) == {
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -617,24 +553,16 @@ def test_make_pod_with_env():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {
-                        },
-                        "requests": {
-                        }
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -642,20 +570,16 @@ def test_make_pod_with_lifecycle():
     """
     Test specification of a pod with lifecycle
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        lifecycle_hooks={
-            'preStop': {
-                'exec': {
-                    'command': ['/bin/sh', 'test']
-                }
-            }
-        }
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            lifecycle_hooks={'preStop': {'exec': {'command': ['/bin/sh', 'test']}}},
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -670,31 +594,19 @@ def test_make_pod_with_lifecycle():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {
-                        },
-                        "requests": {
-                        }
-                    },
+                    "resources": {"limits": {}, "requests": {}},
                     "lifecycle": {
-                        "preStop": {
-                            "exec": {
-                                "command": ["/bin/sh", "test"]
-                            }
-                        }
-                    }
+                        "preStop": {"exec": {"command": ["/bin/sh", "test"]}}
+                    },
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -702,25 +614,35 @@ def test_make_pod_with_init_containers():
     """
     Test specification of a pod with initContainers
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        init_containers=[
-            {
-                'name': 'init-myservice',
-                'image': 'busybox',
-                'command': ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
-            },
-            {
-                'name': 'init-mydb',
-                'image': 'busybox',
-                'command': ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']
-            }
-        ]
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            init_containers=[
+                {
+                    'name': 'init-myservice',
+                    'image': 'busybox',
+                    'command': [
+                        'sh',
+                        '-c',
+                        'until nslookup myservice; do echo waiting for myservice; sleep 2; done;',
+                    ],
+                },
+                {
+                    'name': 'init-mydb',
+                    'image': 'busybox',
+                    'command': [
+                        'sh',
+                        '-c',
+                        'until nslookup mydb; do echo waiting for mydb; sleep 2; done;',
+                    ],
+                },
+            ],
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -735,37 +657,36 @@ def test_make_pod_with_init_containers():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {
-                        },
-                        "requests": {
-                        }
-                    },
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             "initContainers": [
                 {
                     "name": "init-myservice",
                     "image": "busybox",
-                    "command": ["sh", "-c",
-                                "until nslookup myservice; do echo waiting for myservice; sleep 2; done;"]
+                    "command": [
+                        "sh",
+                        "-c",
+                        "until nslookup myservice; do echo waiting for myservice; sleep 2; done;",
+                    ],
                 },
                 {
                     "name": "init-mydb",
                     "image": "busybox",
-                    "command": ["sh", "-c", "until nslookup mydb; do echo waiting for mydb; sleep 2; done;"]
-                }
+                    "command": [
+                        "sh",
+                        "-c",
+                        "until nslookup mydb; do echo waiting for mydb; sleep 2; done;",
+                    ],
+                },
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -773,22 +694,18 @@ def test_make_pod_with_extra_container_config():
     """
     Test specification of a pod with initContainers
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        extra_container_config={
-            'envFrom': [
-                {
-                    'configMapRef': {
-                        'name': 'special-config'
-                    }
-                }
-            ]
-        }
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            extra_container_config={
+                'envFrom': [{'configMapRef': {'name': 'special-config'}}]
+            },
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -803,31 +720,17 @@ def test_make_pod_with_extra_container_config():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {
-                        },
-                        "requests": {
-                        }
-                    },
-                    'envFrom': [
-                        {
-                            'configMapRef': {
-                                'name': 'special-config'
-                            }
-                        }
-                    ]
+                    "resources": {"limits": {}, "requests": {}},
+                    'envFrom': [{'configMapRef': {'name': 'special-config'}}],
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -835,27 +738,29 @@ def test_make_pod_with_extra_pod_config():
     """
     Test specification of a pod with initContainers
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        tolerations=[{
-            'key': 'wrong_toleration',
-            'operator': 'Equal',
-            'value': 'wrong_value'
-        }],
-        extra_pod_config={
-            'dns_policy': 'ClusterFirstWithHostNet',
-            'restartPolicy': 'Always',
-            'tolerations': [{
-                'key': 'correct_toleration',
-                'operator': 'Equal',
-                'value': 'correct_value'
-            }],
-        },
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            tolerations=[
+                {'key': 'wrong_toleration', 'operator': 'Equal', 'value': 'wrong_value'}
+            ],
+            extra_pod_config={
+                'dns_policy': 'ClusterFirstWithHostNet',
+                'restartPolicy': 'Always',
+                'tolerations': [
+                    {
+                        'key': 'correct_toleration',
+                        'operator': 'Equal',
+                        'value': 'correct_value',
+                    }
+                ],
+            },
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -870,17 +775,9 @@ def test_make_pod_with_extra_pod_config():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {
-                        },
-                        "requests": {
-                        }
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'volumes': [],
@@ -890,12 +787,12 @@ def test_make_pod_with_extra_pod_config():
                 {
                     'key': 'correct_toleration',
                     'operator': 'Equal',
-                    'value': 'correct_value'
+                    'value': 'correct_value',
                 }
-            ]
+            ],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -903,20 +800,22 @@ def test_make_pod_with_extra_containers():
     """
     Test specification of a pod with initContainers
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        extra_containers=[
-            {
-                'name': 'crontab',
-                'image': 'supercronic',
-                'command': ['/usr/local/bin/supercronic', '/etc/crontab']
-            }
-        ]
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            extra_containers=[
+                {
+                    'name': 'crontab',
+                    'image': 'supercronic',
+                    'command': ['/usr/local/bin/supercronic', '/etc/crontab'],
+                }
+            ],
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -931,29 +830,21 @@ def test_make_pod_with_extra_containers():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {
-                        },
-                        "requests": {
-                        }
-                    },
+                    "resources": {"limits": {}, "requests": {}},
                 },
                 {
                     'name': 'crontab',
                     'image': 'supercronic',
-                    'command': ['/usr/local/bin/supercronic', '/etc/crontab']
-                }
+                    'command': ['/usr/local/bin/supercronic', '/etc/crontab'],
+                },
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -961,21 +852,22 @@ def test_make_pod_with_extra_resources():
     """
     Test specification of extra resources (like GPUs)
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cpu_limit=2,
-        cpu_guarantee=1,
-        extra_resource_limits={
-            "nvidia.com/gpu": "5", "k8s.io/new-resource": "1"},
-        extra_resource_guarantees={"nvidia.com/gpu": "3"},
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        mem_limit='1Gi',
-        mem_guarantee='512Mi',
-        image_pull_policy='IfNotPresent',
-        node_selector={"disk": "ssd"}
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cpu_limit=2,
+            cpu_guarantee=1,
+            extra_resource_limits={"nvidia.com/gpu": "5", "k8s.io/new-resource": "1"},
+            extra_resource_guarantees={"nvidia.com/gpu": "3"},
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            mem_limit='1Gi',
+            mem_guarantee='512Mi',
+            image_pull_policy='IfNotPresent',
+            node_selector={"disk": "ssd"},
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -991,31 +883,28 @@ def test_make_pod_with_extra_resources():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
                     "resources": {
                         "limits": {
                             "cpu": 2,
                             "memory": '1Gi',
                             "nvidia.com/gpu": "5",
-                            "k8s.io/new-resource": "1"
+                            "k8s.io/new-resource": "1",
                         },
                         "requests": {
                             "cpu": 1,
                             "memory": '512Mi',
-                            "nvidia.com/gpu": "3"
-                        }
-                    }
+                            "nvidia.com/gpu": "3",
+                        },
+                    },
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1023,29 +912,20 @@ def test_make_pvc_simple():
     """
     Test specification of the simplest possible pvc specification
     """
-    assert api_client.sanitize_for_serialization(make_pvc(
-        name='test',
-        storage_class=None,
-        access_modes=[],
-        selector=None,
-        storage=None,
-        labels={}
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pvc(
+            name='test',
+            storage_class=None,
+            access_modes=[],
+            selector=None,
+            storage=None,
+            labels={},
+        )
+    ) == {
         'kind': 'PersistentVolumeClaim',
         'apiVersion': 'v1',
-        'metadata': {
-            'name': 'test',
-            'annotations': {},
-            'labels': {}
-        },
-        'spec': {
-            'accessModes': [],
-            'resources': {
-                'requests': {
-                    'storage': None
-                }
-            }
-        }
+        'metadata': {'name': 'test', 'annotations': {}, 'labels': {}},
+        'spec': {'accessModes': [], 'resources': {'requests': {'storage': None}}},
     }
 
 
@@ -1053,32 +933,28 @@ def test_make_pvc_empty_storage_class():
     """
     Test specification of pvc with empty storage class
     """
-    assert api_client.sanitize_for_serialization(make_pvc(
-        name='test',
-        storage_class='',
-        access_modes=[],
-        selector=None,
-        storage=None,
-        labels={}
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pvc(
+            name='test',
+            storage_class='',
+            access_modes=[],
+            selector=None,
+            storage=None,
+            labels={},
+        )
+    ) == {
         'kind': 'PersistentVolumeClaim',
         'apiVersion': 'v1',
         'metadata': {
             'name': 'test',
-            'annotations': {
-                'volume.beta.kubernetes.io/storage-class': ''
-            },
-            'labels': {}
+            'annotations': {'volume.beta.kubernetes.io/storage-class': ''},
+            'labels': {},
         },
         'spec': {
             'accessModes': [],
-            'resources': {
-                'requests': {
-                    'storage': None
-                }
-            },
-            'storageClassName': ''
-        }
+            'resources': {'requests': {'storage': None}},
+            'storageClassName': '',
+        },
     }
 
 
@@ -1086,14 +962,16 @@ def test_make_resources_all():
     """
     Test specifying all possible resource limits & guarantees
     """
-    assert api_client.sanitize_for_serialization(make_pvc(
-        name='test',
-        storage_class='gce-standard-storage',
-        access_modes=['ReadWriteOnce'],
-        selector={'matchLabels': {'content': 'jupyter'}},
-        storage='10Gi',
-        labels={'key': 'value'}
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pvc(
+            name='test',
+            storage_class='gce-standard-storage',
+            access_modes=['ReadWriteOnce'],
+            selector={'matchLabels': {'content': 'jupyter'}},
+            storage='10Gi',
+            labels={'key': 'value'},
+        )
+    ) == {
         'kind': 'PersistentVolumeClaim',
         'apiVersion': 'v1',
         'metadata': {
@@ -1101,24 +979,14 @@ def test_make_resources_all():
             'annotations': {
                 'volume.beta.kubernetes.io/storage-class': 'gce-standard-storage'
             },
-            'labels': {
-                'key': 'value'
-            }
+            'labels': {'key': 'value'},
         },
         'spec': {
             'storageClassName': 'gce-standard-storage',
             'accessModes': ['ReadWriteOnce'],
-            'selector': {
-                'matchLabels': {
-                    'content': 'jupyter'
-                }
-            },
-            'resources': {
-                'requests': {
-                    'storage': '10Gi'
-                }
-            }
-        }
+            'selector': {'matchLabels': {'content': 'jupyter'}},
+            'resources': {'requests': {'storage': '10Gi'}},
+        },
     }
 
 
@@ -1126,19 +994,17 @@ def test_make_pod_with_service_account():
     """
     Test specification of the simplest possible pod specification with non-default service account
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        service_account='test'
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            service_account='test',
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             "containers": [
                 {
@@ -1147,23 +1013,17 @@ def test_make_pod_with_service_account():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
-            'serviceAccountName': 'test'
+            'serviceAccountName': 'test',
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1171,14 +1031,16 @@ def test_make_pod_with_scheduler_name():
     """
     Test specification of the simplest possible pod specification with non-default scheduler name
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        scheduler_name='my-custom-scheduler'
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            scheduler_name='my-custom-scheduler',
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -1193,15 +1055,9 @@ def test_make_pod_with_scheduler_name():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -1209,7 +1065,7 @@ def test_make_pod_with_scheduler_name():
             'schedulerName': 'my-custom-scheduler',
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1222,27 +1078,21 @@ def test_make_pod_with_tolerations():
             'key': 'hub.jupyter.org/dedicated',
             'operator': 'Equal',
             'value': 'user',
-            'effect': 'NoSchedule'
+            'effect': 'NoSchedule',
         },
-        {
-            'key': 'key',
-            'operator': 'Exists',
-            'effect': 'NoSchedule'
-        }
+        {'key': 'key', 'operator': 'Exists', 'effect': 'NoSchedule'},
     ]
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        tolerations=tolerations
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            tolerations=tolerations,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [
@@ -1252,23 +1102,17 @@ def test_make_pod_with_tolerations():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
-            'tolerations': tolerations
+            'tolerations': tolerations,
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1276,29 +1120,31 @@ def test_make_pod_with_node_affinity_preferred():
     """
     Test specification of the simplest possible pod specification with non-empty node_affinity_preferred
     """
-    node_affinity_preferred = [{
-        "weight": 1,
-        "preference": {
-            "matchExpressions": [{
-                "key": "hub.jupyter.org/node-purpose",
-                "operator": "In",
-                "values": ["user"],
-            }],
+    node_affinity_preferred = [
+        {
+            "weight": 1,
+            "preference": {
+                "matchExpressions": [
+                    {
+                        "key": "hub.jupyter.org/node-purpose",
+                        "operator": "In",
+                        "values": ["user"],
+                    }
+                ],
+            },
         }
-    }]
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        node_affinity_preferred=node_affinity_preferred
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    ]
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            node_affinity_preferred=node_affinity_preferred,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [
@@ -1308,15 +1154,9 @@ def test_make_pod_with_node_affinity_preferred():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -1325,10 +1165,10 @@ def test_make_pod_with_node_affinity_preferred():
                 "nodeAffinity": {
                     "preferredDuringSchedulingIgnoredDuringExecution": node_affinity_preferred
                 }
-            }
+            },
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1336,26 +1176,28 @@ def test_make_pod_with_node_affinity_required():
     """
     Test specification of the simplest possible pod specification with non-empty node_affinity_required
     """
-    node_affinity_required = [{
-        "matchExpressions": [{
-            "key": "hub.jupyter.org/node-purpose",
-            "operator": "In",
-            "values": ["user"],
-        }]
-    }]
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        node_affinity_required=node_affinity_required
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    node_affinity_required = [
+        {
+            "matchExpressions": [
+                {
+                    "key": "hub.jupyter.org/node-purpose",
+                    "operator": "In",
+                    "values": ["user"],
+                }
+            ]
+        }
+    ]
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            node_affinity_required=node_affinity_required,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [
@@ -1365,15 +1207,9 @@ def test_make_pod_with_node_affinity_required():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -1384,10 +1220,10 @@ def test_make_pod_with_node_affinity_required():
                         "nodeSelectorTerms": node_affinity_required
                     }
                 }
-            }
+            },
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1395,32 +1231,34 @@ def test_make_pod_with_pod_affinity_preferred():
     """
     Test specification of the simplest possible pod specification with non-empty pod_affinity_preferred
     """
-    pod_affinity_preferred = [{
-        "weight": 100,
-        "podAffinityTerm": {
-            "labelSelector": {
-                "matchExpressions": [{
-                    "key": "hub.jupyter.org/pod-kind",
-                    "operator": "In",
-                    "values": ["user"],
-                }]
+    pod_affinity_preferred = [
+        {
+            "weight": 100,
+            "podAffinityTerm": {
+                "labelSelector": {
+                    "matchExpressions": [
+                        {
+                            "key": "hub.jupyter.org/pod-kind",
+                            "operator": "In",
+                            "values": ["user"],
+                        }
+                    ]
+                },
+                "topologyKey": "kubernetes.io/hostname",
             },
-            "topologyKey": "kubernetes.io/hostname"
         }
-    }]
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        pod_affinity_preferred=pod_affinity_preferred
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    ]
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            pod_affinity_preferred=pod_affinity_preferred,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [
@@ -1430,15 +1268,9 @@ def test_make_pod_with_pod_affinity_preferred():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -1447,10 +1279,10 @@ def test_make_pod_with_pod_affinity_preferred():
                 "podAffinity": {
                     "preferredDuringSchedulingIgnoredDuringExecution": pod_affinity_preferred
                 }
-            }
+            },
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1458,29 +1290,31 @@ def test_make_pod_with_pod_affinity_required():
     """
     Test specification of the simplest possible pod specification with non-empty pod_affinity_required
     """
-    pod_affinity_required = [{
-        "labelSelector": {
-            "matchExpressions": [{
-                "key": "security",
-                "operator": "In",
-                "values": ["S1"],
-            }]
-        },
-        "topologyKey": "failure-domain.beta.kubernetes.io/zone"
-    }]
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        pod_affinity_required=pod_affinity_required
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    pod_affinity_required = [
+        {
+            "labelSelector": {
+                "matchExpressions": [
+                    {
+                        "key": "security",
+                        "operator": "In",
+                        "values": ["S1"],
+                    }
+                ]
+            },
+            "topologyKey": "failure-domain.beta.kubernetes.io/zone",
+        }
+    ]
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            pod_affinity_required=pod_affinity_required,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [
@@ -1490,15 +1324,9 @@ def test_make_pod_with_pod_affinity_required():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -1507,10 +1335,10 @@ def test_make_pod_with_pod_affinity_required():
                 "podAffinity": {
                     "requiredDuringSchedulingIgnoredDuringExecution": pod_affinity_required
                 }
-            }
+            },
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1518,32 +1346,34 @@ def test_make_pod_with_pod_anti_affinity_preferred():
     """
     Test specification of the simplest possible pod specification with non-empty pod_anti_affinity_preferred
     """
-    pod_anti_affinity_preferred = [{
-        "weight": 100,
-        "podAffinityTerm": {
-            "labelSelector": {
-                "matchExpressions": [{
-                    "key": "hub.jupyter.org/pod-kind",
-                    "operator": "In",
-                    "values": ["user"],
-                }]
+    pod_anti_affinity_preferred = [
+        {
+            "weight": 100,
+            "podAffinityTerm": {
+                "labelSelector": {
+                    "matchExpressions": [
+                        {
+                            "key": "hub.jupyter.org/pod-kind",
+                            "operator": "In",
+                            "values": ["user"],
+                        }
+                    ]
+                },
+                "topologyKey": "kubernetes.io/hostname",
             },
-            "topologyKey": "kubernetes.io/hostname"
         }
-    }]
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        pod_anti_affinity_preferred=pod_anti_affinity_preferred
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    ]
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            pod_anti_affinity_preferred=pod_anti_affinity_preferred,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [
@@ -1553,15 +1383,9 @@ def test_make_pod_with_pod_anti_affinity_preferred():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -1570,10 +1394,10 @@ def test_make_pod_with_pod_anti_affinity_preferred():
                 "podAntiAffinity": {
                     "preferredDuringSchedulingIgnoredDuringExecution": pod_anti_affinity_preferred
                 }
-            }
+            },
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1581,29 +1405,31 @@ def test_make_pod_with_pod_anti_affinity_required():
     """
     Test specification of the simplest possible pod specification with non-empty pod_anti_affinity_required
     """
-    pod_anti_affinity_required = [{
-        "labelSelector": {
-            "matchExpressions": [{
-                "key": "security",
-                "operator": "In",
-                "values": ["S1"],
-            }]
-        },
-        "topologyKey": "failure-domain.beta.kubernetes.io/zone"
-    }]
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        pod_anti_affinity_required=pod_anti_affinity_required
-    )) == {
-        "metadata": {
-            "name": "test",
-            "labels": {},
-            "annotations": {}
-        },
+    pod_anti_affinity_required = [
+        {
+            "labelSelector": {
+                "matchExpressions": [
+                    {
+                        "key": "security",
+                        "operator": "In",
+                        "values": ["S1"],
+                    }
+                ]
+            },
+            "topologyKey": "failure-domain.beta.kubernetes.io/zone",
+        }
+    ]
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            pod_anti_affinity_required=pod_anti_affinity_required,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
             "automountServiceAccountToken": False,
             "containers": [
@@ -1613,15 +1439,9 @@ def test_make_pod_with_pod_anti_affinity_required():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -1630,10 +1450,10 @@ def test_make_pod_with_pod_anti_affinity_required():
                 "podAntiAffinity": {
                     "requiredDuringSchedulingIgnoredDuringExecution": pod_anti_affinity_required
                 }
-            }
+            },
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1641,14 +1461,16 @@ def test_make_pod_with_priority_class_name():
     """
     Test specification of the simplest possible pod specification with non-default priorityClassName set
     """
-    assert api_client.sanitize_for_serialization(make_pod(
-        name='test',
-        image='jupyter/singleuser:latest',
-        cmd=['jupyterhub-singleuser'],
-        port=8888,
-        image_pull_policy='IfNotPresent',
-        priority_class_name='my-custom-priority-class'
-    )) == {
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            priority_class_name='my-custom-priority-class',
+        )
+    ) == {
         "metadata": {
             "name": "test",
             "annotations": {},
@@ -1663,15 +1485,9 @@ def test_make_pod_with_priority_class_name():
                     "image": "jupyter/singleuser:latest",
                     "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
-                    "ports": [{
-                        "name": "notebook-port",
-                        "containerPort": 8888
-                    }],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],
-                    "resources": {
-                        "limits": {},
-                        "requests": {}
-                    }
+                    "resources": {"limits": {}, "requests": {}},
                 }
             ],
             'restartPolicy': 'OnFailure',
@@ -1679,7 +1495,7 @@ def test_make_pod_with_priority_class_name():
             'priorityClassName': 'my-custom-priority-class',
         },
         "kind": "Pod",
-        "apiVersion": "v1"
+        "apiVersion": "v1",
     }
 
 
@@ -1690,15 +1506,17 @@ def test_make_ingress():
     labels = {
         'heritage': 'jupyterhub',
         'component': 'singleuser-server',
-        'hub.jupyter.org/proxy-route': 'true'
+        'hub.jupyter.org/proxy-route': 'true',
     }
-    endpoint, service, ingress = api_client.sanitize_for_serialization(make_ingress(
-        name='jupyter-test',
-        routespec='/my-path',
-        target='http://192.168.1.10:9000',
-        labels=labels,
-        data={"mykey": "myvalue"}
-    ))
+    endpoint, service, ingress = api_client.sanitize_for_serialization(
+        make_ingress(
+            name='jupyter-test',
+            routespec='/my-path',
+            target='http://192.168.1.10:9000',
+            labels=labels,
+            data={"mykey": "myvalue"},
+        )
+    )
 
     assert endpoint == {
         'kind': 'Endpoints',
@@ -1706,17 +1524,16 @@ def test_make_ingress():
             'annotations': {
                 'hub.jupyter.org/proxy-data': '{"mykey": "myvalue"}',
                 'hub.jupyter.org/proxy-routespec': '/my-path',
-                'hub.jupyter.org/proxy-target': 'http://192.168.1.10:9000'},
+                'hub.jupyter.org/proxy-target': 'http://192.168.1.10:9000',
+            },
             'labels': {
                 'component': 'singleuser-server',
                 'heritage': 'jupyterhub',
-                'hub.jupyter.org/proxy-route': 'true'},
-            'name': 'jupyter-test'
+                'hub.jupyter.org/proxy-route': 'true',
+            },
+            'name': 'jupyter-test',
         },
-        'subsets': [
-            {'addresses': [{'ip': '192.168.1.10'}
-                           ],
-             'ports': [{'port': 9000}]}]
+        'subsets': [{'addresses': [{'ip': '192.168.1.10'}], 'ports': [{'port': 9000}]}],
     }
 
     assert service == {
@@ -1725,18 +1542,20 @@ def test_make_ingress():
             'annotations': {
                 'hub.jupyter.org/proxy-data': '{"mykey": "myvalue"}',
                 'hub.jupyter.org/proxy-routespec': '/my-path',
-                'hub.jupyter.org/proxy-target': 'http://192.168.1.10:9000'},
+                'hub.jupyter.org/proxy-target': 'http://192.168.1.10:9000',
+            },
             'labels': {
                 'component': 'singleuser-server',
                 'heritage': 'jupyterhub',
-                'hub.jupyter.org/proxy-route': 'true'},
-            'name': 'jupyter-test'
+                'hub.jupyter.org/proxy-route': 'true',
+            },
+            'name': 'jupyter-test',
         },
         'spec': {
             'externalName': '',
             'ports': [{'port': 9000, 'targetPort': 9000}],
-            'type': 'ClusterIP'
-        }
+            'type': 'ClusterIP',
+        },
     }
     assert ingress == {
         'kind': 'Ingress',
@@ -1744,26 +1563,34 @@ def test_make_ingress():
             'annotations': {
                 'hub.jupyter.org/proxy-data': '{"mykey": "myvalue"}',
                 'hub.jupyter.org/proxy-routespec': '/my-path',
-                'hub.jupyter.org/proxy-target': 'http://192.168.1.10:9000'},
+                'hub.jupyter.org/proxy-target': 'http://192.168.1.10:9000',
+            },
             'labels': {
                 'component': 'singleuser-server',
                 'heritage': 'jupyterhub',
-                'hub.jupyter.org/proxy-route': 'true'},
-            'name': 'jupyter-test'},
+                'hub.jupyter.org/proxy-route': 'true',
+            },
+            'name': 'jupyter-test',
+        },
         'spec': {
             'rules': [
-                {'http': {
-                    'paths': [
-                        {
-                            'backend': {
-                                'serviceName': 'jupyter-test',
-                                'servicePort': 9000},
-                            'path': '/my-path'
-                        }
-                    ]}
-                 }]
-        }
+                {
+                    'http': {
+                        'paths': [
+                            {
+                                'backend': {
+                                    'serviceName': 'jupyter-test',
+                                    'servicePort': 9000,
+                                },
+                                'path': '/my-path',
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
     }
+
 
 def test_make_pod_with_ssl():
     """
@@ -1843,9 +1670,9 @@ def test_make_namespace():
         'heritage': 'jupyterhub',
         'component': 'singleuser-server',
     }
-    namespace = api_client.sanitize_for_serialization(make_namespace(
-        name='test-namespace',
-        labels=labels))
+    namespace = api_client.sanitize_for_serialization(
+        make_namespace(name='test-namespace', labels=labels)
+    )
     assert namespace == {
         'metadata': {
             'annotations': {},
@@ -1857,6 +1684,7 @@ def test_make_namespace():
         },
     }
 
+
 def test_make_pod_with_ssl():
     """
     Test specification of a pod with ssl enabled
@@ -1935,9 +1763,9 @@ def test_make_namespace():
         'heritage': 'jupyterhub',
         'component': 'singleuser-server',
     }
-    namespace = api_client.sanitize_for_serialization(make_namespace(
-        name='test-namespace',
-        labels=labels))
+    namespace = api_client.sanitize_for_serialization(
+        make_namespace(name='test-namespace', labels=labels)
+    )
     assert namespace == {
         'metadata': {
             'annotations': {},

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -4,15 +4,14 @@ import time
 from unittest.mock import Mock
 
 import pytest
-from jupyterhub.objects import Hub, Server
+from jupyterhub.objects import Hub
+from jupyterhub.objects import Server
 from jupyterhub.orm import Spawner
-from kubernetes.client.models import (
-    V1Capabilities,
-    V1Container,
-    V1PersistentVolumeClaim,
-    V1Pod,
-    V1SecurityContext,
-)
+from kubernetes.client.models import V1Capabilities
+from kubernetes.client.models import V1Container
+from kubernetes.client.models import V1PersistentVolumeClaim
+from kubernetes.client.models import V1Pod
+from kubernetes.client.models import V1SecurityContext
 from traitlets.config import Config
 
 from kubespawner import KubeSpawner
@@ -21,6 +20,7 @@ from kubespawner import KubeSpawner
 class MockUser(Mock):
     name = 'fake'
     server = Server()
+
     def __init__(self, **kwargs):
         super().__init__()
         for key, value in kwargs.items():
@@ -49,8 +49,7 @@ def test_deprecated_config():
         c.KubeSpawner.fs_gid = 10
         # only deprecated set, should still work
         c.KubeSpawner.hub_connect_ip = '10.0.1.1'
-        c.KubeSpawner.singleuser_extra_pod_config = extra_pod_config = {
-            "key": "value"}
+        c.KubeSpawner.singleuser_extra_pod_config = extra_pod_config = {"key": "value"}
         c.KubeSpawner.image_spec = 'abc:123'
         c.KubeSpawner.image_pull_secrets = 'k8s-secret-a'
         spawner = KubeSpawner(hub=Hub(), config=c, _mock=True)
@@ -345,7 +344,7 @@ async def test_get_pod_manifest_tolerates_mixed_input():
     dict_model = {
         'name': 'mock_name_1',
         'image': 'mock_image_1',
-        'command': ['mock_command_1']
+        'command': ['mock_command_1'],
     }
     object_model = V1Container(
         name="mock_name_2",
@@ -354,8 +353,8 @@ async def test_get_pod_manifest_tolerates_mixed_input():
         security_context=V1SecurityContext(
             privileged=True,
             run_as_user=0,
-            capabilities=V1Capabilities(add=['NET_ADMIN'])
-        )
+            capabilities=V1Capabilities(add=['NET_ADMIN']),
+        ),
     )
     c.KubeSpawner.init_containers = [dict_model, object_model]
 
@@ -379,7 +378,7 @@ _test_profiles = [
             'image': 'training/python:label',
             'cpu_limit': 1,
             'mem_limit': 512 * 1024 * 1024,
-        }
+        },
     },
     {
         'display_name': 'Training Env - Datascience',
@@ -388,7 +387,7 @@ _test_profiles = [
             'image': 'training/datascience:label',
             'cpu_limit': 4,
             'mem_limit': 8 * 1024 * 1024 * 1024,
-        }
+        },
     },
 ]
 
@@ -400,7 +399,8 @@ async def test_user_options_set_from_form():
     # render the form
     await spawner.get_options_form()
     spawner.user_options = spawner.options_from_form(
-        {'profile': [_test_profiles[1]['slug']]})
+        {'profile': [_test_profiles[1]['slug']]}
+    )
     assert spawner.user_options == {
         'profile': _test_profiles[1]['slug'],
     }
@@ -564,6 +564,7 @@ async def test_pod_connect_ip(kube_ns, kube_client, config, hub_pod, hub):
 
     assert res == "http://jupyter-connectip--server.foo.example.com:8888"
     await spawner.stop()
+
 
 def test_get_pvc_manifest():
     c = Config()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-minversion = 1.6
-skipsdist = True
-
-envlist = py35,py36
-
-[flake8]
-max-line-length = 100


### PR DESCRIPTION
imports pre-commit CI Action, configuration from jupyterhub repo for consistency across the organization

applies result of `pre-commit run --all-files` and only enough code changes to get it to pass (a few commas, decorators)

avoid future issues like the formatting/conflict issues in #458