### PR TITLE
Drop support for k8s 1.20-1.22 (stop testing against it)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
             k3s: v1.23
             test_dependencies: >-
               jupyterhub==1.3.0
-              kubernetes_asyncio==19.15.1
+              kubernetes_asyncio==23.6.0
               traitlets==4.3.2
 
           # Test with modern python and k8s versions

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
         include:
           # Tests with oldest supported Python, jupyterhub, k8s, and k8s client
           - python: "3.7"
-            k3s: v1.20
+            k3s: v1.23
             test_dependencies: >-
               jupyterhub==1.3.0
               kubernetes_asyncio==19.15.1

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,8 +6,8 @@
 
 ### Breaking changes
 
-- Support for use against k8s 1.20-1.22 is no longer maintained, please upgrade
-  to k8s 1.23+ to ensure function.
+- Versions of K8s older than 1.23 are no longer supported, they may work but
+  this is not guaranteed.
 - Now `c.KubeSpawner.environment` values supports substitution, just like other config options [#642](https://github.com/jupyterhub/kubespawner/pull/642) ([@dolfinus](https://github.com/dolfinus)).
   For example, `{"MYVAR": "jupyterhub-{username}"}` will rendered as `{"MYVAR": "jupyterhub-sam"}` for a user named `sam`.
   This could break backward compatibility if environment variable value contains strings like `{something}` there `something` is a substitution variable unknown for the KubeSpawner. You should escape braces by using `{{something}}` syntax.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,6 +6,8 @@
 
 ### Breaking changes
 
+- Support for use against k8s 1.20-1.22 is no longer maintained, please upgrade
+  to k8s 1.23+ to ensure function.
 - Now `c.KubeSpawner.environment` values supports substitution, just like other config options [#642](https://github.com/jupyterhub/kubespawner/pull/642) ([@dolfinus](https://github.com/dolfinus)).
   For example, `{"MYVAR": "jupyterhub-{username}"}` will rendered as `{"MYVAR": "jupyterhub-sam"}` for a user named `sam`.
   This could break backward compatibility if environment variable value contains strings like `{something}` there `something` is a substitution variable unknown for the KubeSpawner. You should escape braces by using `{{something}}` syntax.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "escapism",
     "jinja2",
     "jupyterhub>=1.3.0",
-    "kubernetes_asyncio>=19.15.1",
+    "kubernetes_asyncio>=23.6.0",
     "python-slugify",
     "pyYAML",
     "traitlets>=4.3.2",


### PR DESCRIPTION
Our next release is a major release, and z2jh will drop support for k8s 1.22 as well when including kubespawner and making its major release - see https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3040