### PR TITLE
[POC] Auth aware profile list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,13 @@ repos:
 
   # Autoformat: Python code
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2935,6 +2935,8 @@ class KubeSpawner(Spawner):
     async def _render_options_form_dynamically(self, current_spawner):
         if callable(self.profile_list):
             profile_list = await maybe_future(self.profile_list(current_spawner))
+        else:
+            profile_list = self.profile_list
         profile_list = self._init_profile_list(profile_list)
         # protect non oauthenticator instances
         if all(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,7 +202,6 @@ async def watch_kubernetes(kube_client, kube_ns):
             func=kube_client.list_namespaced_event,
             namespace=kube_ns,
         ):
-
             resource = event['object']
             obj = resource.involved_object
             print(


### PR DESCRIPTION
# Motivaion

The overall goal of this PR is to allow auth logic in KubeSpawner.profile_list depending on the instance of OAuthenticator chosen. This PR is meant to continue the discussions [here](https://discourse.jupyter.org/t/tailoring-spawn-options-and-server-configuration-to-certain-users/8449) as well as a sibling PR to https://github.com/jupyterhub/oauthenticator/pull/571. 

# Changes

* `_options_form_default`: Returns callable if `self.profile_list` is not empty
* `_render_options_form_dynamically`: Checks if `self.profile_list` is callable, and generates the list, then proceeds to filter out profiles (and profile options) if the authenticator class meets the auth criteria
* `_filter_profile_options_form`: New async function that filters profiles based on user configured `oauthenticator_override`

Per reviewer feedback I will proceed with extending some test coverage to this new logic. No auth is currently being tested beyond Dummy, so this will require some review as well.
