### PR TITLE
Remove unneeded dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'test': [
             'bump2version',
             'flake8',
-            'jupyterhub-dummyauthenticator',
             'pytest>=5.4',
             'pytest-cov',
             'pytest-asyncio>=0.11.0',


### PR DESCRIPTION
It seems [`jupyterhub-dummyauthenticator`](https://github.com/jupyterhub/dummyauthenticator) may no longer be required?

![image](https://user-images.githubusercontent.com/881019/118334527-29036980-b551-11eb-9563-b5dded41b214.png)
