### PR TITLE
Expand environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ lib64/
 parts/
 sdist/
 var/
+venv/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+#### Breaking changes
+
+- Now `c.KubeSpawner.environment` values supports substitution, just like other config options [#642](https://github.com/jupyterhub/kubespawner/pull/642) ([@dolfinus](https://github.com/dolfinus)).
+  For example, `{"MYVAR": "jupyterhub-{username}"}` will rendered as `{"MYVAR": "jupyterhub-sam"}` for a user named `sam`.
+  This could break backward compatibility if environment variable value contains strings like `{something}` there `something` is a substitution variable unknown for the KubeSpawner. You should escape braces by using `{{something}}` syntax.
+
 ## 4.2
 
 ### [4.2.0] - 2022-08-29

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2055,7 +2055,7 @@ class KubeSpawner(Spawner):
             allow_privilege_escalation=self.allow_privilege_escalation,
             container_security_context=csc,
             pod_security_context=psc,
-            env=self.get_env(),
+            env=self._expand_all(self.get_env()),
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),
             working_dir=self.working_dir,


### PR DESCRIPTION
In #644 spawner can add extra services after pod creation. To pass created service name, I've tried to set up notebook environment like this:
```python
c.KubeSpawner.environment = {"SPARK_DRIVER_HOST": "jupyter-{username}-spark-driver--{servername}"}
```
But unfortunately, environment variables does not support substitutions. Now they are