### PR TITLE
Warn about cli args being ignored when KubeSpawner.cmd is not set

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1861,7 +1861,7 @@ class KubeSpawner(Spawner):
             real_cmd = self.cmd + args
         elif args:
             self.log.warning(
-                f"Ignoring argumetns when using implicit command from image: {args}."
+                f"Ignoring arguments when using implicit command from image: {args}."
                 " Set KubeSpawner.cmd explicitly to support passing cli arguments."
             )
 


### PR DESCRIPTION
Behavior is unchanged, but this ensures an informative log message when there are cli args being ignored.

Mentioned [here](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2386#issuecomment-926419467)