### PR TITLE
Require jupyterhub 4+, currently latest kubernetes_asyncio, and stop testing k8s 1.23

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,12 +39,15 @@ jobs:
         #
         include:
           # Tests with oldest supported Python, jupyterhub, k8s, and k8s client
+          #
+          # NOTE: If lower bounds are updated, also update our test for the
+          #       lower bounds in pyproject.toml.
+          #
           - python: "3.7"
             k3s: v1.23
             test_dependencies: >-
-              jupyterhub==1.3.0
-              kubernetes_asyncio==23.6.0
-              traitlets==4.3.2
+              jupyterhub==4.0.0
+              kubernetes_asyncio==24.2.3
 
           # Test with modern python and k8s versions
           - python: "3.9"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,13 +9,13 @@ on:
       - "docs/**"
       - "**.md"
       - ".github/workflows/*"
-      - "!.github/workflows/test-chart.yaml"
+      - "!.github/workflows/test.yaml"
   push:
     paths-ignore:
       - "docs/**"
       - "**.md"
       - ".github/workflows/*"
-      - "!.github/workflows/test-chart.yaml"
+      - "!.github/workflows/test.yaml"
     branches-ignore:
       - "dependabot/**"
       - "pre-commit-ci-update-config"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
           #       lower bounds in pyproject.toml.
           #
           - python: "3.7"
-            k3s: v1.23
+            k3s: v1.24
             test_dependencies: >-
               jupyterhub==4.0.0
               kubernetes_asyncio==24.2.3

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -8,6 +8,9 @@
 
 - JupyterHub 4 is now required by KubeSpawner.
   [#726](https://github.com/jupyterhub/kubespawner/pull/726)
+- Versions of K8s older than 1.24 are no longer supported, KubeSpawner may still
+  work but this is not guaranteed.
+  [#726](https://github.com/jupyterhub/kubespawner/pull/726)
 
 ## 5.0
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+#### Breaking changes
+
+- JupyterHub 4 is now required by KubeSpawner.
+  [#726](https://github.com/jupyterhub/kubespawner/pull/726)
+
 ## 5.0
 
 ### [5.0.0] - 2023-04-19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ dependencies = [
     #       bounds in .github/workflows/test.yaml.
     "escapism",
     "jinja2",
-    "jupyterhub>=1.3.0",
-    "kubernetes_asyncio>=23.6.0",
+    "jupyterhub>=4.0.0",
+    "kubernetes_asyncio>=24.2.3",
     "python-slugify",
     "pyYAML",
-    "traitlets>=4.3.2",
+    "traitlets",
     "urllib3",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
I repeatedly failed to figure out why our test suite started failing in our oldest dependencies test using JupyterHub 1 in #725. I spend a lot of time looking into this as it was also a clue for test failures in binderhub that probably was unrelated it turns out. With this background of investing significant time into maintenance for backward compatibility, I suggested in #727 we drop support for the previous major JupyterHub versions in KubeSpawner 6.0.0.

In this PR I'm declaring it a requirement to use `jupyterhub>=4` directly even though `jupyterhub>=2` practically works to my knowledge. I motivate going straight to `>=4` to simplify future maintenance and reduce the amounts of tests we need to run in our test suite. My assumption is that there is little value to support jupyterhub 2, 3 and 4 in kubespawner 6+ released after jupyterhub 4, because the z2jh distribution and other users of kubespawner would upgrade to jupyterhub 4 at the same time they would update to a new version of kubespawner.

---

In the spirit of reducing some maintenance load, I'd like to also stop testing against k8s 1.23 and let KubeSpawner 6 come without guarantees it will work, even though it currently is known to work.

I suggest KubeSpawner 6 and z2jh 3 both ship with a disclaimer of "k8s 1.23 is tested to work, but going onwards we won't test against k8s 1.23".

Note that dropping testing against k8s 1.23 is motivated by wanting to make a new breaking release of action-k3s-helm that drops support for k8s 1.23 testing which is hard to maintain as well, see https://github.com/jupyterhub/action-k3s-helm/issues/94.

---

- Closes #725 
- Closes #727 