### PR TITLE
Sort env to reliably expand nested env references

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -450,7 +450,8 @@ def make_pod(
             return set()
         # $(MY_ENV) pattern: $( followed by non-)-characters to be captured, followed by )
         re_k8s_env_reference_pattern = r"\$\(([^\)]+)\)"
-        return set(re.findall(re_k8s_env_reference_pattern, env_var_obj.value))
+        deps = set(re.findall(re_k8s_env_reference_pattern, env_var_obj.value))
+        return deps - {env_var_obj.name}
 
     unsorted_env = {}
     for env_var_key, env_var_obj in (env or {}).items():

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -435,24 +435,82 @@ def make_pod(
     if not csc:
         csc = None
 
-    # Transform a dict into valid Kubernetes EnvVar Python representations. This
-    # representation shall always have a "name" field as well as either a
+    # Transform KubeSpawners env input to valid Kubernetes EnvVar Python
+    # representations. They should have a "name" field as well as either a
     # "value" field or "value_from" field. For examples see the
     # test_make_pod_with_env function.
-    prepared_env = []
-    for k, v in (env or {}).items():
-        if type(v) == dict:
-            if not "name" in v:
-                v["name"] = k
-            prepared_env.append(get_k8s_model(V1EnvVar, v))
+    #
+    # While doing this, also extract information about references to other envs
+    # as we want to use those to make an intelligent sorting before we render
+    # this into a list with an order that matters.
+    #
+    def _get_env_var_deps(env_var_obj):
+        # only env var objects with explicit string values set will be evaluated
+        if not env_var_obj.value:
+            return set()
+        # $(MY_ENV) pattern: $( followed by non-)-characters to be captured, followed by )
+        re_k8s_env_reference_pattern = r"\$\(([^\)]+)\)"
+        return set(re.findall(re_k8s_env_reference_pattern, env_var_obj.value))
+
+    unsorted_env = {}
+    for env_var_key, env_var_obj in (env or {}).items():
+        if type(env_var_obj) == dict:
+            if not "name" in env_var_obj:
+                env_var_obj["name"] = env_var_key
+            env_var_obj = get_k8s_model(V1EnvVar, env_var_obj)
         else:
-            prepared_env.append(V1EnvVar(name=k, value=v))
+            env_var_obj = V1EnvVar(name=env_var_key, value=env_var_obj)
+
+        unsorted_env[env_var_obj.name] = {
+            "deps": _get_env_var_deps(env_var_obj),
+            "env_var_key": env_var_key,
+            "env_var_obj": env_var_obj,
+        }
+
+    # We also want to sort environment variables in a way that allows
+    # dependencies to other env to resolve as much as possible. There could be
+    # circular dependencies so we will just do our best and settle with that.
+    #
+    # Algorithm description:
+    # - assumption: an env can depend on 0-X other env
+    # - init: unsorted_env = [<all-env>]
+    # - init: sorted_env = []
+    # - init: make dependencies for each env explicit
+    # - loop step:
+    #   - pop all unsorted_env entries with dependencies in sorted_env
+    #   - sort popped env and extend the sorted_env list
+    # - loop exit:
+    #   - exit if loop step didn't pop anything from unsorted_env
+    #   - then finish by sorting what remains and extending the sorted_env list
+    #
+    sorted_env = []
+    while True:
+        extracted_env = {}
+        resolved_env = [e.name for e in sorted_env]
+        for k, v in unsorted_env.copy().items():
+            if v["deps"].issubset(resolved_env):
+                extracted_env[k] = unsorted_env.pop(k)
+
+        extracted_env = [
+            d["env_var_obj"]
+            for d in sorted(extracted_env.values(), key=lambda d: d["env_var_key"])
+        ]
+        if extracted_env:
+            sorted_env.extend(extracted_env)
+        else:
+            remaining_env = [
+                d["env_var_obj"]
+                for d in sorted(unsorted_env.values(), key=lambda d: d["env_var_key"])
+            ]
+            sorted_env.extend(remaining_env)
+            break
+
     notebook_container = V1Container(
         name='notebook',
         image=image,
         working_dir=working_dir,
         ports=[V1ContainerPort(name='notebook-port', container_port=port)],
-        env=prepared_env,
+        env=sorted_env,
         args=cmd,
         image_pull_policy=image_pull_policy,
         lifecycle=lifecycle_hooks,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2165,18 +2165,18 @@ def test_make_pod_with_ssl():
                 {
                     "env": [
                         {
-                            'name': 'JUPYTERHUB_SSL_KEYFILE',
-                            'value': '/etc/jupyterhub/ssl/ssl.key',
-                        },
-                        {
                             'name': 'JUPYTERHUB_SSL_CERTFILE',
                             'value': '/etc/jupyterhub/ssl/ssl.crt',
                         },
-                        {'name': 'JUPYTERHUB_USER', 'value': 'TEST'},
                         {
                             'name': 'JUPYTERHUB_SSL_CLIENT_CA',
                             'value': '/etc/jupyterhub/ssl/notebooks-ca_trust.crt',
                         },
+                        {
+                            'name': 'JUPYTERHUB_SSL_KEYFILE',
+                            'value': '/etc/jupyterhub/ssl/ssl.key',
+                        },
+                        {'name': 'JUPYTERHUB_USER', 'value': 'TEST'},
                     ],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -776,6 +776,7 @@ def test_make_pod_with_env_dependency_sorted():
             name='test',
             image='jupyter/singleuser:latest',
             env={
+                'NAME_SELF_REF': '$(NAME_SELF_REF)',
                 'NAME_1B': '$(NAME_2)',
                 'NAME_1A': '$(NAME_2)',
                 'NAME_1C': {"name": "NAME_0", "value": "$(NAME_2)"},
@@ -807,6 +808,10 @@ def test_make_pod_with_env_dependency_sorted():
                         {
                             'name': 'NAME_3B',
                             'value': 'NAME_3B_VALUE',
+                        },
+                        {
+                            'name': 'NAME_SELF_REF',
+                            'value': '$(NAME_SELF_REF)',
                         },
                         {
                             'name': 'NAME_2',

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2113,79 +2113,6 @@ def test_make_ingress_external_name():
     }
 
 
-def test_make_pod_with_ssl():
-    """
-    Test specification of a pod with ssl enabled
-    """
-    assert api_client.sanitize_for_serialization(
-        make_pod(
-            name='ssl',
-            image='jupyter/singleuser:latest',
-            env={
-                'JUPYTERHUB_SSL_KEYFILE': 'TEST_VALUE',
-                'JUPYTERHUB_SSL_CERTFILE': 'TEST',
-                'JUPYTERHUB_USER': 'TEST',
-            },
-            working_dir='/',
-            cmd=['jupyterhub-singleuser'],
-            port=8888,
-            image_pull_policy='IfNotPresent',
-            ssl_secret_name='ssl',
-            ssl_secret_mount_path="/etc/jupyterhub/ssl/",
-        )
-    ) == {
-        "metadata": {
-            "name": "ssl",
-            "annotations": {},
-            "labels": {},
-        },
-        "spec": {
-            'automountServiceAccountToken': False,
-            "containers": [
-                {
-                    "env": [
-                        {
-                            'name': 'JUPYTERHUB_SSL_KEYFILE',
-                            'value': '/etc/jupyterhub/ssl/ssl.key',
-                        },
-                        {
-                            'name': 'JUPYTERHUB_SSL_CERTFILE',
-                            'value': '/etc/jupyterhub/ssl/ssl.crt',
-                        },
-                        {'name': 'JUPYTERHUB_USER', 'value': 'TEST'},
-                        {
-                            'name': 'JUPYTERHUB_SSL_CLIENT_CA',
-                            'value': '/etc/jupyterhub/ssl/notebooks-ca_trust.crt',
-                        },
-                    ],
-                    "name": "notebook",
-                    "image": "jupyter/singleuser:latest",
-                    "imagePullPolicy": "IfNotPresent",
-                    "args": ["jupyterhub-singleuser"],
-                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
-                    'volumeMounts': [
-                        {
-                            'mountPath': '/etc/jupyterhub/ssl/',
-                            'name': 'jupyterhub-internal-certs',
-                        }
-                    ],
-                    'workingDir': '/',
-                    "resources": {"limits": {}, "requests": {}},
-                }
-            ],
-            'restartPolicy': 'OnFailure',
-            'volumes': [
-                {
-                    'name': 'jupyterhub-internal-certs',
-                    'secret': {'defaultMode': 511, 'secretName': 'ssl'},
-                }
-            ],
-        },
-        "kind": "Pod",
-        "apiVersion": "v1",
-    }
-
-
 def test_make_namespace():
     labels = {
         'heritage': 'jupyterhub',
@@ -2276,24 +2203,4 @@ def test_make_pod_with_ssl():
         },
         "kind": "Pod",
         "apiVersion": "v1",
-    }
-
-
-def test_make_namespace():
-    labels = {
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
-    }
-    namespace = api_client.sanitize_for_serialization(
-        make_namespace(name='test-namespace', labels=labels)
-    )
-    assert namespace == {
-        'metadata': {
-            'annotations': {},
-            'labels': {
-                'component': 'singleuser-server',
-                'heritage': 'jupyterhub',
-            },
-            'name': 'test-namespace',
-        },
     }

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -675,8 +675,11 @@ def test_make_pod_with_env():
             name='test',
             image='jupyter/singleuser:latest',
             env={
-                'TEST_KEY_1': 'TEST_VALUE',
-                'TEST_KEY_2': {
+                'NAME_1': 'TEST_VALUE',
+                'NAME_2': {
+                    'value': 'TEST_VALUE',
+                },
+                'NAME_3': {
                     'valueFrom': {
                         'secretKeyRef': {
                             'name': 'my-k8s-secret',
@@ -684,8 +687,12 @@ def test_make_pod_with_env():
                         },
                     },
                 },
-                'TEST_KEY_NAME_IGNORED': {
-                    'name': 'TEST_KEY_3',
+                'IGNORED_NAME_1': {
+                    'name': 'NAME_4',
+                    'value': 'TEST_VALUE',
+                },
+                'IGNORED_NAME_2': {
+                    'name': 'NAME_5',
                     'valueFrom': {
                         'secretKeyRef': {
                             'name': 'my-k8s-secret',
@@ -710,11 +717,11 @@ def test_make_pod_with_env():
                 {
                     "env": [
                         {
-                            'name': 'TEST_KEY_1',
+                            'name': 'NAME_4',
                             'value': 'TEST_VALUE',
                         },
                         {
-                            'name': 'TEST_KEY_2',
+                            'name': 'NAME_5',
                             'valueFrom': {
                                 'secretKeyRef': {
                                     'name': 'my-k8s-secret',
@@ -723,13 +730,107 @@ def test_make_pod_with_env():
                             },
                         },
                         {
-                            'name': 'TEST_KEY_3',
+                            'name': 'NAME_1',
+                            'value': 'TEST_VALUE',
+                        },
+                        {
+                            'name': 'NAME_2',
+                            'value': 'TEST_VALUE',
+                        },
+                        {
+                            'name': 'NAME_3',
                             'valueFrom': {
                                 'secretKeyRef': {
                                     'name': 'my-k8s-secret',
                                     'key': 'password',
                                 },
                             },
+                        },
+                    ],
+                    "name": "notebook",
+                    "image": "jupyter/singleuser:latest",
+                    "imagePullPolicy": "IfNotPresent",
+                    "args": ["jupyterhub-singleuser"],
+                    "ports": [{"name": "notebook-port", "containerPort": 8888}],
+                    'volumeMounts': [],
+                    "resources": {"limits": {}, "requests": {}},
+                }
+            ],
+            'restartPolicy': 'OnFailure',
+            'volumes': [],
+        },
+        "kind": "Pod",
+        "apiVersion": "v1",
+    }
+
+
+def test_make_pod_with_env_dependency_sorted():
+    """
+    Test specification of a pod with custom environment variables that involve
+    references to other environment variables. Note that KubeSpawner also tries
+    to sort the environment variables in the rendered list in a way that helps
+    maximize the amount of variables that are resolved.
+    """
+    assert api_client.sanitize_for_serialization(
+        make_pod(
+            name='test',
+            image='jupyter/singleuser:latest',
+            env={
+                'NAME_1B': '$(NAME_2)',
+                'NAME_1A': '$(NAME_2)',
+                'NAME_1C': {"name": "NAME_0", "value": "$(NAME_2)"},
+                'NAME_2': '$(NAME_3A)',
+                'NAME_3B': 'NAME_3B_VALUE',
+                'NAME_3A': 'NAME_3A_VALUE',
+                'NAME_CIRCLE_B': '$(NAME_CIRCLE_A)',
+                'NAME_CIRCLE_A': '$(NAME_CIRCLE_B)',
+            },
+            cmd=['jupyterhub-singleuser'],
+            port=8888,
+            image_pull_policy='IfNotPresent',
+        )
+    ) == {
+        "metadata": {
+            "name": "test",
+            "annotations": {},
+            "labels": {},
+        },
+        "spec": {
+            'automountServiceAccountToken': False,
+            "containers": [
+                {
+                    "env": [
+                        {
+                            'name': 'NAME_3A',
+                            'value': 'NAME_3A_VALUE',
+                        },
+                        {
+                            'name': 'NAME_3B',
+                            'value': 'NAME_3B_VALUE',
+                        },
+                        {
+                            'name': 'NAME_2',
+                            'value': '$(NAME_3A)',
+                        },
+                        {
+                            'name': 'NAME_1A',
+                            'value': '$(NAME_2)',
+                        },
+                        {
+                            'name': 'NAME_1B',
+                            'value': '$(NAME_2)',
+                        },
+                        {
+                            'name': 'NAME_0',
+                            'value': '$(NAME_2)',
+                        },
+                        {
+                            'name': 'NAME_CIRCLE_A',
+                            'value': '$(NAME_CIRCLE_B)',
+                        },
+                        {
+                            'name': 'NAME_CIRCLE_B',
+                            'value': '$(NAME_CIRCLE_A)',
                         },
                     ],
                     "name": "notebook",


### PR DESCRIPTION
KubeSpawner exposes a dictionary as configuration of environment variables, but a k8s container specification contain an ordered list where the order actually matters.

### How the order matters

If an environment variable is set to be a string that contains `$(SOME_ENV)`, it will be expanded if `SOME_ENV` has been defined earlier in the ordered list in the container specification.

### What this PR does

This PR makes KubeSpawner emit the container's environment list in a way that first and foremost ensures as many environment variables are expanded as possible.

### Is this a breaking change?

In a way yes, but I think most users will think of it as a bugfix - that the changed behavior will always be appreciated.

### Related

- https://github.com/jupyterhub/kubespawner/issues/491
- https://github.com/2i2c-org/pilot-hubs/issues/442