### PR TITLE
ci: stop testinging 1.17-1.19, assume k8s 1.20+ going onwards

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
         include:
           # Tests with oldest supported Python, k8s, and k8s client
           - python: "3.7"
-            k3s: v1.17
+            k3s: v1.20
             test_dependencies: kubernetes_asyncio==19.*
 
           # Test with modern python and k8s versions


### PR DESCRIPTION
While KubeSpawner 3 supports k8s 1.17-1.19, I'd like to actively stop tests of:
- k8s 1.17-1.18 as those don't include networking.k8s.io/v1 and would cause problems with resolving #598 that has shown up for KubeIngressProxy
- k8s 1.19 as it is no longer supported by cloud providers as discussed in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2591

Due to that, I'd like to drop testing of k8s 1.17-1.19 and rely on tests for k8s 1.20+.

---

My plan is to cut a 3.0.3 release that include a KubeIngressProxy fix for kubernetes_asyncio v22 along with an update to KuberSpawner 3.0.0 release note - adding an post-release edit note - saying that it may work with k8s 1.17-1.19, but use of KubeSpawner 3 should be for k8s clusters 1.20+.