### PR TITLE
[KubeIngressProxy] Fix delete_route

### DIFF
--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -324,19 +324,19 @@ class KubeIngressProxy(Proxy):
 
         delete_options = client.V1DeleteOptions(grace_period_seconds=0)
 
-        delete_endpoint = await self.core_api.delete_namespaced_endpoints(
+        delete_endpoint = self.core_api.delete_namespaced_endpoints(
             name=safe_name,
             namespace=self.namespace,
             body=delete_options,
         )
 
-        delete_service = await self.core_api.delete_namespaced_service(
+        delete_service = self.core_api.delete_namespaced_service(
             name=safe_name,
             namespace=self.namespace,
             body=delete_options,
         )
 
-        delete_ingress = await self.networking_api.delete_namespaced_ingress(
+        delete_ingress = self.networking_api.delete_namespaced_ingress(
             name=safe_name,
             namespace=self.namespace,
             body=delete_options,


### PR DESCRIPTION
Same as for #646, but for route deletion.

Without this fix, Jupyterhub correctly creates Ingress for user server, but does nothing while this server is being deleted. More than that, KubeSpawner in case of failing route deletion does not remove pod, so `Stop server` button just don't work at all