### PR TITLE
Select profile if any of its choices are interacted with

### DIFF
--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -17,11 +17,10 @@
           <div>
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
-                <label for="profile-option-{{ profile.slug }}-{{ k }}" class="js-profile-option-label">
+                <span class="profile-options-label">
                   {{ option.display_name }}
-                </label>
-                <select name="profile-option-{{ profile.slug }}-{{ k }}"
-                        class="form-control js-profile-option-select">
+                </span>
+                <select name="profile-option-{{ profile.slug }}-{{ k }}">
                   {%- for k, choice in option['choices'].items() %}
                     <option value="{{ k }}" {% if choice.default %}selected{% endif %}>
                       {{ choice.display_name }}
@@ -37,9 +36,8 @@
   {%- endfor %}
 </div>
 <script>
-  $('.js-profile-option-select, .js-profile-option-label').click(function() {
-    // if the user clicks on either the select or label for the select,
-    // make sure to select the associated profile radio.
+  $('.js-profile-option-select').click(function() {
+    // we need this bit of JS to select the profile when a <select> inside is clicked.
     $(this).parents('.js-profile-label')
       .find('input[type=radio]')
       .prop('checked', true);

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -17,7 +17,7 @@
           <div>
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
-                <label for="profile-option-{{ profile.slug }}-{{ k }}">{{ option.display_name }}</label>
+                <label for="profile-option-{{ profile.slug }}-{{ k }}" class="js-profile-option-label">{{ option.display_name }}</label>
                 <select name="profile-option-{{ profile.slug }}-{{ k }}" class="js-profile-option-select form-control">
                   {%- for k, choice in option['choices'].items() %}
                     <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
@@ -32,7 +32,7 @@
   {%- endfor %}
 </div>
 <script>
-  $('.js-profile-option-select').click(function() {
+  $('.js-profile-option-select, .js-profile-option-label').click(function() {
     // if the user changes a select box of a profile option,
     // make sure we also select the radio button for that option
     $(this).parents('.js-profile-label')

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -2,7 +2,8 @@
 <div class="form-group" id="kubespawner-profiles-list">
   {%- for profile in profile_list %}
     {#- Wrap everything in a label tag so clicking anywhere selects the option #}
-    <label for="profile-item-{{ profile.slug }}" class="profile js-profile-label">
+    <label for="profile-item-{{ profile.slug }}"
+           class="profile js-profile-label">
       <div class="radio">
         <input type="radio"
                name="profile"
@@ -17,14 +18,10 @@
           <div>
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
-                <span class="profile-options-label">
-                  {{ option.display_name }}
-                </span>
+                <span class="profile-options-label">{{ option.display_name }}</span>
                 <select name="profile-option-{{ profile.slug }}-{{ k }}">
                   {%- for k, choice in option['choices'].items() %}
-                    <option value="{{ k }}" {% if choice.default %}selected{% endif %}>
-                      {{ choice.display_name }}
-                    </option>
+                    <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                   {%- endfor %}
                 </select>
               </div>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -2,7 +2,7 @@
 <div class="form-group" id="kubespawner-profiles-list">
   {%- for profile in profile_list %}
     {#- Wrap everything in a label tag so clicking anywhere selects the option #}
-    <label for="profile-item-{{ profile.slug }}" class="profile">
+    <label for="profile-item-{{ profile.slug }}" class="profile js-profile-label">
       <div class="radio">
         <input type="radio"
                name="profile"
@@ -18,7 +18,7 @@
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
                 <label for="profile-option-{{ profile.slug }}-{{ k }}">{{ option.display_name }}</label>
-                <select name="profile-option-{{ profile.slug }}-{{ k }}" class="form-control">
+                <select name="profile-option-{{ profile.slug }}-{{ k }}" class="js-profile-option-select form-control">
                   {%- for k, choice in option['choices'].items() %}
                     <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                   {%- endfor %}
@@ -31,3 +31,10 @@
     </label>
   {%- endfor %}
 </div>
+<script>
+  $('.js-profile-option-select').change(function() {
+    // if the user changes a select box of an option,
+    // make sure we also select that option
+    $(this).parents('.js-profile-label').find('input[type=radio]').prop('checked', true);
+  });
+</script>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -33,8 +33,10 @@
 </div>
 <script>
   $('.js-profile-option-select').change(function() {
-    // if the user changes a select box of an option,
-    // make sure we also select that option
-    $(this).parents('.js-profile-label').find('input[type=radio]').prop('checked', true);
+    // if the user changes a select box of a profile option,
+    // make sure we also select the radio button for that option
+    $(this).parents('.js-profile-label')
+      .find('input[type=radio]')
+      .prop('checked', true);
   });
 </script>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -32,7 +32,7 @@
   {%- endfor %}
 </div>
 <script>
-  $('.js-profile-option-select').change(function() {
+  $('.js-profile-option-select').click(function() {
     // if the user changes a select box of a profile option,
     // make sure we also select the radio button for that option
     $(this).parents('.js-profile-label')

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -17,10 +17,15 @@
           <div>
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
-                <label for="profile-option-{{ profile.slug }}-{{ k }}" class="js-profile-option-label">{{ option.display_name }}</label>
-                <select name="profile-option-{{ profile.slug }}-{{ k }}" class="js-profile-option-select form-control">
+                <label for="profile-option-{{ profile.slug }}-{{ k }}" class="js-profile-option-label">
+                  {{ option.display_name }}
+                </label>
+                <select name="profile-option-{{ profile.slug }}-{{ k }}"
+                        class="form-control js-profile-option-select">
                   {%- for k, choice in option['choices'].items() %}
-                    <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
+                    <option value="{{ k }}" {% if choice.default %}selected{% endif %}>
+                      {{ choice.display_name }}
+                    </option>
                   {%- endfor %}
                 </select>
               </div>
@@ -33,8 +38,8 @@
 </div>
 <script>
   $('.js-profile-option-select, .js-profile-option-label').click(function() {
-    // if the user changes a select box of a profile option,
-    // make sure we also select the radio button for that option
+    // if the user clicks on either the select or label for the select,
+    // make sure to select the associated profile radio.
     $(this).parents('.js-profile-label')
       .find('input[type=radio]')
       .prop('checked', true);

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -18,8 +18,10 @@
           <div>
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
-                <span class="profile-options-label">{{ option.display_name }}</span>
-                <select name="profile-option-{{ profile.slug }}-{{ k }}">
+                <label for="profile-option-{{ profile.slug }}-{{ k }}"
+                       class="js-profile-option-label">{{ option.display_name }}</label>
+                <select name="profile-option-{{ profile.slug }}-{{ k }}"
+                        class="form-control js-profile-option-select">
                   {%- for k, choice in option['choices'].items() %}
                     <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                   {%- endfor %}
@@ -33,7 +35,7 @@
   {%- endfor %}
 </div>
 <script>
-  $('.js-profile-option-select').click(function() {
+  $('.js-profile-option-select, .js-profile-option-label').click(function() {
     // we need this bit of JS to select the profile when a <select> inside is clicked.
     $(this).parents('.js-profile-label')
       .find('input[type=radio]')

--- a/kubespawner/templates/style.css
+++ b/kubespawner/templates/style.css
@@ -22,7 +22,7 @@
   padding-bottom: 12px;
 }
 
-#kubespawner-profiles-list .profile .option label {
+#kubespawner-profiles-list .profile-options-label {
   font-weight: normal;
   margin-right: 8px;
   min-width: 96px;

--- a/kubespawner/templates/style.css
+++ b/kubespawner/templates/style.css
@@ -22,7 +22,7 @@
   padding-bottom: 12px;
 }
 
-#kubespawner-profiles-list .profile-options-label {
+#kubespawner-profiles-list .profile .option label {
   font-weight: normal;
   margin-right: 8px;
   min-width: 96px;


### PR DESCRIPTION
This builds on top of this PR: https://github.com/jupyterhub/kubespawner/pull/724

Fixes #696 

Does:
 - Adds `js-` prefixed classes to the Select boxes and the Label containers - this is not strictly necessary, but I find it good practice to separate out classes used by Javascript
 - Adds a `<script>` tag to the end of the template with simple jQuery to react to changes to the select tag and ensure that the parent Input Radio is selected. If there's a strong preference, can move to a separate file right away, or can do that if and when the JS gets more complex.

Stylistic choices:

 - I've gone ahead and used jQuery since it existed - happy to remove the dependency, but it would mean a bit more verbose code.
 - There's probably a few different ways to handle traversing the DOM and selecting the correct radio, probably with different trade-offs. I've gone for the simplest approach here: this does mean that this function would need to be looked at in case the HTML structure of the page drastically changes, but hopefully it's simple enough to tell what's going on here that it would be easy to fix.

Let me know if this works / if there's anything else that would be good to do here.

cc @yuvipanda 