### PR TITLE
Terminate process correctly from reflector thread

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -11,6 +11,7 @@ import multiprocessing
 import os
 import string
 import sys
+import signal
 import warnings
 from asyncio import sleep
 from concurrent.futures import ThreadPoolExecutor
@@ -1927,7 +1928,10 @@ class KubeSpawner(Spawner):
                 "%s reflector failed, halting Hub.",
                 key.title(),
             )
-            sys.exit(1)
+            # This won't be called from the main thread, so sys.exit
+            # will only kill current thread - not process.
+            # https://stackoverflow.com/a/7099229
+            os.kill(os.getpid(), signal.SIGINT)
 
         previous_reflector = self.__class__.reflectors.get(key)
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -9,9 +9,9 @@ import asyncio
 import json
 import multiprocessing
 import os
+import signal
 import string
 import sys
-import signal
 import warnings
 from asyncio import sleep
 from concurrent.futures import ThreadPoolExecutor


### PR DESCRIPTION
Our reflectors run on their own thread, and sys.exit() from
a thread does not actually exit the process - just the thread.
When the reflector has to shut down because it can not talk
to the k8s master anymore for a while, we had just been stopping
the reflector thread and doing nothing else.

This will instead actually cause the hub to stop, and in z2jh
restart - which seems the right thing to do.

Ref https://github.com/2i2c-org/pilot-hubs/issues/680,
where we encountered this during a period of time when the
k8s master was unreachable for about 1 minute.