### PR TITLE
[KubeIngressProxy] Migrate to networking.k8s.io/v1 api for Ingress resources

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
         include:
           # Tests with oldest supported Python, k8s, and k8s client
           - python: "3.7"
-            k3s: v1.17
+            k3s: v1.20
             test_dependencies: kubernetes_asyncio==19.*
 
           # Test with modern python and k8s versions

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -15,6 +15,13 @@ from kubernetes_asyncio.client.models import V1EndpointAddress
 from kubernetes_asyncio.client.models import V1Endpoints
 from kubernetes_asyncio.client.models import V1EndpointSubset
 from kubernetes_asyncio.client.models import V1EnvVar
+from kubernetes_asyncio.client.models import V1HTTPIngressPath
+from kubernetes_asyncio.client.models import V1HTTPIngressRuleValue
+from kubernetes_asyncio.client.models import V1Ingress
+from kubernetes_asyncio.client.models import V1IngressBackend
+from kubernetes_asyncio.client.models import V1IngressRule
+from kubernetes_asyncio.client.models import V1IngressServiceBackend
+from kubernetes_asyncio.client.models import V1IngressSpec
 from kubernetes_asyncio.client.models import V1Lifecycle
 from kubernetes_asyncio.client.models import V1LocalObjectReference
 from kubernetes_asyncio.client.models import V1Namespace
@@ -33,6 +40,7 @@ from kubernetes_asyncio.client.models import V1PreferredSchedulingTerm
 from kubernetes_asyncio.client.models import V1ResourceRequirements
 from kubernetes_asyncio.client.models import V1Secret
 from kubernetes_asyncio.client.models import V1Service
+from kubernetes_asyncio.client.models import V1ServiceBackendPort
 from kubernetes_asyncio.client.models import V1ServicePort
 from kubernetes_asyncio.client.models import V1ServiceSpec
 from kubernetes_asyncio.client.models import V1Toleration
@@ -722,42 +730,6 @@ def make_ingress(name, routespec, target, labels, data):
     """
     Returns an ingress, service, endpoint object that'll work for this service
     """
