### PR TITLE
docs: relocate docs/requirements.txt into pyproject.toml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,7 @@ jobs:
             test_dependencies: >-
               jupyterhub==1.3.0
               kubernetes_asyncio==19.15.1
+              traitlets==4.1.0
 
           # Test with modern python and k8s versions
           - python: "3.9"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
             test_dependencies: >-
               jupyterhub==1.3.0
               kubernetes_asyncio==19.15.1
-              traitlets==4.1.0
+              traitlets==4.3.2
 
           # Test with modern python and k8s versions
           - python: "3.9"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,10 +14,5 @@ build:
 
 python:
   install:
-    - requirements: docs/requirements.txt
-    # NOTE:    We also install the kubespawner package itself, because we use
-    #          the autodoc_traits sphinx extension to generate documentation via
-    #          source code inspection.
-    #
     - method: pip
-      path: .
+      path: ".[doc]"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,9 @@ walk you through the process of proposing your change ("making a Pull Request").
 A brief guide to setting up for local development
 
 ```sh
-# Installing kubespawner itself is required as its source code
-# is inspected to construct the reference documentation.
-pip install -e .
+pip install -e ".[doc]"
 
 cd docs
-pip install -r requirements.txt
-
 make html
 ```
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-autodoc_traits
-myst-parser>=0.17.0
-pyyaml
-setuptools
-# sphinx 4.2+ is required to be compatible with Python 3.10
-sphinx>=4.2,<5
-sphinx-book-theme
-sphinx-copybutton
-traitlets>=4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "kubernetes_asyncio>=19.15.1",
     "python-slugify",
     "pyYAML",
-    "traitlets>=4.1",
+    "traitlets>=4.3.2",
     "urllib3",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,18 @@ dependencies = [
     "kubernetes_asyncio>=19.15.1",
     "python-slugify",
     "pyYAML",
+    "traitlets>=4.1",
     "urllib3",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
+doc = [
+    "autodoc_traits",
+    "myst-parser>=0.17.0",
+    "sphinx-book-theme",
+    "sphinx-copybutton",
+]
 test = [
     "kubernetes>=11",
     "pytest>=5.4",


### PR DESCRIPTION
When we have autodoc_traits, inspecting a python package (kubespawner) to build documentation, it makes sense to put the requirements in the package itself rather than in a dedicated docs/requirements.txt file I figure.