### PR TITLE
set spec hostname to get headless service to work

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -674,6 +674,7 @@ def make_pod(
             changes_name="extra_pod_config",
         )
 
+    pod.spec.hostname = name
     return pod
 
 


### PR DESCRIPTION
Notebook pod hostname could not be resolved from another pod through headless service.  Setting pod.spec.hostname to pod name will get it to work. 

Other people affected:

https://discourse.jupyter.org/t/how-to-run-single-user-pod-in-headless-mode-so-that-i-can-run-spark-jobs-on-an-external-hadoop-cluster/13806

https://gitter.im/jupyterhub/jupyterhub?at=5e316125f301780b83439232

https://groups.google.com/g/jupyter/c/UxeDkxAmuTI/m/tV0jN5ZxAwAJ

