### PR TITLE
Use jupyterhub.utils.maybe_future instead of tornado.get.maybe_future

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,10 +41,12 @@ jobs:
         # kubernetes_asyncio:  https://github.com/tomplus/kubernetes_asyncio/tags
         #
         include:
-          # Tests with oldest supported Python, k8s, and k8s client
+          # Tests with oldest supported Python, jupyterhub, k8s, and k8s client
           - python: "3.7"
             k3s: v1.20
-            test_dependencies: kubernetes_asyncio==19.*
+            test_dependencies: >-
+              jupyterhub==1.3.0
+              kubernetes_asyncio==19.15.1
 
           # Test with modern python and k8s versions
           - python: "3.9"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'escapism',
         'python-slugify',
-        'jupyterhub>=0.9',
+        'jupyterhub>=0.9.1',
         'jinja2',
         'kubernetes_asyncio>=19.15.1',
         'urllib3',

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,12 @@ if v[:2] < (3, 7):
 setup(
     name='jupyterhub-kubespawner',
     version='4.2.1.dev',
+    # NOTE: If lower bounds are updated, also update our test for the lower
+    #       bounds in .github/workflows/test.yaml.
     install_requires=[
         'escapism',
         'python-slugify',
-        'jupyterhub>=0.9.1',
+        'jupyterhub>=1.3.0',
         'jinja2',
         'kubernetes_asyncio>=19.15.1',
         'urllib3',
@@ -27,7 +29,7 @@ setup(
             'kubernetes>=11',
             'pytest>=5.4',
             'pytest-cov',
-            'pytest-asyncio>=0.11.0',
+            'pytest-asyncio>=0.17',
         ]
     },
     description='JupyterHub Spawner for Kubernetes',


### PR DESCRIPTION
`tornado.get.maybe_future` handles only functions decorated by `@gen.coroutine`, but not `async def` syntax added in Python 3.5. Using `jupyterhub.utils.maybe_future` instead fixes this issue.

Fixes #490.

