### PR TITLE
properly handle IPv6 IPs

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1937,7 +1937,7 @@ class KubeSpawner(Spawner):
             hostname = pod["status"]["podIP"]
             if type(ipaddress.ip_address(hostname)) == ipaddress.IPv6Address:
                 hostname = f"[{hostname}]"
-            
+
         if self.pod_connect_ip:
             hostname = ".".join(
                 [

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1935,7 +1935,7 @@ class KubeSpawner(Spawner):
         else:
             proto = "http"
             hostname = pod["status"]["podIP"]
-            if type(ipaddress.ip_address(hostname)) == ipaddress.IPv6Address:
+            if isinstance(ipaddress.ip_address(hostname), ipaddress.IPv6Address):
                 hostname = f"[{hostname}]"
 
         if self.pod_connect_ip:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -9,6 +9,7 @@ import os
 import string
 import sys
 import warnings
+import ipaddress
 from functools import partial, wraps
 from urllib.parse import urlparse
 
@@ -1944,12 +1945,21 @@ class KubeSpawner(Spawner):
                     )
                 ]
             )
-
-        return "{}://{}:{}".format(
-            proto,
-            hostname,
-            self.port,
-        )
+        
+        fmtstr = "{}://{}:{}"
+        # Parsing as an IP Address may fail if hostname is a DNS name.
+        try:
+            addr = ipaddress.ip_address(hostname)
+            if type(addr) == ipaddress.IPv6Address:
+                fmtstr = "{}://[{}]:{}"
+        except:
+            pass
+        
+        return fmtstr.format(
+                proto,
+                hostname,
+                self.port,
+            )
 
     async def get_pod_manifest(self):
         """

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -809,6 +809,8 @@ async def test_ipv6_addr():
     # https://github.com/jupyterhub/jupyterhub/pull/3020
     # https://github.com/jupyterhub/kubespawner/pull/619
 
-    spawner = KubeSpawner(_mock=True,)
+    spawner = KubeSpawner(
+        _mock=True,
+    )
     url = spawner._get_pod_url({"status": {"podIP": "cafe:f00d::"}})
     assert "[" in url and "]" in url

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -802,3 +802,13 @@ async def test_delete_pvc(kube_ns, kube_client, hub, config):
         else:
             break
     assert pvc_name not in pvc_names
+
+
+async def test_ipv6_addr():
+    """make sure ipv6 addresses are templated into URL correctly"""
+    # https://github.com/jupyterhub/jupyterhub/pull/3020
+    # https://github.com/jupyterhub/kubespawner/pull/619
+
+    spawner = KubeSpawner(_mock=True,)
+    url = spawner._get_pod_url({"status": {"podIP": "cafe:f00d::"}})
+    assert "[" in url and "]" in url


### PR DESCRIPTION
Currently, trying to launch JupyterHub on an IPv6 Primary / IPv4 Secondary K8S cluster (PodIP = IPv6) fails.

```
[E .. JupyterHub gen:623] Exception in Future <Task finished name='Task-284' coro=<BaseHandler.spawn_single_user.<locals>.finish_user_spawn() done, defined at /usr/local/lib/python3.8/dist-packages/jupyterhub/handlers/base.py:900> exception=ValueError("Port could not be cast to integer value as ‘ffff:ffff:ffff::ffff:ffff’”)> after timeout
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/dist-packages/tornado/gen.py", line 618, in error_callback
        future.result()
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/handlers/base.py", line 907, in finish_user_spawn
        await spawn_future
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/user.py", line 736, in spawn
        raise e
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/user.py", line 653, in spawn
        port = urlinfo.port
      File "/usr/lib/python3.8/urllib/parse.py", line 174, in port
        raise ValueError(message) from None
    ValueError: Port could not be cast to integer value as 'ffff:ffff:ffff::ffff:ffff'
```

This PR resolves the issue by attempting to parse the PodIP as an IP Address using Python's built in (correct) IP address detection mechanism, and then outputting a correctly formatted URL for IPv6 addresses.

The issue is a regression from https://github.com/jupyterhub/jupyterhub/pull/3020 but the root cause is in kubespawner not formatting the URL correctly.

fixes #620