### PR TITLE
Fix 492 -- config kubernetes client ssl_ca_cert

### DIFF
--- a/kubespawner/clients.py
+++ b/kubespawner/clients.py
@@ -38,6 +38,9 @@ def shared_client(ClientType, *args, **kwargs):
         client = _client_cache[cache_key]()
 
     if client is None:
+        # Kubernetes client configuration is handled globally
+        # in kubernetes.py and is already called in spawner.py
+        # or proxy.py prior a shared_client being instantiated
         Client = getattr(kubernetes.client, ClientType)
         client = Client(*args, **kwargs)
         # cache weakref so that clients can be garbage collected

--- a/kubespawner/clients.py
+++ b/kubespawner/clients.py
@@ -40,7 +40,7 @@ def shared_client(ClientType, *args, **kwargs):
     if client is None:
         # Kubernetes client configuration is handled globally
         # in kubernetes.py and is already called in spawner.py
-        # or proxy.py prior a shared_client being instantiated
+        # or proxy.py prior to a shared_client being instantiated
         Client = getattr(kubernetes.client, ClientType)
         client = Client(*args, **kwargs)
         # cache weakref so that clients can be garbage collected

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -4,10 +4,10 @@ import string
 from concurrent.futures import ThreadPoolExecutor
 
 import escapism
+import kubernetes.config
 from jupyterhub.proxy import Proxy
 from jupyterhub.utils import exponential_backoff
 from kubernetes import client
-import kubernetes.config
 from tornado import gen
 from tornado.concurrent import run_on_executor
 from traitlets import Unicode

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -134,8 +134,12 @@ class KubeIngressProxy(Proxy):
         self.extension_api = shared_client('ExtensionsV1beta1Api')
 
     def _set_k8s_client_configuration(self):
