### PR TITLE
Add `storage_extra_annotations` configuration, used when PVCs are created

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1102,6 +1102,26 @@ class KubeSpawner(Spawner):
         """,
     )
 
+    storage_extra_annotations = Dict(
+        config=True,
+        help="""
+        Extra kubernetes annotations to set on the user PVCs.
+
+        The keys and values specified here would be set as annotations on the PVCs
+        created by kubespawner for the user. Note that these are only set
+        when the PVC is created, not later when this setting is updated.
+
+        See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`__
+        for more info on what annotations are and why you might want to use them!
+
+        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
+        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
+        found within strings of this configuration. The username and servername
+        come escaped to follow the [DNS label
+        standard](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names).
+        """,
+    )
+
     storage_extra_labels = Dict(
         config=True,
         help="""
@@ -2099,7 +2119,9 @@ class KubeSpawner(Spawner):
         labels = self._build_common_labels(self._expand_all(self.storage_extra_labels))
         labels.update({'component': 'singleuser-storage'})
 
-        annotations = self._build_common_annotations({})
+        annotations = self._build_common_annotations(
+            self._expand_all(self.storage_extra_annotations)
+        )
 
         storage_selector = self._expand_all(self.storage_selector)
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -717,9 +717,7 @@ class KubeSpawner(Spawner):
 
         `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
         `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the [DNS label
-        standard](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names).
+        found within strings of this configuration.
         """,
     )
 
@@ -1116,9 +1114,7 @@ class KubeSpawner(Spawner):
 
         `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
         `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the [DNS label
-        standard](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names).
+        found within strings of this configuration.
         """,
     )
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -564,6 +564,7 @@ async def test_get_pvc_manifest():
 
     c.KubeSpawner.pvc_name_template = "user-{username}"
     c.KubeSpawner.storage_extra_labels = {"user": "{username}"}
+    c.KubeSpawner.storage_extra_annotations = {"user": "{username}"}
     c.KubeSpawner.storage_selector = {"matchLabels": {"user": "{username}"}}
 
     spawner = KubeSpawner(config=c, _mock=True)
@@ -578,6 +579,10 @@ async def test_get_pvc_manifest():
         "app": "jupyterhub",
         "component": "singleuser-storage",
         "heritage": "jupyterhub",
+    }
+    assert manifest.metadata.annotations == {
+        "user": "mock-5fname",
+        "hub.jupyter.org/username": "mock_name",
     }
     assert manifest.spec.selector == {"matchLabels": {"user": "mock-5fname"}}
 
@@ -610,6 +615,10 @@ async def test_variable_expansion(ssl_app):
         },
         "storage_extra_labels": {
             "configured_value": {"dummy": "storage-extra-labels-{username}"},
+            "findable_in": ["pvc"],
+        },
+        "storage_extra_annotations": {
+            "configured_value": {"dummy": "storage-extra-annotations-{username}"},
             "findable_in": ["pvc"],
         },
         "extra_labels": {


### PR DESCRIPTION
This commit adds the ability for kubespawner to add custom annotations to PVCs created for single user pods

EDIT: Closes #629