### PR TITLE
set fsGroupChangePolicy to always be OnRootMismatch

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -372,6 +372,7 @@ def make_pod(
         pod_security_context.supplemental_groups = [
             int(gid) for gid in supplemental_gids
         ]
+    pod_security_context.fs_group_change_policy = "OnRootMismatch"
     # Only clutter pod spec with actual content
     if not all([e is None for e in pod_security_context.to_dict().values()]):
         pod.spec.security_context = pod_security_context


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/kubespawner/issues/478 

I am not sure what would happen to versions below 1.18 / 1.19. In theory that would speed up mounting larger docker-stacks image. I have not checked what happens on older versions, I am hoping the CI can check it....