### PR TITLE
Followup to kubernetes_asyncio transition change

### DIFF
--- a/kubespawner/clients.py
+++ b/kubespawner/clients.py
@@ -68,8 +68,18 @@ async def load_config(caller):
     KubeIngressProxy both have these attributes.
     """
     try:
+        # This attempts to load configuration available within k8s Pod's
+        # containers with a mounted service account.
         kubernetes_asyncio.config.load_incluster_config()
     except kubernetes_asyncio.config.ConfigException:
+        # This attempts to load kubernetes client configuration and credentials
+        # to an api-server in a similar way as `kubectl` on your computer would
+        # do which is relevant if KubeSpawner runs from outside a k8s cluster.
+        #
+        # There seems to be a need for this to be async that relates to
+        # acquiring credentials via credential helpers as can be inspected here:
+        # https://github.com/tomplus/kubernetes_asyncio/blob/c88b3b9c78a9388ef3af00858b8c516b84b0bf30/kubernetes_asyncio/config/kube_config.py#L183-L195
+        #
         await kubernetes_asyncio.config.load_kube_config()
 
     if caller.k8s_api_ssl_ca_cert:


### PR DESCRIPTION
I wanted to ensure that JupyterHub wouldn't end up erroring by using a KubeSpawner object that wasn't fully initialized after a trick was introduced in #563 to ensure we await initialization logic that couldn't be awaited in `__init__`.

This PR is inspired by a more thorough inspection of what JupyterHub actually does against a Spawner object, as documented in https://github.com/jupyterhub/kubespawner/pull/563#discussion_r811498699.

I'm mainly concerned about this PR reduce performance by decorating `progress()` which may be called quite often.