### PR TITLE
Add name to service port for Istio support

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -940,7 +940,7 @@ def make_service(
         metadata=metadata,
         spec=V1ServiceSpec(
             type='ClusterIP',
-            ports=[V1ServicePort(port=port, target_port=port)],
+            ports=[V1ServicePort(name='http', port=port, target_port=port)],
             selector={
                 'component': 'singleuser-server',
                 'hub.jupyter.org/servername': servername,


### PR DESCRIPTION
Istio treats all traffic as TCP if the service port name does not start with a protocol. This PR adds a name to the port with the proper protocol.