### PR TITLE
[KubeIngressProxy] Add KubeIngressProxy.ingress_class_name

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -737,6 +737,7 @@ def make_ingress(
     common_labels: Optional[dict] = None,
     ingress_extra_labels: Optional[dict] = None,
     ingress_extra_annotations: Optional[dict] = None,
+    ingress_class_name: Optional[str] = None,
 ):
     """
     Returns an ingress, service, endpoint object that'll work for this service
@@ -833,6 +834,7 @@ def make_ingress(
         kind='Ingress',
         metadata=ingress_meta,
         spec=V1IngressSpec(
+            ingress_class_name=ingress_class_name,
             rules=[
                 V1IngressRule(
                     host=host,
@@ -853,7 +855,7 @@ def make_ingress(
                         ]
                     ),
                 )
-            ]
+            ],
         ),
     )
 

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -225,6 +225,13 @@ class KubeIngressProxy(Proxy):
         """,
     )
 
+    ingress_class_name = Unicode(
+        config=True,
+        help="""
+        Default value for 'ingressClassName' field in Ingress specification
+        """,
+    )
+
     k8s_api_ssl_ca_cert = Unicode(
         "",
         config=True,
@@ -375,6 +382,7 @@ class KubeIngressProxy(Proxy):
             common_labels=common_labels,
             ingress_extra_labels=ingress_extra_labels,
             ingress_extra_annotations=ingress_extra_annotations,
+            ingress_class_name=self.ingress_class_name,
         )
 
         async def ensure_object(create_func, patch_func, body, kind):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2004,6 +2004,7 @@ def test_make_ingress(target, ip):
             common_labels=common_labels,
             ingress_extra_labels=ingress_extra_labels,
             ingress_extra_annotations=ingress_extra_annotations,
+            ingress_class_name='nginx',
         )
     )
 
@@ -2067,6 +2068,7 @@ def test_make_ingress(target, ip):
             'name': 'jupyter-test',
         },
         'spec': {
+            'ingressClassName': 'nginx',
             'rules': [
                 {
                     'http': {
@@ -2086,7 +2088,7 @@ def test_make_ingress(target, ip):
                         ]
                     }
                 }
-            ]
+            ],
         },
     }
 


### PR DESCRIPTION
This allows to set `ingressClassName` field in ingress specification, which is important for k8s instances with multiple ingress class names allowed.

Last step of dividing https://github.com/jupyterhub/kubespawner/pull/648 into smaller pieces