### PR TITLE
Allow mounting of service account token to be configurable (automount_service_account_token)

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -467,6 +467,8 @@ def make_pod(
 
     if automount_service_account_token is None:
         if service_account is None:
+            # This makes sure that we don't accidentally give access to the whole
+            # kubernetes API to the users in the spawned pods.
             pod.spec.automount_service_account_token = False
     else:
         pod.spec.automount_service_account_token = automount_service_account_token

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -417,11 +417,11 @@ def make_pod(
         security_context=container_security_context,
     )
 
-    if service_account is None:
-        # This makes sure that we don't accidentally give access to the whole
-        # kubernetes API to the users in the spawned pods.
-        pod.spec.automount_service_account_token = False
-    else:
+    # This makes sure that we don't accidentally give access to the whole
+    # kubernetes API to the users in the spawned pods.
+    pod.spec.automount_service_account_token = False
+
+    if service_account is not None:
         pod.spec.service_account_name = service_account
 
     notebook_container.resources.requests = {}

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -78,6 +78,7 @@ def make_pod(
     lifecycle_hooks=None,
     init_containers=None,
     service_account=None,
+    automount_service_account_token=False,
     extra_container_config=None,
     extra_pod_config=None,
     extra_containers=None,
@@ -417,10 +418,7 @@ def make_pod(
         security_context=container_security_context,
     )
 
-    # This makes sure that we don't accidentally give access to the whole
-    # kubernetes API to the users in the spawned pods.
-    pod.spec.automount_service_account_token = False
-
+    pod.spec.automount_service_account_token = automount_service_account_token
     if service_account is not None:
         pod.spec.service_account_name = service_account
 

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -80,7 +80,7 @@ def make_pod(
     lifecycle_hooks=None,
     init_containers=None,
     service_account=None,
-    automount_service_account_token=False,
+    automount_service_account_token=None,
     extra_container_config=None,
     extra_pod_config=None,
     extra_containers=None,
@@ -462,9 +462,14 @@ def make_pod(
         security_context=csc,
     )
 
-    pod.spec.automount_service_account_token = automount_service_account_token
     if service_account is not None:
         pod.spec.service_account_name = service_account
+
+    if automount_service_account_token is None:
+        if service_account is None:
+            pod.spec.automount_service_account_token = False
+    else:
+        pod.spec.automount_service_account_token = automount_service_account_token
 
     notebook_container.resources.requests = {}
     if cpu_guarantee:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -404,12 +404,14 @@ class KubeSpawner(Spawner):
     )
 
     automount_service_account_token = Bool(
-        False,
+        None,
+        allow_none=True,
         config=True,
         help="""
         Whether to mount the service account token in the spawned user pod.
 
-        The default value is False, and the token is NOT mounted.
+        The default value is None, which mounts the token if the service account is explicitly set,
+        but doesn't mount it if not.
 
         WARNING: Be careful with this configuration! Make sure the service account being mounted
         has the minimal permissions needed, and nothing more. When misconfigured, this can easily

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -394,10 +394,22 @@ class KubeSpawner(Spawner):
         help="""
         The service account to be mounted in the spawned user pod.
 
-        When set to `None` (the default), no service account is mounted, and the default service account
-        is explicitly disabled.
+        The token of the service account is NOT mounted by default.
+        This makes sure that we don't accidentally give access to the whole
+        kubernetes API to the users in the spawned pods.
+        Set automount_service_account_token True to mount it.
 
         This `serviceaccount` must already exist in the namespace the user pod is being spawned in.
+        """,
+    )
+
+    automount_service_account_token = Bool(
+        False,
+        config=True,
+        help="""
+        Whether to mount the service account token in the spawned user pod.
+
+        The default value is False, and the token is NOT mounted.
 
         WARNING: Be careful with this configuration! Make sure the service account being mounted
         has the minimal permissions needed, and nothing more. When misconfigured, this can easily
@@ -1719,6 +1731,7 @@ class KubeSpawner(Spawner):
             lifecycle_hooks=self.lifecycle_hooks,
             init_containers=self._expand_all(self.init_containers),
             service_account=self.service_account,
+            automount_service_account_token=self.automount_service_account_token,
             extra_container_config=self.extra_container_config,
             extra_pod_config=self._expand_all(self.extra_pod_config),
             extra_containers=self._expand_all(self.extra_containers),

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1185,6 +1185,82 @@ def test_make_pod_with_service_account():
             port=8888,
             image_pull_policy='IfNotPresent',
             service_account='test',
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
+        "spec": {
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
+                    'volumeMounts': [],
+                    "resources": {"limits": {}, "requests": {}},
+                }
+            ],
+            'restartPolicy': 'OnFailure',
+            'volumes': [],
+            'serviceAccountName': 'test',
+        },
+        "kind": "Pod",
+        "apiVersion": "v1",
+    }
+
+
+def test_make_pod_with_service_account_and_with_mount_token():
+    """
+    Test specification of the simplest possible pod specification with non-default service account and automount service account token.
+    """
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            service_account='test',
+            automount_service_account_token=True,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
+        "spec": {
+            "automountServiceAccountToken": True,
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
+                    'volumeMounts': [],
+                    "resources": {"limits": {}, "requests": {}},
+                }
+            ],
+            'restartPolicy': 'OnFailure',
+            'volumes': [],
+            'serviceAccountName': 'test',
+        },
+        "kind": "Pod",
+        "apiVersion": "v1",
+    }
+
+
+def test_make_pod_with_service_account_and_with_no_mount_token():
+    """
+    Test specification of the simplest possible pod specification with non-default service account and no automount service account token.
+    """
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            service_account='test',
             automount_service_account_token=False,
         )
     ) == {
@@ -1223,7 +1299,6 @@ def test_make_pod_with_automount_service_account_token():
             cmd=['jupyterhub-singleuser'],
             port=8888,
             image_pull_policy='IfNotPresent',
-            service_account='test',
             automount_service_account_token=True,
         )
     ) == {
@@ -1244,7 +1319,43 @@ def test_make_pod_with_automount_service_account_token():
             ],
             'restartPolicy': 'OnFailure',
             'volumes': [],
