### PR TITLE
Fix error message when default profile is missing options

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3045,7 +3045,7 @@ class KubeSpawner(Spawner):
                     not in profile.get('profile_options').keys()
                 ):
                     raise ValueError(
-                        f'Expected option {user_selected_option_name} for profile {slug}, not found in posted form'
+                        f'Expected option {user_selected_option_name} for profile {profile["slug"]}, not found in posted form'
                     )
 
             # Get selected options or default to the first option if none is passed


### PR DESCRIPTION
If slug is unset, the default profile is chosen. If we're missing options, this patch fixes the error message to print the slug corresponding to the default profile rather than the less helpful "None".