### PR TITLE
Fix tests badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [kubespawner](https://github.com/jupyterhub/kubespawner) (jupyterhub-kubespawner @ PyPI)
 
 [![Documentation status](https://img.shields.io/readthedocs/jupyterhub-kubespawner?logo=read-the-docs)](https://jupyterhub-kubespawner.readthedocs.io/en/latest/?badge=latest)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jupyterhub/kubespawner/Test?logo=github)](https://github.com/jupyterhub/kubespawner/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jupyterhub/kubespawner/test.yaml?logo=github)](https://github.com/jupyterhub/kubespawner/actions)
 [![Code coverage](https://codecov.io/gh/jupyterhub/kubespawner/branch/main/graph/badge.svg)](https://codecov.io/gh/jupyterhub/kubespawner)
 [![](https://img.shields.io/pypi/v/jupyterhub-kubespawner.svg?logo=pypi)](https://pypi.python.org/pypi/jupyterhub-kubespawner)
 


### PR DESCRIPTION
![изображение](https://user-images.githubusercontent.com/4661021/231246463-191e13c3-8260-4df0-8c4c-6e0d9106080e.png)

According to https://github.com/badges/shields/issues/8671, CI badge URL format should be changed.

Here is a fix:
![изображение](https://user-images.githubusercontent.com/4661021/231246812-af8e05ea-965f-419f-a8a2-1d34ac293ad1.png)
