### PR TITLE
Avoid class state by passing relevant config to PodReflector on instanciation

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -55,11 +55,6 @@ class PodReflector(ResourceReflector):
 
     kind = "pods"
 
-    # The default component label can be over-ridden by specifying the component_label property
-    labels = {
-        'component': 'singleuser-server',
-    }
-
     @property
     def pods(self):
         """
@@ -2387,8 +2382,8 @@ class KubeSpawner(Spawner):
 
     def _start_reflector(
         self,
-        kind=None,
-        reflector_class=ResourceReflector,
+        kind,
+        reflector_class,
         replace=False,
         **kwargs,
     ):
@@ -2468,11 +2463,10 @@ class KubeSpawner(Spawner):
         If replace=True, a running pod reflector will be stopped
         and a new one started (for recovering from possible errors).
         """
-        pod_reflector_class = PodReflector
-        pod_reflector_class.labels.update({"component": self.component_label})
         return self._start_reflector(
-            "pods",
-            PodReflector,
+            kind="pods",
+            reflector_class=PodReflector,
+            labels={"component": self.component_label},
             omit_namespace=self.enable_user_namespaces,
             replace=replace,
         )


### PR DESCRIPTION
Based on this discussion:
https://github.com/jupyterhub/kubespawner/pull/654#discussion_r1019049868