### PR TITLE
Fix typo in reflector._stopping

### DIFF
--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -333,7 +333,7 @@ class ResourceReflector(LoggingConfigurable):
                         else:
                             # This is an atomic operation on the dictionary!
                             self.resources[ref_key] = resource
-                        if self._stopped:
+                        if self._stopping:
                             self.log.info("%s watcher stopped: inner", self.kind)
                             break
                         watch_duration = time.monotonic() - start


### PR DESCRIPTION
private attribute for whether a reflector is stopping is called `_stopping` not `_stopped`. `_stopping` is [declared](https://github.com/jupyterhub/kubespawner/blob/a93cef46e1a3847c42a7a39a2ec2f7e7b0b5c28f/kubespawner/reflector.py#L166) at the class level and can never be undefined.

closes #585