### PR TITLE
Save the namespace between restarts

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2188,9 +2188,13 @@ class KubeSpawner(Spawner):
 
         It's also useful for cases when the `pod_template` changes between
         restarts - this keeps the old pods around.
+
+        We also save the namespace for use cases where the namespace is
+        calculated dynamically.
         """
         state = super().get_state()
         state['pod_name'] = self.pod_name
+        state['namespace'] = self.namespace
         return state
 
     def get_env(self):
@@ -2215,9 +2219,14 @@ class KubeSpawner(Spawner):
         but if the `pod_template` has changed in between restarts, it will no longer
         be the case. This allows us to continue serving from the old pods with
         the old names.
+
+        For a similar reason, we also save the namespace.
         """
         if 'pod_name' in state:
             self.pod_name = state['pod_name']
+
+        if 'namespace' in state:
+            self.namespace = state['namespace']
 
     @_await_pod_reflector
     async def poll(self):


### PR DESCRIPTION
Hi,

I'm using a setup of kubespawner, where the `namespace` depends on the jupyter profile which the users selects. So users can start sessions in different namespaces where they will have access to different resources on our cluster. This is implemented by setting `namespace` in `kubespawner_override`.

So far this works great, the only issue we've found is that when the hub is restarted, it doesn't find the pod any more because it looks for the pod in the default namespace.

This PR will serialize the namespace, so when the spawner is loaded, the `namespace` is set up correctly. For my use case, this is necessary, and it also shouldn't cause problems for other use cases, so is this something you could consider merging?

On an unrelated note, we are also customizing the `pod_name` for different jupyter profiles, so we actually depend on `pod_name` being serialized. This is already the case, but the documentation in the code says that this isn't really necessary.
