### PR TITLE
Test restoring pod name from previos state

### DIFF
--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -557,7 +557,7 @@ async def test_spawn_start_restore_pod_name(
     )
     spawner.load_state(old_state)
 
-    # previous pod name is restored
+    # previous pod name is restored by the load_state call
     assert spawner.pod_name == old_spawner_pod_name
 
     # empty spawner isn't running

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -589,7 +589,7 @@ async def test_spawn_start_restore_pod_name(
     # stop the pod
     await spawner.stop()
 
-    # verify pod is gone
+    # verify pod with old name is gone
     pods = (await kube_client.list_namespaced_pod(kube_ns)).items
     pod_names = [p.metadata.name for p in pods]
     assert pod_name not in pod_names

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -569,7 +569,7 @@ async def test_spawn_start_restore_pod_name(
     # start the spawner
     url = await spawner.start()
 
-    # verify the pod exists
+    # verify pod with old name now exists
     pods = (await kube_client.list_namespaced_pod(kube_ns)).items
     pod_names = [p.metadata.name for p in pods]
     assert pod_name in pod_names


### PR DESCRIPTION
Added test that if `c.KubeSpawner.pod_name_template` was changed with restarting a JupyterHub instance, the restored server state contains the same pod name as before restart.

Splitting #678 into smaller pieces.