### PR TITLE
docs: stick with docs/requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,5 +14,4 @@ build:
 
 python:
   install:
-    - method: pip
-      path: ".[doc]"
+    - requirements: docs/requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ walk you through the process of proposing your change ("making a Pull Request").
 A brief guide to setting up for local development
 
 ```sh
-pip install -e ".[doc]"
+pip install -r docs/requirements.txt
 
 cd docs
 make html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,12 @@
+# This requirements.txt file must be installed from the projects root folder:
+#
+#     pip install -r docs/requirements.txt
+#
+# Install the package to help autodoc-traits inspect and generate documentation.
+#
+--editable .
+
+autodoc-traits
+myst-parser>=0.17.0
+sphinx-book-theme
+sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-# This requirements.txt file must be installed from the projects root folder:
+# This requirements.txt file must be installed from the project's root folder:
 #
 #     pip install -r docs/requirements.txt
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,6 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-doc = [
-    "autodoc_traits",
-    "myst-parser>=0.17.0",
-    "sphinx-book-theme",
-    "sphinx-copybutton",
-]
 test = [
     "kubernetes>=11",
     "pytest>=5.4",


### PR DESCRIPTION
Based on a discussion in jupyterhub/jupyterhub, I want to revert a switch to use a doc target in extras_require and stick with having a docs/requirements.txt file here like in jupyterhub/jupyterhub.

## Related
- This is to a large extent reverting #673