-        # Load kubernetes config here, since this is a Singleton and
-        # so this __init__ will be run way before anything else gets run.
+        # The actual (singleton) Kubernetes client will be created
+        # in clients.py shared_client but the configuration
+        # for token / ca_cert / k8s api host is set globally
+        # in kubernetes.py syntax.  It is being set here
+        # and this method called prior to shared_client
+        # for readability / coupling with traitlets values
         try:
             kubernetes.config.load_incluster_config()
         except kubernetes.config.ConfigException:

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -79,6 +79,32 @@ class KubeIngressProxy(Proxy):
         """,
     )
 
+    k8s_api_ssl_ca_cert = Unicode(
+        "",
+        config=True,
+        help="""
+        Location (absolute filepath) for CA certs of the k8s API server.
+        
+        Typically this is unnecessary, CA certs are picked up by 
+        config.load_incluster_config() or config.load_kube_config.
+        
+        In rare non-standard cases, such as using custom intermediate CA
+        for your cluster, you may need to mount root CA's elsewhere in
+        your Pod/Container and point this variable to that filepath
+        """,
+    )
+
+    k8s_api_host = Unicode(
+        "",
+        config=True,
+        help="""
+        Full host name of the k8s API server ("https://hostname:port").
+        
+        Typically this is unnecessary, the hostname is picked up by 
+        config.load_incluster_config() or config.load_kube_config.
+        """,
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -101,8 +127,26 @@ class KubeIngressProxy(Proxy):
             parent=self, namespace=self.namespace, labels=labels
         )
 
+        # Global configuration before reflector.py code runs
+        self._set_k8s_client_configuration()
         self.core_api = shared_client('CoreV1Api')
         self.extension_api = shared_client('ExtensionsV1beta1Api')
+
+    def _set_k8s_client_configuration(self):
+        # Load kubernetes config here, since this is a Singleton and
+        # so this __init__ will be run way before anything else gets run.
+        try:
+            kubernetes.config.load_incluster_config()
+        except kubernetes.config.ConfigException:
+            kubernetes.config.load_kube_config()
+        if self.k8s_api_ssl_ca_cert:
+            global_conf = client.Configuration.get_default_copy()
+            global_conf.ssl_ca_cert = self.k8s_api_ssl_ca_cert
+            client.Configuration.set_default(global_conf)
+        if self.k8s_api_host:
+            global_conf = client.Configuration.get_default_copy()
+            global_conf.host = self.k8s_api_host
+            client.Configuration.set_default(global_conf)
 
     @run_on_executor
     def asynchronize(self, method, *args, **kwargs):

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -7,6 +7,7 @@ import escapism
 from jupyterhub.proxy import Proxy
 from jupyterhub.utils import exponential_backoff
 from kubernetes import client
+import kubernetes.config
 from tornado import gen
 from tornado.concurrent import run_on_executor
 from traitlets import Unicode

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -158,12 +158,7 @@ class ResourceReflector(LoggingConfigurable):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Load kubernetes config here, since this is a Singleton and
-        # so this __init__ will be run way before anything else gets run.
-        try:
-            config.load_incluster_config()
-        except config.ConfigException:
-            config.load_kube_config()
+        # client configuration for kubernetes has already taken place
         self.api = shared_client(self.api_group_name)
 
         # FIXME: Protect against malicious labels?

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -254,7 +254,7 @@ class KubeSpawner(Spawner):
         In rare non-standard cases, such as using custom intermediate CA
         for your cluster, you may need to mount root CA's elsewhere in
         your Pod/Container and point this variable to that filepath
-        """
+        """,
     )
 
     k8s_api_host = Unicode(
@@ -265,7 +265,7 @@ class KubeSpawner(Spawner):
         
         Typically this is unnecessary, the hostname is picked up by 
         config.load_incluster_config() or config.load_kube_config.
-        """
+        """,
     )
 
     k8s_api_threadpool_workers = Integer(

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -23,6 +23,7 @@ from jupyterhub.traitlets import Command
 from jupyterhub.utils import exponential_backoff
 from kubernetes import client
 from kubernetes.client.rest import ApiException
+import kubernetes.config
 from slugify import slugify
 from tornado import gen
 from tornado.concurrent import run_on_executor
@@ -229,9 +230,9 @@ class KubeSpawner(Spawner):
         # Load kubernetes config here, since this is a Singleton and
         # so this __init__ will be run way before anything else gets run.
         try:
-            config.load_incluster_config()
-        except config.ConfigException:
-            config.load_kube_config()
+            kubernetes.config.load_incluster_config()
+        except kubernetes.config.ConfigException:
+            kubernetes.config.load_kube_config()
         if self.k8s_api_ssl_ca_cert:
             global_conf = client.Configuration.get_default_copy()
             global_conf.ssl_ca_cert = self.k8s_api_ssl_ca_cert

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -16,6 +16,7 @@ from functools import partial
 from urllib.parse import urlparse
 
 import escapism
+import kubernetes.config
 from jinja2 import BaseLoader
 from jinja2 import Environment
 from jupyterhub.spawner import Spawner
@@ -23,7 +24,6 @@ from jupyterhub.traitlets import Command
 from jupyterhub.utils import exponential_backoff
 from kubernetes import client
 from kubernetes.client.rest import ApiException
-import kubernetes.config
 from slugify import slugify
 from tornado import gen
 from tornado.concurrent import run_on_executor
@@ -199,7 +199,7 @@ class KubeSpawner(Spawner):
                     max_workers=self.k8s_api_threadpool_workers
                 )
 
-            # Set global kubernetes client configurations 
+            # Set global kubernetes client configurations
             # before reflector.py code runs
             self._set_k8s_client_configuration()
             self.api = shared_client('CoreV1Api')
@@ -209,8 +209,6 @@ class KubeSpawner(Spawner):
             self._start_watching_pods()
             if self.events_enabled:
                 self._start_watching_events()
-
-            
 
         # runs during both test and normal execution
         self.pod_name = self._expand_user_properties(self.pod_name_template)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -225,8 +225,12 @@ class KubeSpawner(Spawner):
             self.port = 8888
 
     def _set_k8s_client_configuration(self):
-        # Load kubernetes config here, since this is a Singleton and
-        # so this __init__ will be run way before anything else gets run.
+        # The actual (singleton) Kubernetes client will be created
+        # in clients.py shared_client but the configuration
+        # for token / ca_cert / k8s api host is set globally
+        # in kubernetes.py syntax.  It is being set here
+        # and this method called prior to shared_client
+        # for readability / coupling with traitlets values
         try:
             kubernetes.config.load_incluster_config()
         except kubernetes.config.ConfigException:


### PR DESCRIPTION
This is the first draft to fix https://github.com/jupyterhub/kubespawner/issues/492.  

- [x] Kubernetes client ssl_ca_cert configured with traitlets
- [x] Also included conf option for kubernetes client host
- [x] Documentation in the form of traitlet `help` strings
- [x] System tested, working in our cluster with z2jh (mounted root CA and `hub.config.KubeSpawner.k8s_api_ssl_ca_cert` in config.yaml)
- [x] `pytest`  60 passed, 12 skipped, 16 warnings on my dev environment
- [x] Adding this config logic to proxy.py -- @consideRatio you mentioned that was sort of a "parallel" effort to spawner.py but in the same project.  Does this need to be in there too?
- [x] Opinionated change -- calling `shared_client` from spawner.py before it is called in reflector.py.  I personally think that this is more intuitive, but totally understand if you want to keep it in reflector.py for historic/maintenance reasons I have missed.  
- [ ] Documentation in z2jh for mounting root CA's and setting `k8s_api_ssl_ca_cert` in config.yaml  

