### PR TITLE
Fix hard-coded component label for services_enabled=True

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -6,7 +6,7 @@ import ipaddress
 import json
 import operator
 import re
-from typing import Optional
+from typing import List, Optional
 from urllib.parse import urlparse
 
 from kubernetes_asyncio.client.models import (
@@ -938,12 +938,12 @@ def make_secret(
 
 
 def make_service(
-    name,
-    port,
-    servername,
-    owner_references,
-    labels=None,
-    annotations=None,
+    name: str,
+    port: int,
+    selector: dict,
+    owner_references: List[V1OwnerReference],
+    labels: Optional[dict] = None,
+    annotations: Optional[dict] = None,
 ):
     """
     Make a k8s service specification for using dns to communicate with the notebook.
@@ -953,8 +953,10 @@ def make_service(
     name:
         Name of the service. Must be unique within the namespace the object is
         going to be created in.
-    env:
-        Dictionary of environment variables.
+    selector:
+        Labels of server pod to be used in spec.selector
+    owner_references:
+        Pod's owner references used to automatically remote service after pod removal
     labels:
         Labels to add to the service.
     annotations:
@@ -975,11 +977,7 @@ def make_service(
         spec=V1ServiceSpec(
             type='ClusterIP',
             ports=[V1ServicePort(name='http', port=port, target_port=port)],
-            selector={
-                'component': 'singleuser-server',
-                'hub.jupyter.org/servername': servername,
-                'hub.jupyter.org/username': metadata.labels['hub.jupyter.org/username'],
-            },
+            selector=selector,
         ),
     )
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -206,6 +206,39 @@ async def test_spawn_start(
     assert isinstance(status, int)
 
 
+async def test_spawn_component_label(
+    kube_ns,
+    kube_client,
+    config,
+    hub,
+):
+    spawner = KubeSpawner(
+        hub=hub,
+        user=MockUser(name="start"),
+        config=config,
+        api_token="abc123",
+        oauth_client_id="unused",
+        component_label="something",
+    )
+
+    pod_name = spawner.pod_name
+
+    # start the spawner
+    await spawner.start()
+
+    # verify the pod exists
+    pods = (await kube_client.list_namespaced_pod(kube_ns)).items
+    pods = [p for p in pods if p.metadata.name == pod_name]
+    assert pods
+
+    # component label is same as expected
+    pod = pods[0]
+    assert pod.metadata.labels["component"] == "something"
+
+    # stop the pod
+    await spawner.stop()
+
+
 async def test_spawn_internal_ssl(
     kube_ns,
     kube_client,
@@ -301,6 +334,75 @@ async def test_spawn_internal_ssl(
     assert service_name not in service_names
 
 
+async def test_spawn_services_enabled(
+    kube_ns,
+    kube_client,
+    hub,
+    config,
+):
+    spawner = KubeSpawner(
+        config=config,
+        hub=hub,
+        user=MockUser(name="services"),
+        api_token="abc123",
+        oauth_client_id="unused",
+        services_enabled=True,
+        component_label="something",
+        common_labels={
+            "some/label": "value1",
+        },
+        extra_labels={
+            "extra/label": "value2",
+        },
+    )
+
+    # start the spawner
+    await spawner.start()
+    pod_name = "jupyter-%s" % spawner.user.name
+    # verify the pod exists
+    pods = (await kube_client.list_namespaced_pod(kube_ns)).items
+    pod_names = [p.metadata.name for p in pods]
+    assert pod_name in pod_names
+    # verify poll while running
+    status = await spawner.poll()
+    assert status is None
+
+    # verify service exist
+    service_name = pod_name
+    services = (await kube_client.list_namespaced_service(kube_ns)).items
+    services = [s for s in services if s.metadata.name == service_name]
+    assert services
+
+    # verify selector contains component_label, common_labels and extra_labels
+    # as well as user and server name
+    selector = services[0].spec.selector
+    assert selector["component"] == "something"
+    assert selector["some/label"] == "value1"
+    assert selector["extra/label"] == "value2"
+    assert selector["hub.jupyter.org/servername"] == ""
+    assert selector["hub.jupyter.org/username"] == "services"
+
+    # stop the pod
+    await spawner.stop()
+
+    # verify pod is gone
+    pods = (await kube_client.list_namespaced_pod(kube_ns)).items
+    pod_names = [p.metadata.name for p in pods]
+    assert "jupyter-%s" % spawner.user.name not in pod_names
+
+    # verify service is gone
+    # it may take a little while for them to get cleaned up
+    for _ in range(5):
+        services = (await kube_client.list_namespaced_service(kube_ns)).items
+        service_names = {s.metadata.name for s in services}
+        if service_name in service_names:
+            await asyncio.sleep(1)
+        else:
+            break
+
+    assert service_name not in service_names
+
+
 async def test_spawn_after_pod_created_hook(
     kube_ns,
     kube_client,
@@ -314,11 +416,12 @@ async def test_spawn_after_pod_created_hook(
         annotations = spawner._build_common_annotations(
             spawner._expand_all(spawner.extra_annotations)
         )
+        selector = spawner._build_pod_labels(spawner._expand_all(spawner.extra_labels))
 
         service_manifest = make_service(
             name=spawner.pod_name + "-hook",
             port=spawner.port,
-            servername=spawner.name,
+            selector=selector,
             owner_references=[owner_reference],
             labels=labels,
             annotations=annotations,
@@ -340,7 +443,7 @@ async def test_spawn_after_pod_created_hook(
     spawner = KubeSpawner(
         config=config,
         hub=hub,
-        user=MockUser(name="ssl"),
+        user=MockUser(name="hook"),
         api_token="abc123",
         oauth_client_id="unused",
         after_pod_created_hook=after_pod_created_hook,

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -211,6 +211,7 @@ async def test_spawn_component_label(
     kube_client,
     config,
     hub,
+    reset_pod_reflector,
 ):
     spawner = KubeSpawner(
         hub=hub,
@@ -339,6 +340,7 @@ async def test_spawn_services_enabled(
     kube_client,
     hub,
     config,
+    reset_pod_reflector,
 ):
     spawner = KubeSpawner(
         config=config,


### PR DESCRIPTION
I've set up KubeSpawner with following settings:
```python
c.KubeSpawner.component_label = "mylabel"
c.KubeSpawner.services_enabled = True
```

But created services were not bound to the notebook pod because 'component' label is hard-coded in `make_service` function, and always have `singleuser-server` value.

Fixed that by moving selector build outside the `make_service` function.
Added tests for custom `component_label` value passed with different values of `services_enabled`.