### PR TITLE
Add MANIFEST.in (LICENCE, README.md)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md


### PR DESCRIPTION
The LICENSE file is missing from the [`pypi`](https://pypi.org/project/jupyterhub-kubespawner/#files) sdist. I think this should be sufficient to fix that.