### PR TITLE
Add pod_security_context and container_security_context config

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -397,14 +397,14 @@ def make_pod(
     if fs_gid is not None:
         psc["fs_group"] = int(fs_gid)
     if supplemental_gids is not None:
-        psc["supplemental_groups"] = [
-            int(gid) for gid in supplemental_gids
-        ]
+        psc["supplemental_groups"] = [int(gid) for gid in supplemental_gids]
     if pod_security_context is not None:
         psc.update(pod_security_context)
     try:
         # validate truthy config by casting it
-        pod.spec.security_context = get_k8s_model(V1PodSecurityContext, psc) if psc else None
+        pod.spec.security_context = (
+            get_k8s_model(V1PodSecurityContext, psc) if psc else None
+        )
     except TypeError as err:
         print("Not a valid security context: ", str(psc))
         print("You supplied: ", str(pod_security_context))

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -415,11 +415,11 @@ def make_pod(
 
     csc = {}
     # populate with uid / gid  / privileged / allow_privilege_escalation
-    if run_as_uid is not None:
-        csc["run_as_user"] = int(run_as_uid)
-    if run_as_gid is not None:
-        csc["run_as_group"] = int(run_as_gid)
-    if run_privileged:  # false as default
+    if uid is not None:
+        csc["run_as_user"] = int(uid)
+    if gid is not None:
+        csc["run_as_group"] = int(gid)
+    if privileged:  # false as default
         csc["privileged"] = True
     if not allow_privilege_escalation:  # true as default
         csc["allow_privilege_escalation"] = False

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -404,7 +404,7 @@ def make_pod(
         psc.update(pod_security_context)
     try:
         # validate truthy config by casting it
-        pod.spec.security_context = V1PodSecurityContext(**psc) if psc else None
+        pod.spec.security_context = get_k8s_model(V1PodSecurityContext, psc) if psc else None
     except TypeError as err:
         print("Not a valid security context: ", str(psc))
         print("You supplied: ", str(pod_security_context))
@@ -427,7 +427,7 @@ def make_pod(
         csc.update(container_security_context)
     try:
         # validate truthy config by casting it
-        csc = V1SecurityContext(**csc) if csc else None
+        csc = get_k8s_model(V1SecurityContext, csc) if csc else None
     except TypeError as err:
         print("Not a valid security context: ", str(csc))
         print("You supplied: ", str(container_security_context))

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -403,10 +403,11 @@ def make_pod(
     if supplemental_gids is not None:
         psc["supplementalGroups"] = [int(gid) for gid in supplemental_gids]
     if pod_security_context is not None:
-        if any("_" in key for key in pod_security_context.keys()):
-            raise ValueError(
-                "pod_security_context's keys should be directly k8s compliant camelCase, but snake_case formatting was detected."
-            )
+        for key in pod_security_context.keys():
+            if "_" in key:
+                raise ValueError(
+                    f"pod_security_context's keys should have k8s camelCase names, got '{key}'"
+                )
         psc.update(pod_security_context)
     if not psc:
         psc = None
@@ -423,10 +424,11 @@ def make_pod(
     if not allow_privilege_escalation:  # true as default
         csc["allowPrivilegeEscalation"] = False
     if container_security_context is not None:
-        if any("_" in key for key in container_security_context.keys()):
-            raise ValueError(
-                "container_security_context's keys should be directly k8s compliant camelCase, but snake_case formatting was detected."
-            )
+        for key in container_security_context.keys():
+            if "_" in key:
+                raise ValueError(
+                    f"container_security_context's keys should have k8s camelCase names, got '{key}'"
+                )
         csc.update(container_security_context)
     if not csc:
         csc = None

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -403,6 +403,10 @@ def make_pod(
     if supplemental_gids is not None:
         psc["supplementalGroups"] = [int(gid) for gid in supplemental_gids]
     if pod_security_context is not None:
+        if any("_" in key for key in pod_security_context.keys()):
+            raise ValueError(
+                "pod_security_context's keys should be directly k8s compliant camelCase, but snake_case formatting was detected."
+            )
         psc.update(pod_security_context)
     if not psc:
         psc = None
@@ -419,6 +423,10 @@ def make_pod(
     if not allow_privilege_escalation:  # true as default
         csc["allowPrivilegeEscalation"] = False
     if container_security_context is not None:
+        if any("_" in key for key in container_security_context.keys()):
+            raise ValueError(
+                "container_security_context's keys should be directly k8s compliant camelCase, but snake_case formatting was detected."
+            )
         csc.update(container_security_context)
     if not csc:
         csc = None

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1720,14 +1720,14 @@ class KubeSpawner(Spawner):
             supplemental_gids = self.supplemental_gids
 
         if callable(self.container_security_context):
-            container_security_context = await gen.maybe_future(self.container_security_context(self))
+            csc = await gen.maybe_future(self.container_security_context(self))
         else:
-            container_security_context = self.container_security_context
+            csc = self.container_security_context
 
         if callable(self.pod_security_context):
-            pod_security_context = await gen.maybe_future(self.pod_security_context(self))
+            psc = await gen.maybe_future(self.pod_security_context(self))
         else:
-            pod_security_context = self.pod_security_context
+            psc = self.pod_security_context
 
         if self.cmd:
             real_cmd = self.cmd + self.get_args()
@@ -1753,8 +1753,8 @@ class KubeSpawner(Spawner):
             supplemental_gids=supplemental_gids,
             privileged=self.privileged,
             allow_privilege_escalation=self.allow_privilege_escalation,
-            container_security_context=container_security_context,
-            pod_security_context=pod_security_context,
+            container_security_context=csc,
+            pod_security_context=psc,
             env=self.get_env(),
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -824,6 +824,34 @@ class KubeSpawner(Spawner):
         """,
     )
 
+    container_security_context = Union(
+        trait_types=[
+            Dict(),
+            Callable(),
+        ],
+        config=True,
+        help="""
+        A Kubernetes security context for the container. It overrides the pod.
+        It takes precedence over values like `runAsUser`.
+        The supported options are dependent on your own Kubernetes version and
+        on whether the Python kubernetes-client library supports them.
+        """,
+    )
+
+    pod_security_context = Union(
+        trait_types=[
+            Dict(),
+            Callable(),
+        ],
+        config=True,
+        help="""
+        A Kubernetes security context for the pod. It applies to the container
+        unless overriden by container_security_context. It takes precedence over values like `runAsUser`.
+        The supported options are dependent on your own Kubernetes version and
+        on whether the Python kubernetes-client library supports them.
+        """,
+    )
+
     modify_pod_hook = Callable(
         None,
         allow_none=True,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -831,14 +831,16 @@ class KubeSpawner(Spawner):
         ],
         config=True,
         help="""
-        A Kubernetes security context for the container.
+        A Kubernetes security context for the container. Note that all
+        configuration options within here should be camelCased.
 
         What is configured here has the highest priority, so the alternative
         configuration `uid`, `gid`, `privileged`, and
         `allow_privilege_escalation` will be overridden by this.
 
-        The supported options are dependent on your own Kubernetes version and
-        on whether the Python kubernetes-client library supports them.
+        Rely on `the Kubernetes reference
+        <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#securitycontext-v1-core>`__
+        for details on allowed configuration.
         """,
     )
 
@@ -849,7 +851,8 @@ class KubeSpawner(Spawner):
         ],
         config=True,
         help="""
-        A Kubernetes security context for the pod.
+        A Kubernetes security context for the pod. Note that all configuration
+        options within here should be camelCased.
 
         What is configured here has higher priority than `fs_gid` and
         `supplemental_gids`, but lower priority than what is set in the
@@ -858,8 +861,9 @@ class KubeSpawner(Spawner):
         Note that anything configured on the Pod level will influence all
         containers, including init containers and sidecar containers.
 
-        The supported options are dependent on your own Kubernetes version and
-        on whether the Python kubernetes-client library supports them.
+        Rely on `the Kubernetes reference
+        <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core>`__
+        for details on allowed configuration.
         """,
     )
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1719,6 +1719,16 @@ class KubeSpawner(Spawner):
         else:
             supplemental_gids = self.supplemental_gids
 
+        if callable(self.container_security_context):
+            container_security_context = await gen.maybe_future(self.container_security_context(self))
+        else:
+            container_security_context = self.container_security_context
+
+        if callable(self.pod_security_context):
+            pod_security_context = await gen.maybe_future(self.pod_security_context(self))
+        else:
+            pod_security_context = self.pod_security_context
+
         if self.cmd:
             real_cmd = self.cmd + self.get_args()
         else:
@@ -1743,6 +1753,8 @@ class KubeSpawner(Spawner):
             supplemental_gids=supplemental_gids,
             privileged=self.privileged,
             allow_privilege_escalation=self.allow_privilege_escalation,
+            container_security_context=container_security_context,
+            pod_security_context=pod_security_context,
             env=self.get_env(),
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -831,8 +831,12 @@ class KubeSpawner(Spawner):
         ],
         config=True,
         help="""
-        A Kubernetes security context for the container. It overrides the pod.
-        It takes precedence over values like `runAsUser`.
+        A Kubernetes security context for the container.
+
+        What is configured here has the highest priority, so the alternative
+        configuration `uid`, `gid`, `privileged`, and
+        `allow_privilege_escalation` will be overridden by this.
+
         The supported options are dependent on your own Kubernetes version and
         on whether the Python kubernetes-client library supports them.
         """,
@@ -845,8 +849,15 @@ class KubeSpawner(Spawner):
         ],
         config=True,
         help="""
-        A Kubernetes security context for the pod. It applies to the container
-        unless overriden by container_security_context. It takes precedence over values like `runAsUser`.
+        A Kubernetes security context for the pod.
+
+        What is configured here has higher priority than `fs_gid` and
+        `supplemental_gids`, but lower priority than what is set in the
+        `container_security_context`.
+
+        Note that anything configured on the Pod level will influence all
+        containers, including init containers and sidecar containers.
+
         The supported options are dependent on your own Kubernetes version and
         on whether the Python kubernetes-client library supports them.
         """,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -575,6 +575,48 @@ def test_container_security_context_container():
     }
 
 
+def test_bad_pod_security_context_container():
+    """
+    Test specification of the container to run with a security context.
+
+    ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#securitycontext-v1-core
+    """
+    with pytest.raises(ValueError):
+        assert api_client.sanitize_for_serialization(
+            make_pod(
+                name='test',
+                image='jupyter/singleuser:latest',
+                image_pull_policy='IfNotPresent',
+                cmd=['jupyterhub-singleuser'],
+                port=8888,
+                pod_security_context={
+                    "run_as_user": 1000,
+                },
+            )
+        )
+
+
+def test_bad_container_security_context_container():
+    """
+    Test specification of the container to run with a security context.
+
+    ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#securitycontext-v1-core
+    """
+    with pytest.raises(ValueError):
+        assert api_client.sanitize_for_serialization(
+            make_pod(
+                name='test',
+                image='jupyter/singleuser:latest',
+                image_pull_policy='IfNotPresent',
+                cmd=['jupyterhub-singleuser'],
+                port=8888,
+                container_security_context={
+                    "allow_privilege_escalation": True,
+                },
+            )
+        )
+
+
 def test_make_pod_resources_all():
     """
     Test specifying all possible resource limits & guarantees

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -494,7 +494,7 @@ def test_security_context_priority():
             image='jupyter/singleuser:latest',
             cmd=['jupyterhub-singleuser'],
             port=8888,
-            run_as_uid=1001,
+            uid=1001,
             supplemental_gids=[101],
             container_security_context={'run_as_user': 1000},
             pod_security_context={'supplemental_groups': [100]},


### PR DESCRIPTION
This PR adds `container_security_context` and `pod_security_context` configuration options.

__Old vs new options__
The new options `container_security_context` and `pod_security_context` updates the partial security contexts built from the following older options:

- `supplemental_gids` (pod)
- `fs_gid` (pod)
- `privileged` (container)
- `allow_privilege_escalation` (container)
- `uid` (container)
- `gid` (container).

__Related__
Fixes #454 - pod/container security contexts can now be configured
Related to #478 - exposes fsGroupChangePolicy through pod security context, but doesn't provide a default value.