### PR TITLE
Generalize omit_namespace functionality

### DIFF
--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -20,7 +20,6 @@ from .utils import generate_hashed_slug
 
 class IngressReflector(ResourceReflector):
     kind = 'ingresses'
-    list_method_name = 'list_namespaced_ingress'
     api_group_name = 'ExtensionsV1beta1Api'
 
     @property
@@ -30,7 +29,6 @@ class IngressReflector(ResourceReflector):
 
 class ServiceReflector(ResourceReflector):
     kind = 'services'
-    list_method_name = 'list_namespaced_service'
 
     @property
     def services(self):
@@ -39,7 +37,6 @@ class ServiceReflector(ResourceReflector):
 
 class EndpointsReflector(ResourceReflector):
     kind = 'endpoints'
-    list_method_name = 'list_namespaced_endpoints'
 
     @property
     def endpoints(self):

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -179,22 +179,23 @@ class ResourceReflector(LoggingConfigurable):
         #  their __init__() methods to derive list_method_name, but you
         #  could just set it directly in the subclass.
         if not self.list_method_name:
-            # This logic can be extended if we add other reflector types or
-            #  it can be directly supplied or overridden in a subclass.
-            if self.kind in ["pods", "events", "services", "ingresses", "endpoints"]:
-                if self.kind == "ingresses":
-                    singular_kind = "ingress"
-                if self.kind == "endpoints":
-                    # This handles inconsistent nomenclature in the
-                    # Python Kubernetes client.
-                    singular_kind = self.kind
-                else:
-                    singular_kind = self.kind[:-1]
+            plural_to_singular = {
+                "endpoints": "endpoints",
+                "events": "event",
+                "ingresses": "ingress",
+                "pods": "pod",
+                "services": "service",
+            }
 
+            if self.kind in plural_to_singular:
                 if self.omit_namespace:
-                    self.list_method_name = f"list_{singular_kind}_for_all_namespaces"
+                    self.list_method_name = (
+                        f"list_{plural_to_singular[self.kind]}_for_all_namespaces"
+                    )
                 else:
-                    self.list_method_name = f"list_namespaced_{singular_kind}"
+                    self.list_method_name = (
+                        f"list_namespaced_{plural_to_singular[self.kind]}"
+                    )
 
         # Make sure we have the required values.
         if not self.kind:

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -184,6 +184,10 @@ class ResourceReflector(LoggingConfigurable):
             if self.kind in ["pods", "events", "services", "ingresses", "endpoints"]:
                 if self.kind == "ingresses":
                     singular_kind = "ingress"
+                if self.kind == "endpoints":
+                    # This handles inconsistent nomenclature in the
+                    # Python Kubernetes client.
+                    singular_kind = self.kind
                 else:
                     singular_kind = self.kind[:-1]
 

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -182,9 +182,10 @@ class ResourceReflector(LoggingConfigurable):
             # This logic can be extended if we add other reflector types or
             #  it can be directly supplied or overridden in a subclass.
             if self.kind in ["pods", "events", "services", "ingresses", "endpoints"]:
-                singular_kind = self.kind[:-1]
                 if self.kind == "ingresses":
-                    singular_kind = self.kind[:-2]
+                    singular_kind = "ingress"
+                else:
+                    singular_kind = self.kind[:-1]
 
                 if self.omit_namespace:
                     self.list_method_name = f"list_{singular_kind}_for_all_namespaces"

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -172,26 +172,24 @@ class ResourceReflector(LoggingConfigurable):
         self.first_load_future = Future()
         self._stop_event = threading.Event()
 
-        # Make sure that we know kind, whether we should omit the namespace,
-        #  and what our list_method_name is.  For the things we already
-        #  know about (that is, Pod and Event reflectors) we can derive
-        #  list_method_name from those two things.  New reflector types
-        #  should also update their __init__() methods to derive
-        #  list_method_name, but you could just set it directly in the
-        #  subclass.
+        # Make sure that we know kind, whether we should omit the
+        #  namespace, and what our list_method_name is.  For the things
+        #  we already know about, we can derive list_method_name from
+        #  those two things.  New reflector types should also update
+        #  their __init__() methods to derive list_method_name, but you
+        #  could just set it directly in the subclass.
         if not self.list_method_name:
             # This logic can be extended if we add other reflector types or
             #  it can be directly supplied or overridden in a subclass.
-            if self.kind == "pods":
+            if self.kind in ["pods", "events", "services", "ingresses", "endpoints"]:
+                singular_kind = self.kind[:-1]
+                if self.kind == "ingresses":
+                    singular_kind = self.kind[:-2]
+
                 if self.omit_namespace:
-                    self.list_method_name = "list_pod_for_all_namespaces"
+                    self.list_method_name = f"list_{singular_kind}_for_all_namespaces"
                 else:
-                    self.list_method_name = "list_namespaced_pod"
-            elif self.kind == "events":
-                if self.omit_namespace:
-                    self.list_method_name = "list_event_for_all_namespaces"
-                else:
-                    self.list_method_name = "list_namespaced_event"
+                    self.list_method_name = f"list_namespaced_{singular_kind}"
 
         # Make sure we have the required values.
         if not self.kind:


### PR DESCRIPTION
This PR generalizes the `omit_namespace` functionality leveraged by `pods` and `events` and leverages it for `services`, `ingresses`, and `endpoints`. 

We're altering our deployment to leverage user-scoped namespaces and found that this was required in our ingress proxy subclasses, but I think it may be useful enough to implement in the base. 

Totally open to feedback. 