### PR TITLE
[KubeIngressProxy] Add KubeIngressProxy.ingress_specifications

### DIFF
--- a/kubespawner/utils.py
+++ b/kubespawner/utils.py
@@ -186,3 +186,19 @@ def _get_k8s_model_attribute(model_type, field_name):
                 model_type.__name__, field_name
             )
         )
+
+
+def host_matching(host: str, wildcard: str) -> bool:
+    # user.example.com == user.example.com
+    # user.example.com != wrong.example.com
+    # user.example.com != example.com
+    if not wildcard.startswith("*."):
+        return host == wildcard
+
+    host_parts = host.split(".")
+    wildcard_parts = wildcard.split(".")
+
+    # user.example.com =~ *.example.com
+    # user.example.com !~ *.user.example.com
+    # user.example.com !~ *.example
+    return host_parts[1:] == wildcard_parts[1:]


### PR DESCRIPTION
This allows to add `host` field to ingress rules, and also set `tls` field in ingress specification. Alternative implementation of #406, should fix #404.

Next step of dividing #648 into smaller pieces