### PR TITLE
Save dns_name between restarts

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2190,12 +2190,13 @@ class KubeSpawner(Spawner):
         It's also useful for cases when the `pod_template` changes between
         restarts - this keeps the old pods around.
 
-        We also save the namespace for use cases where the namespace is
-        calculated dynamically.
+        We also save the namespace and DNS name for use cases where the namespace is
+        calculated dynamically, or it changes between restarts.
         """
         state = super().get_state()
         state['pod_name'] = self.pod_name
         state['namespace'] = self.namespace
+        state['dns_name'] = self.dns_name
         return state
 
     def get_env(self):
@@ -2228,6 +2229,9 @@ class KubeSpawner(Spawner):
 
         if 'namespace' in state:
             self.namespace = state['namespace']
+
+        if 'dns_name' in state:
+            self.dns_name = state['dns_name']
 
     @_await_pod_reflector
     async def poll(self):


### PR DESCRIPTION
In #657 a change with saving and restoring the namespace was added to KubeSpawner, to avoid some issues caused by Jupyterhub restart.
But `namespace` is substituted in `dns_name_template`, so `dns_name` should be saved and restored as well.

Other options in `__init__` support only `hubnamespace` substutution, not pod namespace, so there is no need to preserve it between restart.