### PR TITLE
docs: require sphinx >=2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ autodoc_traits
 pyyaml
 recommonmark==0.4.0
 setuptools
-sphinx>=1.7,<4
+sphinx>=2,<4
 sphinx-copybutton
 sphinx_rtd_theme
 traitlets>=4.1


### PR DESCRIPTION
I think this is required for RTD to build properly. I'm not sure if the RTD build system will react to the change until this is merged though.

Oh, all good - going for a self-merge to fix our broken docs build.