### PR TITLE
Allow profile_options callable to be async

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1595,7 +1595,8 @@ class KubeSpawner(Spawner):
               settings, on top of whatever was applied with the 'kubespawner_override' key
               for the profile itself. The key should be the name of the kubespawner setting,
               and value can be either the final value or a callable that returns the final
-              value when called with the spawner instance as the only parameter.
+              value when called with the spawner instance as the only parameter. The callable
+              may be async.
         - `default`: (optional Bool) True if this is the default selected option
 
         kubespawner setting overrides work in the following manner, with items further in the
@@ -3009,7 +3010,7 @@ class KubeSpawner(Spawner):
                 ]
                 for k, v in chosen_option_overrides.items():
                     if callable(v):
-                        v = v(self)
+                        v = await gen.maybe_future(v(self))
                         self.log.debug(
                             f'.. overriding traitlet {k}={v} for option {option_name}={chosen_option} from callabale'
                         )


### PR DESCRIPTION
This allows network requests to be made here, which allows things like dynamically populating a list of tags for a docker image.

Ref https://github.com/2i2c-org/infrastructure/pull/1735#issuecomment-1261146440