### PR TITLE
add method and test to delete namespaced PVC in spawner base class

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2633,3 +2633,28 @@ class KubeSpawner(Spawner):
                 # It's fine if it already exists
                 self.log.exception("Failed to create namespace %s", self.namespace)
                 raise
+
+    async def delete_forever(self):
+        """Called when a user is deleted.
+
+        This can do things like request removal of resources such as persistent storage.
+        Only called on stopped spawners, and is likely the last action ever taken for the user.
+
+        This will only be called once on the user's default Spawner.
+        Supported by JupyterHub 1.4.0+.
+        """
+        try:
+            self.api.read_namespaced_persistent_volume_claim(
+                self.pvc_name, self.namespace
+            )
+        except ApiException as e:
+            if e.status == 404:
+                self.log.warning(
+                    "Could not delete %s. This PVC does not exist.", self.pvc_name
+                )
+            else:
+                raise
+        else:
+            self.api.delete_namespaced_persistent_volume_claim(
+                self.pvc_name, self.namespace
+            )

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -587,3 +587,53 @@ def test_get_pvc_manifest():
         "heritage": "jupyterhub",
     }
     assert manifest.spec.selector == {"matchLabels": {"user": "mock-5fname"}}
+
+
+@pytest.mark.asyncio
+async def test_delete_pvc(kube_ns, kube_client, hub, config):
+    config.KubeSpawner.storage_pvc_ensure = True
+    config.KubeSpawner.storage_capacity = '1M'
+
+    spawner = KubeSpawner(
+        hub=hub,
+        user=MockUser(name="mockuser"),
+        config=config,
+        _mock=True,
+    )
+    spawner.api = kube_client
+
+    # start the spawner
+    await spawner.start()
+
+    # verify the pod exists
+    pod_name = "jupyter-%s" % spawner.user.name
+    pods = kube_client.list_namespaced_pod(kube_ns).items
+    pod_names = [p.metadata.name for p in pods]
+    assert pod_name in pod_names
+
+    # verify PVC is created
+    pvc_name = spawner.pvc_name
+    pvc_list = kube_client.list_namespaced_persistent_volume_claim(kube_ns).items
+    pvc_names = [s.metadata.name for s in pvc_list]
+    assert pvc_name in pvc_names
+
+    # stop the pod
+    await spawner.stop()
+
+    # verify pod is gone
+    pods = kube_client.list_namespaced_pod(kube_ns).items
+    pod_names = [p.metadata.name for p in pods]
+    assert "jupyter-%s" % spawner.user.name not in pod_names
+
+    # delete the PVC
+    await spawner.delete_forever()
+
+    # verify PVC is deleted, it may take a little while
+    for i in range(5):
+        pvc_list = kube_client.list_namespaced_persistent_volume_claim(kube_ns).items
+        pvc_names = [s.metadata.name for s in pvc_list]
+        if pvc_name in pvc_names:
+            time.sleep(1)
+        else:
+            break
+    assert pvc_name not in pvc_names


### PR DESCRIPTION
**PR Summary by Erik**
This PR implements a delete_forever hook for KubeSpawner. The delete_forever hook will be respected by JupyterHub 1.4.0 and later and was implemented in jupyterhub/jupyterhub#3337. The idea of this hook is to allow the Spawners to perform cleanup of a users associated resources at the time a JupyterHub user is deleted.

As KubeSpawner can create PVCs for users, this KubeSpawner implementation checks for a PVC that it could have created for a user and tries to delete it. This behavior should be documented properly in the CHANGELOG.md for the next KubeSpawner release, I'm not sure if I think it would be labelled as a "breaking" change, but it is a change in the user experience that is quite important to be aware about.

This PR closes #446.

**Original PR message**
have tested with sqlite-pvc