### PR TITLE
Escape pod label `hub.jupyter.org/servername` (pod annotation remains unescaped)

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1913,7 +1913,9 @@ class KubeSpawner(Spawner):
         labels.update(
             {
                 'component': self.component_label,
-                'hub.jupyter.org/servername': self.name,
+                'hub.jupyter.org/servername': escapism.escape(
+                    self.name, safe=self.safe_chars, escape_char='-'
+                ).lower(),
             }
         )
         return labels


### PR DESCRIPTION
Otherwise, server names with spaces in them
get the following error message:

```
HTTP response body:
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod
\"jupyter-user-2dname--server-202\" is invalid: metadata.labels:
Invalid value: \"server 2\": a valid label must be an empty string or
consist of alphanumeric characters, '-', '_' or '.', and must start
and end with an alphanumeric character (e.g. 'MyValue',  or
'my_value',  or '12345', regex used for validation is
'(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')","reason":"Invalid","details":{"name":"jupyter-user-2dname--server-202","kind":"Pod","causes":[{"reason":"FieldValueInvalid","message":"Invalid
value: \"server 2\": a valid label must be an empty string or consist
of alphanumeric characters, '-', '_' or '.', and must start and end
with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or
'12345', regex used for validation is
'(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')","field":"metadata.labels"}]},"code":422}
```