### PR TITLE
add method to delete namespaced PVC in spawner base class

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2818,7 +2818,7 @@ class KubeSpawner(Spawner):
         Only called on stopped spawners, and is likely the last action ever taken for the user.
 
         This will only be called once on the user's default Spawner.
-        Supported by JupyterHub 1.4.0+.
+        Supported by JupyterHub 1.4.1+.
         """
         await exponential_backoff(
             partial(


### PR DESCRIPTION
## PR Summary by Erik

This PR implements a `delete_forever` hook for KubeSpawner. The `delete_forever` hook will be respected by JupyterHub 1.4.0 and later and was implemented in https://github.com/jupyterhub/jupyterhub/pull/3337. The idea of this hook is to allow the Spawners to perform cleanup of a users associated resources at the time a JupyterHub user is deleted.

As KubeSpawner can create PVCs for users, this KubeSpawner implementation checks for a PVC that it could have created for a user and tries to delete it. This behavior should be documented properly in the CHANGELOG.md for the next KubeSpawner release, I'm not sure if I think it would be labelled as a "breaking" change, but it is a change in the user experience that is quite important to be aware about.

This PR closes #446.

## Original PR message

have tested with sqlite-pvc