-
-    # move beta imports here,
-    # which are more sensitive to kubernetes version
-    # and will change when they move out of beta
-    # because of the API changes in 1.16, the import is tried conditionally
-    # to keep compatibility with older K8S versions
-
-    try:
-        from kubernetes_asyncio.client.models import (
-            ExtensionsV1beta1HTTPIngressPath,
-            ExtensionsV1beta1HTTPIngressRuleValue,
-            ExtensionsV1beta1Ingress,
-            ExtensionsV1beta1IngressBackend,
-            ExtensionsV1beta1IngressRule,
-            ExtensionsV1beta1IngressSpec,
-        )
-    except ImportError:
-        from kubernetes_asyncio.client.models import (
-            V1beta1HTTPIngressPath as ExtensionsV1beta1HTTPIngressPath,
-        )
-        from kubernetes_asyncio.client.models import (
-            V1beta1HTTPIngressRuleValue as ExtensionsV1beta1HTTPIngressRuleValue,
-        )
-        from kubernetes_asyncio.client.models import (
-            V1beta1Ingress as ExtensionsV1beta1Ingress,
-        )
-        from kubernetes_asyncio.client.models import (
-            V1beta1IngressBackend as ExtensionsV1beta1IngressBackend,
-        )
-        from kubernetes_asyncio.client.models import (
-            V1beta1IngressRule as ExtensionsV1beta1IngressRule,
-        )
-        from kubernetes_asyncio.client.models import (
-            V1beta1IngressSpec as ExtensionsV1beta1IngressSpec,
-        )
-
     meta = V1ObjectMeta(
         name=name,
         annotations={
@@ -823,20 +795,25 @@ def make_ingress(name, routespec, target, labels, data):
         )
 
     # Make Ingress object
-    ingress = ExtensionsV1beta1Ingress(
+    ingress = V1Ingress(
         kind='Ingress',
         metadata=meta,
-        spec=ExtensionsV1beta1IngressSpec(
+        spec=V1IngressSpec(
             rules=[
-                ExtensionsV1beta1IngressRule(
+                V1IngressRule(
                     host=host,
-                    http=ExtensionsV1beta1HTTPIngressRuleValue(
+                    http=V1HTTPIngressRuleValue(
                         paths=[
-                            ExtensionsV1beta1HTTPIngressPath(
+                            V1HTTPIngressPath(
                                 path=path,
-                                backend=ExtensionsV1beta1IngressBackend(
-                                    service_name=name,
-                                    service_port=target_port,
+                                path_type="Prefix",
+                                backend=V1IngressBackend(
+                                    service=V1IngressServiceBackend(
+                                        name=name,
+                                        port=V1ServiceBackendPort(
+                                            number=target_port,
+                                        ),
+                                    ),
                                 ),
                             )
                         ]

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -18,7 +18,7 @@ from .utils import generate_hashed_slug
 
 class IngressReflector(ResourceReflector):
     kind = 'ingresses'
-    api_group_name = 'ExtensionsV1beta1Api'
+    api_group_name = 'NetworkingV1Api'
 
     @property
     def ingresses(self):
@@ -190,7 +190,7 @@ class KubeIngressProxy(Proxy):
         super().__init__(*args, **kwargs)
         load_config(host=self.k8s_api_host, ssl_ca_cert=self.k8s_api_ssl_ca_cert)
         self.core_api = shared_client('CoreV1Api')
-        self.extension_api = shared_client('ExtensionsV1beta1Api')
+        self.networking_api = shared_client('NetworkingV1Api')
 
         labels = {
             'component': self.component_label,
@@ -301,8 +301,8 @@ class KubeIngressProxy(Proxy):
         )
 
         await ensure_object(
-            self.extension_api.create_namespaced_ingress,
-            self.extension_api.patch_namespaced_ingress,
+            self.networking_api.create_namespaced_ingress,
+            self.networking_api.patch_namespaced_ingress,
             body=ingress,
             kind='ingress',
         )
@@ -334,7 +334,7 @@ class KubeIngressProxy(Proxy):
             body=delete_options,
         )
 
-        delete_ingress = await self.extension_api.delete_namespaced_ingress(
+        delete_ingress = await self.networking_api.delete_namespaced_ingress(
             name=safe_name,
             namespace=self.namespace,
             body=delete_options,

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -120,8 +120,8 @@ class ResourceReflector(LoggingConfigurable):
         Name of class that represents the apigroup on which
         `list_method_name` is to be found.
 
-        Defaults to CoreV1Api, which has everything in the 'core' API group. If you want to watch Ingresses,
-        for example, you would have to use ExtensionsV1beta1Api
+        Defaults to CoreV1Api, which has everything in the 'core' API group. If
+        you want to watch Ingresses you would have to use NetworkingV1Api.
         """,
     )
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -11,8 +11,8 @@ async def test_shared_client():
     core = shared_client("CoreV1Api")
     core2 = shared_client("CoreV1Api")
     assert core2 is core
-    ext = shared_client("ExtensionsV1beta1Api")
-    ext2 = shared_client("ExtensionsV1beta1Api")
+    ext = shared_client("NetworkingV1Api")
+    ext2 = shared_client("NetworkingV1Api")
     assert ext is ext2
     assert ext is not core
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2063,10 +2063,15 @@ def test_make_ingress(target, ip):
                         'paths': [
                             {
                                 'backend': {
-                                    'serviceName': 'jupyter-test',
-                                    'servicePort': 9000,
+                                    'service': {
+                                        'name': 'jupyter-test',
+                                        'port': {
+                                            'number': 9000,
+                                        },
+                                    },
                                 },
                                 'path': '/my-path',
+                                'pathType': 'Prefix',
                             }
                         ]
                     }
@@ -2141,10 +2146,15 @@ def test_make_ingress_external_name():
                         'paths': [
                             {
                                 'backend': {
-                                    'serviceName': 'jupyter-test',
-                                    'servicePort': 9000,
+                                    'service': {
+                                        'name': 'jupyter-test',
+                                        'port': {
+                                            'number': 9000,
+                                        },
+                                    },
                                 },
                                 'path': '/my-path',
+                                'pathType': 'Prefix',
                             }
                         ]
                     }


### PR DESCRIPTION
Closes #597. With the latest release of kubernetes_asyncio version 22 (mapping to k8s 1.22), we had a failure related to outdated k8s API references extensions/v1beta1. This PR makes KubeIngressProxy generate Ingress resources assuming the networking/v1 API  for Ingress resources instead.

Someone installing KubeSpawner 3.0.3 that includes this PR for KubeIngressProxy should clean up all the old Ingress resources for user servers, because they will be orphaned going onwards and could cause collisions etc. I encourage people using KubeIngressProxy to help out documenting more detailed migration steps etc - for example as comments in this PR as it will be linked from the changelog.

This pr should be merged after #599 I think, which it currently includes as well.