### PR TITLE
Wait 0.1s between events, not 1s

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2214,7 +2214,8 @@ class KubeSpawner(Spawner):
 
             if break_while_loop:
                 break
-            await asyncio.sleep(1)
+            # Check for new events every 0.1s
+            await asyncio.sleep(0.1)
 
     def _start_reflector(
         self,


### PR DESCRIPTION
Given that each pod spawn seems to take at least 5 events,
this meant each user start took *at least* 5 seconds, even if
the pod actually started up much much faster! This affects UX
a bit, as the hub seems 'slower' to users than it really is.