-            'serviceAccountName': 'test',
+        },
+        "kind": "Pod",
+        "apiVersion": "v1",
+    }
+
+
+def test_make_pod_with_no_automount_service_account_token():
+    """
+    Test specification of the simplest possible pod specification with no automount service account token.
+    """
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            automount_service_account_token=False,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
+        "spec": {
+            "automountServiceAccountToken": False,
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
+                    'volumeMounts': [],
+                    "resources": {"limits": {}, "requests": {}},
+                }
+            ],
+            'restartPolicy': 'OnFailure',
+            'volumes': [],
         },
         "kind": "Pod",
         "apiVersion": "v1",

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -992,10 +992,9 @@ def test_make_resources_all():
     }
 
 
-@pytest.mark.parametrize('mount', [False, True])
-def test_make_pod_with_service_account(mount):
+def test_make_pod_with_service_account():
     """
-    Test specification of the simplest possible pod specification with service account
+    Test specification of the simplest possible pod specification with non-default service account.
     """
     assert api_client.sanitize_for_serialization(
         make_pod(
@@ -1005,12 +1004,51 @@ def test_make_pod_with_service_account(mount):
             port=8888,
             image_pull_policy='IfNotPresent',
             service_account='test',
-            automount_service_account_token=mount,
+            automount_service_account_token=False,
         )
     ) == {
         "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
-            "automountServiceAccountToken": mount,
+            "automountServiceAccountToken": False,
+            "containers": [
+                {
+                    "env": [],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
+                    'volumeMounts': [],
+                    "resources": {"limits": {}, "requests": {}},
+                }
+            ],
+            'restartPolicy': 'OnFailure',
+            'volumes': [],
+            'serviceAccountName': 'test',
+        },
+        "kind": "Pod",
+        "apiVersion": "v1",
+    }
+
+
+def test_make_pod_with_automount_service_account_token():
+    """
+    Test specification of the simplest possible pod specification with automount service account token.
+    """
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+            service_account='test',
+            automount_service_account_token=True,
+        )
+    ) == {
+        "metadata": {"name": "test", "labels": {}, "annotations": {}},
+        "spec": {
+            "automountServiceAccountToken": True,
             "containers": [
                 {
                     "env": [],

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2,7 +2,6 @@
 Test functions used to create k8s objects
 """
 import pytest
-
 from kubernetes.client import ApiClient
 
 from kubespawner.objects import make_ingress

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1006,6 +1006,7 @@ def test_make_pod_with_service_account():
     ) == {
         "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
+            "automountServiceAccountToken": False,
             "containers": [
                 {
                     "env": [],

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,6 +1,8 @@
 """
 Test functions used to create k8s objects
 """
+import pytest
+
 from kubernetes.client import ApiClient
 
 from kubespawner.objects import make_ingress
@@ -990,9 +992,10 @@ def test_make_resources_all():
     }
 
 
-def test_make_pod_with_service_account():
+@pytest.mark.parametrize('mount', [False, True])
+def test_make_pod_with_service_account(mount):
     """
-    Test specification of the simplest possible pod specification with non-default service account
+    Test specification of the simplest possible pod specification with service account
     """
     assert api_client.sanitize_for_serialization(
         make_pod(
@@ -1002,11 +1005,12 @@ def test_make_pod_with_service_account():
             port=8888,
             image_pull_policy='IfNotPresent',
             service_account='test',
+            automount_service_account_token=mount,
         )
     ) == {
         "metadata": {"name": "test", "labels": {}, "annotations": {}},
         "spec": {
-            "automountServiceAccountToken": False,
+            "automountServiceAccountToken": mount,
             "containers": [
                 {
                     "env": [],

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1210,7 +1210,7 @@ def test_make_pod_with_service_account():
     }
 
 
-def test_make_pod_with_service_account_and_with_mount_token():
+def test_make_pod_with_service_account_and_with_automount_sa_token():
     """
     Test specification of the simplest possible pod specification with non-default service account and automount service account token.
     """
@@ -1249,9 +1249,9 @@ def test_make_pod_with_service_account_and_with_mount_token():
     }
 
 
-def test_make_pod_with_service_account_and_with_no_mount_token():
+def test_make_pod_with_service_account_and_with_negative_automount_sa_token():
     """
-    Test specification of the simplest possible pod specification with non-default service account and no automount service account token.
+    Test specification of the simplest possible pod specification with non-default service account and negative automount service account token.
     """
     assert api_client.sanitize_for_serialization(
         make_pod(
@@ -1325,9 +1325,9 @@ def test_make_pod_with_automount_service_account_token():
     }
 
 
-def test_make_pod_with_no_automount_service_account_token():
+def test_make_pod_with_negative_automount_service_account_token():
     """
-    Test specification of the simplest possible pod specification with no automount service account token.
+    Test specification of the simplest possible pod specification with negative automount service account token.
     """
     assert api_client.sanitize_for_serialization(
         make_pod(


### PR DESCRIPTION
I don't think we always need a service account token even if we set a custom service account. To minimize a security risk by just setting a service account and make the behavior consistent with the default case, we should disable it by default and ask to modify it by `modify_pod_hook` manually although it's kind of breaking change.