### PR TITLE
Observe the default choice for `profile-option-{profile-slug}-{option-slug}`

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2992,7 +2992,7 @@ class KubeSpawner(Spawner):
                 chosen_option = user_options.get(option_name)
                 if not chosen_option:
                     raise ValueError(
-                        f'Expected option {k} for profile {slug}, not found in posted form'
+                        f'Expected option {option_name} for profile {slug}, not found in posted form'
                     )
 
                 chosen_option_overrides = option['choices'][chosen_option][

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1649,7 +1649,7 @@ class KubeSpawner(Spawner):
                                     'kubespawner_override': {
                                         'cpu_limit': 2,
                                         'cpu_guarantee': 1.8,
-                                        'node_selectors': {
+                                        'node_selector': {
                                             'node.kubernetes.io/instance-type': 'n1-standard-2'
                                         }
                                     }
@@ -1659,7 +1659,7 @@ class KubeSpawner(Spawner):
                                     'kubespawner_override': {
                                         'cpu_limit': 4,
                                         'cpu_guarantee': 3.5,
-                                        'node_selectors': {
+                                        'node_selector': {
                                             'node.kubernetes.io/instance-type': 'n1-standard-4'
                                         }
                                     }

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2989,8 +2989,14 @@ class KubeSpawner(Spawner):
             # are in the form data posted. This prevents users who may be authorized
             # to only use one profile from being able to access options set for other
             # profiles
-            for user_selected_option_name, user_selected_option_val in selected_profile_user_options:
-                if user_selected_option_name not in profile.get('profile_options').items():
+            for (
+                user_selected_option_name,
+                user_selected_option_val,
+            ) in selected_profile_user_options:
+                if (
+                    user_selected_option_name
+                    not in profile.get('profile_options').items()
+                ):
                     raise ValueError(
                         f'Expected option {option_name} for profile {slug}, not found in posted form'
                     )

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2998,7 +2998,7 @@ class KubeSpawner(Spawner):
                         f'Expected option {user_selected_option_name} for profile {slug}, not found in posted form'
                     )
 
-            # Get selected options or default to a random option if none is passed
+            # Get selected options or default to the first option if none is passed
             for option_name, option in profile.get('profile_options').items():
                 chosen_option = selected_profile_user_options.get(option_name, None)
                 # If none was selected get the default

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2998,7 +2998,7 @@ class KubeSpawner(Spawner):
                     not in profile.get('profile_options').items()
                 ):
                     raise ValueError(
-                        f'Expected option {option_name} for profile {slug}, not found in posted form'
+                        f'Expected option {user_selected_option_name} for profile {slug}, not found in posted form'
                     )
 
             # Get selected options or default to a random option if none is passed

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2989,9 +2989,7 @@ class KubeSpawner(Spawner):
             # are in the form data posted. This prevents users who may be authorized
             # to only use one profile from being able to access options set for other
             # profiles
-            for (
-                user_selected_option_name,
-            ) in selected_profile_user_options.keys():
+            for (user_selected_option_name,) in selected_profile_user_options.keys():
                 if (
                     user_selected_option_name
                     not in profile.get('profile_options').keys()

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2991,11 +2991,10 @@ class KubeSpawner(Spawner):
             # profiles
             for (
                 user_selected_option_name,
-                user_selected_option_val,
-            ) in selected_profile_user_options:
+            ) in selected_profile_user_options.keys():
                 if (
                     user_selected_option_name
-                    not in profile.get('profile_options').items()
+                    not in profile.get('profile_options').keys()
                 ):
                     raise ValueError(
                         f'Expected option {user_selected_option_name} for profile {slug}, not found in posted form'


### PR DESCRIPTION
### Motivation

Currently, if a hub defines a list of `profile_options` and choices, it doesn't look like it's possible to start another user's server from the admin panel. I believe that is because there is no form submit when starting a server this way, and no convention for what the "default" options should be.

I believe this is related https://github.com/2i2c-org/infrastructure/issues/1611 and debugging that issue was what made me notice this behavior.
### PR changes
- This PR implements a defaulting mechanism for the  `profile-option-{profile-slug}-{option-slug}` similar to the one for profiles:
  https://github.com/jupyterhub/kubespawner/blob/f3d44e6e51d2ca16e787963562e5568f2a5494e0/kubespawner/spawner.py#L2949-L2967

- Fixes a typo in a docstring: `node_selectors` -> `node_selector`
- Fixes a print  message that used the wrong var for the option name: `k` -> `option_name`

### Possibly a different issue

I also noticed that accessing the `Spawn Page` of another user isn't working properly either if the hub has profile options enabled. It looks like its because of a `/` missing from the redirect link.

- Currently the redirect is to this link:
`https://<hub-name>/hub/spawn/<username>undefined`
- Whereas the correct link that renders the options form should be (notice the missing `/` after the user name):
`https://<hub-name>/hub/spawn/<username>/undefined`
