### PR TITLE
Add underscore prefix to private functions: `safe_name_for_routespec` and `delete_if_exists`

### DIFF
--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -179,7 +179,7 @@ class KubeIngressProxy(Proxy):
         )
         return safe_name
 
-    async def delete_if_exists(self, kind, safe_name, future):
+    async def _delete_if_exists(self, kind, safe_name, future):
         try:
             await future
             self.log.info('Deleted %s/%s', kind, safe_name)
@@ -241,7 +241,7 @@ class KubeIngressProxy(Proxy):
                 namespace=self.namespace,
                 body=client.V1DeleteOptions(grace_period_seconds=0),
             )
-            await self.delete_if_exists('endpoint', safe_name, delete_endpoint)
+            await self._delete_if_exists('endpoint', safe_name, delete_endpoint)
 
         await ensure_object(
             self.core_api.create_namespaced_service,
@@ -306,9 +306,9 @@ class KubeIngressProxy(Proxy):
         # foreground cascading deletion (https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#foreground-cascading-deletion)
         # instead, but for now this works well enough.
         await asyncio.gather(
-            self.delete_if_exists('endpoint', safe_name, delete_endpoint),
-            self.delete_if_exists('service', safe_name, delete_service),
-            self.delete_if_exists('ingress', safe_name, delete_ingress),
+            self._delete_if_exists('endpoint', safe_name, delete_endpoint),
+            self._delete_if_exists('service', safe_name, delete_service),
+            self._delete_if_exists('ingress', safe_name, delete_ingress),
         )
 
     @_await_async_init

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -170,7 +170,7 @@ class KubeIngressProxy(Proxy):
 
         return async_method
 
-    def safe_name_for_routespec(self, routespec):
+    def _safe_name_for_routespec(self, routespec):
         safe_chars = set(string.ascii_lowercase + string.digits)
         safe_name = generate_hashed_slug(
             'jupyter-'
@@ -194,7 +194,7 @@ class KubeIngressProxy(Proxy):
         # Use full routespec in label
         # 'data' is JSON encoded and put in an annotation - we don't need to query for it
 
-        safe_name = self.safe_name_for_routespec(routespec).lower()
+        safe_name = self._safe_name_for_routespec(routespec).lower()
         labels = {
             'heritage': 'jupyterhub',
             'component': self.component_label,
@@ -275,7 +275,7 @@ class KubeIngressProxy(Proxy):
         # This means if some of them are already deleted, we just let it
         # be.
 
-        safe_name = self.safe_name_for_routespec(routespec).lower()
+        safe_name = self._safe_name_for_routespec(routespec).lower()
 
         delete_options = client.V1DeleteOptions(grace_period_seconds=0)
 


### PR DESCRIPTION
Closes #570.

These functions are not overriding a function in a base class right? Also, they are actually supposed to be private, right?

I was considering what functions JupyterHub would call on KubeSpawner and concluded that I wasn't sure what was overriding Spawner functions and what was new private helper functions in KubeSpawner etc. This kind of change would benefit such understanding. It also risks breaking someone that has developed some advanced tweaks to KubeSpawner.