### PR TITLE
ci: add dependabot to bump github action versions, and bump them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/kubespawner/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "05:00"
+      timezone: "Etc/UTC"
+    labels:
+      - ci
+      - dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,8 +22,8 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -40,7 +40,7 @@ jobs:
 
       # ref: https://github.com/pypa/gh-action-pypi-publish
       - name: publish to pypi
-        uses: pypa/gh-action-pypi-publish@v1.4.1
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,8 +58,8 @@ jobs:
             test_dependencies: git+https://github.com/jupyterhub/jupyterhub
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python }}"
 
@@ -74,7 +74,7 @@ jobs:
       # though.
       #
       # ref: https://github.com/jupyterhub/action-k3s-helm/
-      - uses: jupyterhub/action-k3s-helm@v1
+      - uses: jupyterhub/action-k3s-helm@v3
         with:
           k3s-channel: ${{ matrix.k3s }}
           metrics-enabled: false
@@ -101,8 +101,8 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 


### PR DESCRIPTION
Note that the unrelated and intermittent test failure observed in this PRs is resolved by https://github.com/jupyterhub/action-k3s-helm/pull/64, and we will get v3 of jupyterhub/action-k3s-helm after this is merged.