### PR TITLE
Do not try to escape None

### DIFF
--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -349,12 +349,12 @@ class KubeIngressProxy(Proxy):
         if hub_namespace == "default":
             hub_namespace = "user"
 
-        raw_username = data.get('user')
+        raw_username = data.get('user') or ''
         safe_username = escapism.escape(
             raw_username, safe=safe_chars, escape_char='-'
         ).lower()
 
-        raw_servicename = data.get('services')
+        raw_servicename = data.get('services') or ''
         safe_servicename = escapism.escape(
             raw_servicename, safe=safe_chars, escape_char='-'
         ).lower()


### PR DESCRIPTION
Fix for #723.

It seems that hub route data is `{"hub": true}`, but function `KubeIngressProxy:_expand_user_properties` try to get user from it.