### PR TITLE
Fix race condition between spawn() calling _start() and progress()

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2105,7 +2105,7 @@ class KubeSpawner(Spawner):
             return
 
         self.log.debug('progress generator: %s', self.pod_name)
-        start_future = None
+        start_future = self._start_future
         progress = 0
         next_event = 0
 
@@ -2116,7 +2116,7 @@ class KubeSpawner(Spawner):
             # progress() will be invoked via self.start(), so what happen first?
             # Due to this, the logic below is to avoid making an assumption that
             # self._start_future was set before this function was called.
-            if start_future == None and self._start_future:
+            if start_future is None and self._start_future:
                 start_future = self._start_future
 
             # Ensure we capture all events by inspecting events a final time


### PR DESCRIPTION
This PR is meant to fix a race condition I observe from time to time. It causes a progress() call to error when it does, of which the implication I'm not confident about.

```
[E 2021-05-31 09:45:36.620 JupyterHub web:1789] Uncaught exception GET /hub/api/users/my-user/server/progress (62.168.159.182)
    HTTPServerRequest(protocol='https', host='hub.example.com', method='GET', uri='/hub/api/users/my-user/server/progress', version='HTTP/1.1', remote_ip='62.168.159.182')
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/dist-packages/tornado/web.py", line 1704, in _execute
        result = await result
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/apihandlers/users.py", line 661, in get
        async for event in events:
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/utils.py", line 545, in iterate_until
        yield item_future.result()
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/spawner.py", line 1068, in _generate_progress
        async for event in progress:
      File "/usr/local/lib/python3.8/dist-packages/kubespawner/spawner.py", line 2108, in progress
        start_future = self._start_future
    AttributeError: 'KubeSpawner' object has no attribute '_start_future'
```

## Review questions

Can we make sure self._start_future is set with a reference first, and then trigger the execution to avoid the risk of a race condition all together?

If not, do we need to add a failsafe to ensure we won't loop for eternity if for example _start() is called twice in less time than 1 second and self._start_future would be overridden or similarly. Hmmm...

## Update

I think I didn't understand this correctly. I know that I experience this issue when my pre_spawn_hook is slow, and this logic in the Spawner base class i observe that when `spawn()` is called then the pre_spawn_hook is called before the `start()` function. So I assume the order of events are...

1. spawner.spawn()
1. spawner.run_pre_spawn_hook()
1. spawner.start()

See [this code](https://github.com/jupyterhub/jupyterhub/blob/05f47b14f323f8a0d3a79aabbb336a450dc4aee3/jupyterhub/user.py#L626-L632) for details.

Where does the user get redirected to the spawn progress route, which in turn end up requesting information about the pending spawn? It must be before `spawner.run_pre_spawn_hook()` based on my interpretation of what I observe.

## Related code

https://github.com/jupyterhub/jupyterhub/blob/046df41f04ea0c38b87701a9476c026f00fa55c0/jupyterhub/spawner.py#L1070-L1085

https://github.com/jupyterhub/jupyterhub/blob/046df41f04ea0c38b87701a9476c026f00fa55c0/jupyterhub/apihandlers/users.py#L660-L671

## New idea

We use the state in `self._spawn_pending` like done in [`_generate_process()`](https://github.com/jupyterhub/jupyterhub/blob/046df41f04ea0c38b87701a9476c026f00fa55c0/jupyterhub/spawner.py#L1070-L1085). That state can help us try to set the _start_future asap