### PR TITLE
Replace recommonmark with myst_parser and fix changelog rendering

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,9 @@
 autodoc_traits
-myst-parser==0.17.0
+myst-parser>=0.17.0
 pyyaml
 setuptools
-sphinx>=4.2.0,<5
+# sphinx 4.2+ is required to be compatible with Python 3.10
+sphinx>=4.2,<5
 sphinx-copybutton
 sphinx_rtd_theme
 traitlets>=4.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
 autodoc_traits
+myst-parser==0.17.0
 pyyaml
 setuptools
 sphinx>=4.2.0,<5
 sphinx-copybutton
 sphinx_rtd_theme
 traitlets>=4.1
-myst-parser==0.17.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
 autodoc_traits
 pyyaml
-recommonmark==0.4.0
 setuptools
-sphinx>=2,<4
+sphinx>=4.2.0,<5
 sphinx-copybutton
 sphinx_rtd_theme
 traitlets>=4.1
+myst-parser==0.17.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,6 @@ import os
 import sys
 from os.path import dirname
 
-import recommonmark.parser
-
 # For conversion from markdown to html
 # set paths
 docs = dirname(dirname(__file__))
@@ -43,6 +41,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'autodoc_traits',
+	'myst_parser'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -50,13 +49,6 @@ templates_path = ['_templates']
 
 # Set the default role so we can use `foo` instead of ``foo``
 default_role = 'literal'
-
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-
-source_parsers = {
-    '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # source_suffix = ['.rst', '.md']
 source_suffix = ['.rst', '.md']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'autodoc_traits',
-	'myst_parser'
+    'myst_parser',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1306,7 +1306,7 @@ class KubeSpawner(Spawner):
         on a node with the corresponding taints. See the official Kubernetes documentation for additional details
         https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 
-        Pass this field an array of `"Toleration" objects
+        Pass this field an array of "Toleration" objects
         * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
 
         Example::


### PR DESCRIPTION
There are some issues with the docs hosted at https://jupyterhub-kubespawner.readthedocs.io/en/2.0.1/changelog.html , some of which are reported in #527 . I think they are in part due to issues with recommonmark, which has been discontinued in favor of myst-parser (https://github.com/readthedocs/recommonmark/issues/221).
I also bumped the sphinx version to >=4.2 as versions below don't work with python 3.10 (see https://github.com/sphinx-doc/sphinx/pull/9513 )

This PR aims to fix those issues.
PS. the page on RTD still points to 1.1.1 for `latest`, I don't know if that's intended 

---

EDIT 1 by Erik: Closes #527, Closes #555
EDIT 2 by Erik: This doesn't resolve an upstream issue when our anchors are numeric though, but let's track that as part of https://github.com/executablebooks/MyST-Parser/issues/527.