### PR TITLE
catch errors in reflector.start

### DIFF
--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -378,9 +378,16 @@ class ResourceReflector(LoggingConfigurable):
         and not afterwards!
         """
         if self.watch_task and not self.watch_task.done():
-            raise RuntimeError('Task watching for resources is already running')
+            raise RuntimeError(f"Task watching for {self.kind} is already running")
+        try:
+            await self._list_and_update()
+        except Exception as e:
+            self.log.exception(f"Initial list of {self.kind} failed")
+            if not self.first_load_future.done():
+                # anyone awaiting our first load event should fail
+                self.first_load_future.set_exception(e)
+            raise
 
-        await self._list_and_update()
         self.watch_task = asyncio.create_task(self._watch_and_update())
 
     async def stop(self):


### PR DESCRIPTION
ensures failure to start reflectors is fatal, rather than resulting in permanent hangs waiting for first_load_future

I _believe_ this closes #627 (it at least explains one such event).

Relevant bits:

- We already have [code](https://github.com/jupyterhub/kubespawner/blob/f3d44e6e51d2ca16e787963562e5568f2a5494e0/kubespawner/spawner.py#L2380-L2385) for reflectors failing to update after a few tries being fatal to the Hub
- reflector.start is [scheduled asynchronously](https://github.com/jupyterhub/kubespawner/blob/f3d44e6e51d2ca16e787963562e5568f2a5494e0/kubespawner/spawner.py#L2396), via `ensure_future`. Exceptions on this future are ignored.
- methods like start/stop/poll [await a first_load_future](https://github.com/jupyterhub/kubespawner/blob/f3d44e6e51d2ca16e787963562e5568f2a5494e0/kubespawner/spawner.py#L212-L213) to ensure the reflector has loaded info at least once
- first_load_future is only set [_on success_](https://github.com/jupyterhub/kubespawner/blob/f3d44e6e51d2ca16e787963562e5568f2a5494e0/kubespawner/reflector.py#L237), it's never set if the first load fails

All these combined mean that if the _first_ load fails, the exception is ignored (it will be logged by asyncio with `Task exception was never retrieved`), and all subsequent calls wait forever instead of raising, never attempting to restart the reflector.

The events described in #627 are:

- reflector starts having trouble talking to k8s (several `iohttp.client_exceptions.ClientConnectorError`)
- it keeps failing, so we get to `Pods reflector failed, halting Hub`
- Hub stops, restarts
- On restart, if we are still in the disrupted state, the _initial_ load fails again with the same `aiohttp.client_exceptions.ClientConnectorError`, but this time it's ignored (`ERROR:asyncio:Task exception was never retrieved`)
- since first_load_future is never set, all start/stop/poll calls are just infinite waits


The fix here is to:

1. catch (any) error in `Reflector.start()`, and
2. call the same fatal cleanup `on_reflector_failure` function
3. store the error in `first_load_future` so that anyone awaiting the first load will get the exception, rather than a forever-incomplete Future

The result should be that the Hub goes into CrashLoopBackoff while it can't talk to the k8s API, which I think is probably correct.

We could also give the first load more retry chances with `exponential_backoff` before it considers errors fatal, but I'm not sure if that's the right thing to do.