### PR TITLE
Allow end user to select a choice different from list of available choices in profile_list

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -46,10 +46,10 @@ c.KubeSpawner.profile_list = [
         'profile_options': {
             'image': {
                 'display_name': 'Image',
-                'free_form': {
+                'other_choice': {
                     'enabled': True,
                     'display_name': 'Image Location',
-                    'match_regex': '^pangeo/.*$',
+                    'validation_match_regex': '^pangeo/.*$',
                     'validation_message': 'Must be a pangeo image, matching ^pangeo/.*$',
                     'kubespawner_override': {'image': '{value}'},
                 },

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -49,7 +49,7 @@ c.KubeSpawner.profile_list = [
                 'other_choice': {
                     'enabled': True,
                     'display_name': 'Image Location',
-                    'validation_match_regex': '^pangeo/.*$',
+                    'validation_regex': '^pangeo/.*$',
                     'validation_message': 'Must be a pangeo image, matching ^pangeo/.*$',
                     'kubespawner_override': {'image': '{value}'},
                 },

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -46,7 +46,13 @@ c.KubeSpawner.profile_list = [
         'profile_options': {
             'image': {
                 'display_name': 'Image',
-                'allow_other': True,
+                'free_form': {
+                    'enabled': True,
+                    'display_name': 'Image Location',
+                    'match_regex': '^pangeo/.*$',
+                    'validation_message': 'Must be a pangeo image, matching ^pangeo/.*$',
+                    'kubespawner_override': {'image': '{value}'},
+                },
                 'choices': {
                     'pytorch': {
                         'display_name': 'Python 3 Training Notebook',

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -46,6 +46,7 @@ c.KubeSpawner.profile_list = [
         'profile_options': {
             'image': {
                 'display_name': 'Image',
+                'allow_other': True,
                 'choices': {
                     'pytorch': {
                         'display_name': 'Python 3 Training Notebook',

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -46,7 +46,7 @@ c.KubeSpawner.profile_list = [
         'profile_options': {
             'image': {
                 'display_name': 'Image',
-                'other_choice': {
+                'unlisted_choice': {
                     'enabled': True,
                     'display_name': 'Image Location',
                     'validation_regex': '^pangeo/.*$',

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3033,9 +3033,7 @@ class KubeSpawner(Spawner):
                         raise ValueError(
                             f'Expected option {option_name} for profile {profile["slug"]} or {unlisted_choice_form_key}, not found in posted form'
                         )
-                    unlisted_choice = selected_options[
-                        unlisted_choice_form_key
-                    ]
+                    unlisted_choice = selected_options[unlisted_choice_form_key]
 
                     # Validate value of 'unlisted_choice' against validation regex
                     if profile.get('profile_options')[option_name][
@@ -3055,6 +3053,7 @@ class KubeSpawner(Spawner):
                     raise ValueError(
                         f'Expected option {option_name} for profile {profile["slug"]}, not found in posted form'
                     )
+
     async def _load_profile(self, slug, selected_profile_user_options):
         """Load a profile by name
 
@@ -3105,7 +3104,9 @@ class KubeSpawner(Spawner):
                 setattr(self, k, v)
 
         if profile.get('profile_options'):
-            self._validate_posted_profile_options(profile, selected_profile_user_options)
+            self._validate_posted_profile_options(
+                profile, selected_profile_user_options
+            )
             # Get selected options or default to the first option if none is passed
             for option_name, option in profile.get('profile_options').items():
                 unlisted_choice_form_key = f'{option_name}--unlisted-choice'
@@ -3129,7 +3130,9 @@ class KubeSpawner(Spawner):
                     ]
                     for k, v in chosen_option_overrides.items():
                         chosen_option_overrides[k] = v.format(
-                            value=selected_profile_user_options[unlisted_choice_form_key]
+                            value=selected_profile_user_options[
+                                unlisted_choice_form_key
+                            ]
                         )
                 else:
                     chosen_option_overrides = option['choices'][chosen_option][

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2963,8 +2963,11 @@ class KubeSpawner(Spawner):
         if not self.profile_list:
             return ''
         if callable(self.profile_list):
+            # Return the function dynamically, so JupyterHub will call this when the
+            # form needs rendering
             return self._render_options_form_dynamically
         else:
+            # Return the rendered string, as it does not change
             return self._render_options_form(self.profile_list)
 
     @default('options_from_form')

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3054,15 +3054,15 @@ class KubeSpawner(Spawner):
                         f'Expected option {option_name} for profile {profile["slug"]}, not found in posted form'
                     )
 
-    def _get_profile(self, slug: str):
+    def _get_profile(self, slug: str, profile_list: list):
         """
         Get the configured profile for given profile slug
 
         Raises an error if no profile exists for the given slug.
 
         If slug is empty string, return the default profile
+        profile_list should already have all its defaults set.
         """
-        profile_list = self._populate_profile_list_defaults(self.profile_list)
         if slug != "":
             for profile in profile_list:
                 if profile['slug'] == slug:
@@ -3106,13 +3106,12 @@ class KubeSpawner(Spawner):
             else:
                 setattr(self, k, v)
 
-    async def _load_profile(self, slug, selected_profile_user_options):
+    async def _load_profile(self, slug, profile_list, selected_profile_user_options):
         """Load a profile by name
 
         Called by load_user_options
         """
-        # find the profile
-        profile = self._get_profile(slug)
+        profile = self._get_profile(slug, profile_list)
 
         self.log.debug(
             "Applying KubeSpawner override for profile '%s'", profile['display_name']
@@ -3230,7 +3229,9 @@ class KubeSpawner(Spawner):
             del selected_profile_user_options['profile']
 
         if profile_list:
-            await self._load_profile(selected_profile, selected_profile_user_options)
+            await self._load_profile(
+                selected_profile, profile_list, selected_profile_user_options
+            )
         elif selected_profile:
             self.log.warning(
                 "Profile %r requested, but profiles are not enabled", selected_profile

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1539,7 +1539,7 @@ class KubeSpawner(Spawner):
 
           - `display_name`: Name used to identify this particular option
           - `unlisted_choice`: Object to specify if there should be a free-form field if the user
-            select "Other" as a choice:
+            selected "Other" as a choice:
             - `enabled`: Boolean, whether the free form input should be enabled
             - `display_name`: String, label for input field
             - `validation_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1546,7 +1546,8 @@ class KubeSpawner(Spawner):
             - `validation_message`: Optional, validation message for the regex. Should describe the required
                input format in a human-readable way.
             - `kubespawner_override`: Object specifying what key:values should be over-ridden
-               with the value of the free form input
+               with the value of the free form input, using `{value}` for the value to be substituted with
+               the user POSTed value in the `other-choice` input field. eg:
               - some_config_key: some_value-with-{value}-substituted-with-what-user-wrote 
           - `choices`: A dictionary containing list of choices for the user to choose from
             to set the value for this particular option. The key is an identifier for this
@@ -3071,7 +3072,7 @@ class KubeSpawner(Spawner):
 
             for option_name, option in profile.get('profile_options').items():
                 if option_name not in selected_profile_user_options:
-                    # other_choice in Enabled:
+                    # other_choice is enabled:
                     if option.get('other_choice', {}).get('enabled', False):
                         if (
                             f'{option_name}--other-choice'
@@ -3091,8 +3092,9 @@ class KubeSpawner(Spawner):
                             other_choice_validation_regex = profile.get(
                                 'profile_options'
                             )[option_name]['other_choice']['validation_regex']
-                            regex = re.compile(other_choice_validation_regex)
-                            if not regex.match(other_choice):
+                            if not re.match(
+                                other_choice_validation_regex, other_choice
+                            ):
                                 raise ValueError(
                                     f'Value of {option_name}--other-choice does not match validation regex.'
                                 )

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3118,7 +3118,7 @@ class KubeSpawner(Spawner):
             "Applying KubeSpawner override for profile '%s'", profile['display_name']
         )
 
-        self._apply_overrides(profile.get('kubespawner_override', {}))
+        await self._apply_overrides(profile.get('kubespawner_override', {}))
 
         if profile.get('profile_options'):
             self._validate_posted_profile_options(
@@ -3154,7 +3154,7 @@ class KubeSpawner(Spawner):
                         'kubespawner_override'
                     ]
 
-                self._apply_overrides(chosen_option_overrides)
+                await self._apply_overrides(chosen_option_overrides)
 
     # set of recognised user option keys
     # used for warning about ignoring unrecognised options

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3070,7 +3070,6 @@ class KubeSpawner(Spawner):
                     return profile
 
             # A slug is specified, but not found
-            # name specified, but not found
             raise ValueError(
                 "No such profile: %s. Options include: %s"
                 % (slug, ', '.join(p['slug'] for p in profile_list))

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -7,6 +7,7 @@ implementation that should be used by JupyterHub.
 import asyncio
 import ipaddress
 import os
+import re
 import string
 import sys
 import warnings
@@ -3078,6 +3079,17 @@ class KubeSpawner(Spawner):
                         ):
                             raise ValueError(
                                 f'Expected option {option_name} for profile {profile["slug"]} or -other-choice, not found in posted form'
+                            )
+                        other_choice = selected_profile_user_options[
+                            f'{option_name}-other-choice'
+                        ]
+                        other_choice_validation_regex = profile.get('profile_options')[
+                            option_name
+                        ]['other_choice']['validation_match_regex']
+                        regex = re.compile(other_choice_validation_regex)
+                        if not regex.match(other_choice):
+                            raise ValueError(
+                                f'Value of {option_name}-other-choice does not match validation regex.'
                             )
                     # other_choice is Disabled
                     else:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3187,7 +3187,8 @@ class KubeSpawner(Spawner):
             if 'slug' not in profile:
                 profile['slug'] = slugify(profile['display_name'])
 
-            # If profile_options are present with choices, but no
+            # If profile_options are present with choices, but no default choice
+            # is specified, we make the first choice the default
             for option_config in profile.get('profile_options', {}).values():
                 if option_config.get('choices'):
                     # Don't do anything if choices are not present, and only unlisted_choice

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1542,7 +1542,7 @@ class KubeSpawner(Spawner):
             select "Other" as a choice:
             - `enabled`: Boolean, whether the free form input should be enabled
             - `display_name`: String, label for input field
-            - `validation_match_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
+            - `validation_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
             - `validation_message`: Optional, validation message for the regex. Should describe the required
                input format in a human-readable way.
             - `kubespawner_override`: Object specifying what key:values should be over-ridden
@@ -1587,7 +1587,7 @@ class KubeSpawner(Spawner):
                             'other_choice': {
                                 'enabled': true,
                                 'display_name': 'Image Location',
-                                'validation_match_regex': '^pangeo/.*$',
+                                'validation_regex': '^pangeo/.*$',
                                 'validation_message': 'Must be a pangeo image, matching ^pangeo/.*$',
                                 'kubespawner_override': {
                                     'image': '{value}'
@@ -3074,24 +3074,24 @@ class KubeSpawner(Spawner):
                     # other_choice in Enabled:
                     if option.get('other_choice', {}).get('enabled', False):
                         if (
-                            f'{option_name}-other-choice'
+                            f'{option_name}--other-choice'
                             not in selected_profile_user_options
                         ):
                             raise ValueError(
-                                f'Expected option {option_name} for profile {profile["slug"]} or -other-choice, not found in posted form'
+                                f'Expected option {option_name} for profile {profile["slug"]} or --other-choice, not found in posted form'
                             )
                         other_choice = selected_profile_user_options[
-                            f'{option_name}-other-choice'
+                            f'{option_name}--other-choice'
                         ]
 
                         # Validate value of 'other-choice' against validation regex
                         other_choice_validation_regex = profile.get('profile_options')[
                             option_name
-                        ]['other_choice']['validation_match_regex']
+                        ]['other_choice']['validation_regex']
                         regex = re.compile(other_choice_validation_regex)
                         if not regex.match(other_choice):
                             raise ValueError(
-                                f'Value of {option_name}-other-choice does not match validation regex.'
+                                f'Value of {option_name}--other-choice does not match validation regex.'
                             )
                     # other_choice is Disabled
                     else:
@@ -3114,7 +3114,7 @@ class KubeSpawner(Spawner):
                 # Handle override for other-choice free text specified by user
                 if (
                     option.get('other_choice', {}).get('enabled', False)
-                    and f'{option_name}-other-choice' in selected_profile_user_options
+                    and f'{option_name}--other-choice' in selected_profile_user_options
                 ):
                     chosen_option_overrides = option['other_choice'][
                         'kubespawner_override'
@@ -3122,7 +3122,7 @@ class KubeSpawner(Spawner):
                     for k, v in chosen_option_overrides.items():
                         chosen_option_overrides[k] = v.format(
                             value=selected_profile_user_options[
-                                f'{option_name}-other-choice'
+                                f'{option_name}--other-choice'
                             ]
                         )
                 else:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3071,18 +3071,16 @@ class KubeSpawner(Spawner):
             # profiles
 
             for option_name, option in profile.get('profile_options').items():
+                other_choice_form_key = f'{option_name}--other-choice'
                 if option_name not in selected_profile_user_options:
                     # other_choice is enabled:
                     if option.get('other_choice', {}).get('enabled', False):
-                        if (
-                            f'{option_name}--other-choice'
-                            not in selected_profile_user_options
-                        ):
+                        if other_choice_form_key not in selected_profile_user_options:
                             raise ValueError(
-                                f'Expected option {option_name} for profile {profile["slug"]} or {option_name}--other-choice, not found in posted form'
+                                f'Expected option {option_name} for profile {profile["slug"]} or {other_choice_form_key}, not found in posted form'
                             )
                         other_choice = selected_profile_user_options[
-                            f'{option_name}--other-choice'
+                            other_choice_form_key
                         ]
 
                         # Validate value of 'other-choice' against validation regex
@@ -3096,7 +3094,7 @@ class KubeSpawner(Spawner):
                                 other_choice_validation_regex, other_choice
                             ):
                                 raise ValueError(
-                                    f'Value of {option_name}--other-choice does not match validation regex.'
+                                    f'Value of {other_choice_form_key} does not match validation regex.'
                                 )
                     # other_choice is Disabled
                     else:
@@ -3106,6 +3104,7 @@ class KubeSpawner(Spawner):
 
             # Get selected options or default to the first option if none is passed
             for option_name, option in profile.get('profile_options').items():
+                other_choice_form_key = f'{option_name}--other-choice'
                 chosen_option = selected_profile_user_options.get(option_name, None)
                 # If none was selected get the default
                 if not chosen_option:
@@ -3119,16 +3118,14 @@ class KubeSpawner(Spawner):
                 # Handle override for other-choice free text specified by user
                 if (
                     option.get('other_choice', {}).get('enabled', False)
-                    and f'{option_name}--other-choice' in selected_profile_user_options
+                    and other_choice_form_key in selected_profile_user_options
                 ):
                     chosen_option_overrides = option['other_choice'][
                         'kubespawner_override'
                     ]
                     for k, v in chosen_option_overrides.items():
                         chosen_option_overrides[k] = v.format(
-                            value=selected_profile_user_options[
-                                f'{option_name}--other-choice'
-                            ]
+                            value=selected_profile_user_options[other_choice_form_key]
                         )
                 else:
                     chosen_option_overrides = option['choices'][chosen_option][

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2926,7 +2926,6 @@ class KubeSpawner(Spawner):
     def _env_keep_default(self):
         return []
 
-
     def _render_options_form(self, profile_list):
         profile_list = self._populate_profile_list_defaults(profile_list)
 
@@ -3107,7 +3106,6 @@ class KubeSpawner(Spawner):
             else:
                 setattr(self, k, v)
 
-
     async def _load_profile(self, slug, selected_profile_user_options):
         """Load a profile by name
 
@@ -3162,7 +3160,6 @@ class KubeSpawner(Spawner):
     # used for warning about ignoring unrecognised options
     _user_option_keys = {'profile'}
 
-
     def _populate_profile_list_defaults(self, profile_list: list):
         """
         Return a fully realized profile_list
@@ -3191,11 +3188,12 @@ class KubeSpawner(Spawner):
                 if option_config.get('choices'):
                     # Don't do anything if choices are not present, and only unlisted_choice
                     # is used.
-                    if not any(c.get('default') for c in option_config['choices'].values()):
+                    if not any(
+                        c.get('default') for c in option_config['choices'].values()
+                    ):
                         # No explicit default is set
                         default_choice = list(option_config['choices'].keys())[0]
                         option_config['choices'][default_choice]["default"] = True
-
 
         if not any(p.get("default") for p in profile_list):
             # No profile has 'default' explicitly set, we set it for the first profile in the List

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3130,14 +3130,12 @@ class KubeSpawner(Spawner):
             for option_name, option in profile.get('profile_options').items():
                 unlisted_choice_form_key = f'{option_name}--unlisted-choice'
                 chosen_option = selected_profile_user_options.get(option_name, None)
-                # If none was selected get the default
+                # If none was selected get the default. At least one choice is
+                # guaranteed to have the default set
                 if not chosen_option:
-                    default_option = list(option['choices'].keys())[0]
                     for choice_name, choice in option['choices'].items():
                         if choice.get('default', False):
-                            # explicit default, not the first
-                            default_option = choice_name
-                    chosen_option = default_option
+                            chosen_option = choice_name
 
                 # Handle override for unlisted_choice free text specified by user
                 if (

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3177,6 +3177,10 @@ class KubeSpawner(Spawner):
         This function is *idempotent*, you can pass the same profile_list
         through it as many times without any problems.
         """
+        if not profile_list:
+            # empty profile lists are just returned unmodified
+            return profile_list
+
         for profile in profile_list:
             # generate missing slug fields from display_name
             if 'slug' not in profile:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3083,6 +3083,8 @@ class KubeSpawner(Spawner):
                         other_choice = selected_profile_user_options[
                             f'{option_name}-other-choice'
                         ]
+
+                        # Validate value of 'other-choice' against validation regex
                         other_choice_validation_regex = profile.get('profile_options')[
                             option_name
                         ]['other_choice']['validation_match_regex']
@@ -3109,6 +3111,7 @@ class KubeSpawner(Spawner):
                             default_option = choice_name
                     chosen_option = default_option
 
+                # Handle override for other-choice free text specified by user
                 if (
                     option.get('other_choice', {}).get('enabled', False)
                     and f'{option_name}-other-choice' in selected_profile_user_options

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1538,7 +1538,7 @@ class KubeSpawner(Spawner):
           and the value is a dictionary with the following keys:
 
           - `display_name`: Name used to identify this particular option
-          - `other_choice`: Object to specify if there should be a free-form field if the user
+          - `unlisted_choice`: Object to specify if there should be a free-form field if the user
             select "Other" as a choice:
             - `enabled`: Boolean, whether the free form input should be enabled
             - `display_name`: String, label for input field
@@ -1547,8 +1547,8 @@ class KubeSpawner(Spawner):
                input format in a human-readable way.
             - `kubespawner_override`: Object specifying what key:values should be over-ridden
                with the value of the free form input, using `{value}` for the value to be substituted with
-               the user POSTed value in the `other-choice` input field. eg:
-              - some_config_key: some_value-with-{value}-substituted-with-what-user-wrote 
+               the user POSTed value in the `unlisted_choice` input field. eg:
+              - some_config_key: some_value-with-{value}-substituted-with-what-user-wrote
           - `choices`: A dictionary containing list of choices for the user to choose from
             to set the value for this particular option. The key is an identifier for this
             choice, and the value is a dictionary with the following possible keys:
@@ -1585,7 +1585,7 @@ class KubeSpawner(Spawner):
                     'profile_options': {
                         'image': {
                             'display_name': 'Image',
-                            'other_choice': {
+                            'unlisted_choice': {
                                 'enabled': true,
                                 'display_name': 'Image Location',
                                 'validation_regex': '^pangeo/.*$',
@@ -3071,32 +3071,32 @@ class KubeSpawner(Spawner):
             # profiles
 
             for option_name, option in profile.get('profile_options').items():
-                other_choice_form_key = f'{option_name}--other-choice'
+                unlisted_choice_form_key = f'{option_name}--unlisted-choice'
                 if option_name not in selected_profile_user_options:
-                    # other_choice is enabled:
-                    if option.get('other_choice', {}).get('enabled', False):
-                        if other_choice_form_key not in selected_profile_user_options:
+                    # unlisted_choice is enabled:
+                    if option.get('unlisted_choice', {}).get('enabled', False):
+                        if unlisted_choice_form_key not in selected_profile_user_options:
                             raise ValueError(
-                                f'Expected option {option_name} for profile {profile["slug"]} or {other_choice_form_key}, not found in posted form'
+                                f'Expected option {option_name} for profile {profile["slug"]} or {unlisted_choice_form_key}, not found in posted form'
                             )
-                        other_choice = selected_profile_user_options[
-                            other_choice_form_key
+                        unlisted_choice = selected_profile_user_options[
+                            unlisted_choice_form_key
                         ]
 
-                        # Validate value of 'other-choice' against validation regex
+                        # Validate value of 'unlisted_choice' against validation regex
                         if profile.get('profile_options')[option_name][
-                            'other_choice'
+                            'unlisted_choice'
                         ].get('validation_regex', False):
-                            other_choice_validation_regex = profile.get(
+                            unlisted_choice_validation_regex = profile.get(
                                 'profile_options'
-                            )[option_name]['other_choice']['validation_regex']
+                            )[option_name]['unlisted_choice']['validation_regex']
                             if not re.match(
-                                other_choice_validation_regex, other_choice
+                                unlisted_choice_validation_regex, unlisted_choice
                             ):
                                 raise ValueError(
-                                    f'Value of {other_choice_form_key} does not match validation regex.'
+                                    f'Value of {unlisted_choice_form_key} does not match validation regex.'
                                 )
-                    # other_choice is Disabled
+                    # unlisted_choice is Disabled
                     else:
                         raise ValueError(
                             f'Expected option {option_name} for profile {profile["slug"]}, not found in posted form'
@@ -3104,7 +3104,7 @@ class KubeSpawner(Spawner):
 
             # Get selected options or default to the first option if none is passed
             for option_name, option in profile.get('profile_options').items():
-                other_choice_form_key = f'{option_name}--other-choice'
+                unlisted_choice_form_key = f'{option_name}--unlisted-choice'
                 chosen_option = selected_profile_user_options.get(option_name, None)
                 # If none was selected get the default
                 if not chosen_option:
@@ -3115,17 +3115,17 @@ class KubeSpawner(Spawner):
                             default_option = choice_name
                     chosen_option = default_option
 
-                # Handle override for other-choice free text specified by user
+                # Handle override for unlisted_choice free text specified by user
                 if (
-                    option.get('other_choice', {}).get('enabled', False)
-                    and other_choice_form_key in selected_profile_user_options
+                    option.get('unlisted_choice', {}).get('enabled', False)
+                    and unlisted_choice_form_key in selected_profile_user_options
                 ):
-                    chosen_option_overrides = option['other_choice'][
+                    chosen_option_overrides = option['unlisted_choice'][
                         'kubespawner_override'
                     ]
                     for k, v in chosen_option_overrides.items():
                         chosen_option_overrides[k] = v.format(
-                            value=selected_profile_user_options[other_choice_form_key]
+                            value=selected_profile_user_options[unlisted_choice_form_key]
                         )
                 else:
                     chosen_option_overrides = option['choices'][chosen_option][

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3185,6 +3185,9 @@ class KubeSpawner(Spawner):
           default
 
         The profile_list passed in is mutated and returned.
+
+        This function is *idempotent*, you can pass the same profile_list
+        through it as many times without any problems.
         """
         for profile in profile_list:
             # generate missing slug fields from display_name

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2948,7 +2948,6 @@ class KubeSpawner(Spawner):
 
     async def _render_options_form_dynamically(self, current_spawner):
         profile_list = await maybe_future(self.profile_list(current_spawner))
-        profile_list = self._populate_profile_list_defaults(profile_list)
         return self._render_options_form(profile_list)
 
     @default('options_form')

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1542,7 +1542,7 @@ class KubeSpawner(Spawner):
             select "Other" as a choice:
             - `enabled`: Boolean, whether the free form input should be enabled
             - `display_name`: String, label for input field
-            - `validation_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
+            - `validation_regex`: Required if enabled is True, regex that the free form input should match - eg. ^pangeo/.*$
             - `validation_message`: Optional, validation message for the regex. Should describe the required
                input format in a human-readable way.
             - `kubespawner_override`: Object specifying what key:values should be over-ridden

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1537,6 +1537,9 @@ class KubeSpawner(Spawner):
           and the value is a dictionary with the following keys:
 
           - `display_name`: Name used to identify this particular option
+          - `allow_other`: Boolean, defines whether the select drop-down showing choices will show
+            an "Other" value. If "Other" is selected, the user will be given an input box. Defaults
+            to False.
           - `choices`: A dictionary containing list of choices for the user to choose from
             to set the value for this particular option. The key is an identifier for this
             choice, and the value is a dictionary with the following possible keys:
@@ -1573,6 +1576,7 @@ class KubeSpawner(Spawner):
                     'profile_options': {
                         'image': {
                             'display_name': 'Image',
+                            'allow_other': True,
                             'choices': {
                                 'pytorch': {
                                     'display_name': 'Python 3 Training Notebook',

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1537,9 +1537,16 @@ class KubeSpawner(Spawner):
           and the value is a dictionary with the following keys:
 
           - `display_name`: Name used to identify this particular option
-          - `allow_other`: Boolean, defines whether the select drop-down showing choices will show
-            an "Other" value. If "Other" is selected, the user will be given an input box. Defaults
-            to False.
+          - `free_form`: Object to specify if there should be a free-form field if the user
+            select "Other" as a choice:
+            - `enabled`: Boolean, whether the free form input should be enabled
+            - `display_name`: String, label for input field
+            - `match_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
+            - `validation_message`: Optional, validation message for the regex. Should describe the required
+               input format in a human-readable way.
+            - `kubespawner_override`: Object specifying what key:values should be over-ridden
+               with the value of the free form input
+              - some_config_key: some_value-with-{value}-substituted-with-what-user-wrote 
           - `choices`: A dictionary containing list of choices for the user to choose from
             to set the value for this particular option. The key is an identifier for this
             choice, and the value is a dictionary with the following possible keys:
@@ -1576,7 +1583,15 @@ class KubeSpawner(Spawner):
                     'profile_options': {
                         'image': {
                             'display_name': 'Image',
-                            'allow_other': True,
+                            'free_form': {
+                                'enabled': true,
+                                'display_name': 'Image Location',
+                                'match_regex': '^pangeo/.*$',
+                                'validation_message': 'Must be a pangeo image, matching ^pangeo/.*$',
+                                'kubespawner_override': {
+                                    'image': '{value}'
+                                }
+                            },
                             'choices': {
                                 'pytorch': {
                                     'display_name': 'Python 3 Training Notebook',

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1542,7 +1542,7 @@ class KubeSpawner(Spawner):
             select "Other" as a choice:
             - `enabled`: Boolean, whether the free form input should be enabled
             - `display_name`: String, label for input field
-            - `validation_regex`: Required if enabled is True, regex that the free form input should match - eg. ^pangeo/.*$
+            - `validation_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
             - `validation_message`: Optional, validation message for the regex. Should describe the required
                input format in a human-readable way.
             - `kubespawner_override`: Object specifying what key:values should be over-ridden
@@ -3085,14 +3085,17 @@ class KubeSpawner(Spawner):
                         ]
 
                         # Validate value of 'other-choice' against validation regex
-                        other_choice_validation_regex = profile.get('profile_options')[
-                            option_name
-                        ]['other_choice']['validation_regex']
-                        regex = re.compile(other_choice_validation_regex)
-                        if not regex.match(other_choice):
-                            raise ValueError(
-                                f'Value of {option_name}--other-choice does not match validation regex.'
-                            )
+                        if profile.get('profile_options')[option_name][
+                            'other_choice'
+                        ].get('validation_regex', False):
+                            other_choice_validation_regex = profile.get(
+                                'profile_options'
+                            )[option_name]['other_choice']['validation_regex']
+                            regex = re.compile(other_choice_validation_regex)
+                            if not regex.match(other_choice):
+                                raise ValueError(
+                                    f'Value of {option_name}--other-choice does not match validation regex.'
+                                )
                     # other_choice is Disabled
                     else:
                         raise ValueError(

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1537,11 +1537,11 @@ class KubeSpawner(Spawner):
           and the value is a dictionary with the following keys:
 
           - `display_name`: Name used to identify this particular option
-          - `free_form`: Object to specify if there should be a free-form field if the user
+          - `other_choice`: Object to specify if there should be a free-form field if the user
             select "Other" as a choice:
             - `enabled`: Boolean, whether the free form input should be enabled
             - `display_name`: String, label for input field
-            - `match_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
+            - `validation_match_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
             - `validation_message`: Optional, validation message for the regex. Should describe the required
                input format in a human-readable way.
             - `kubespawner_override`: Object specifying what key:values should be over-ridden
@@ -1583,10 +1583,10 @@ class KubeSpawner(Spawner):
                     'profile_options': {
                         'image': {
                             'display_name': 'Image',
-                            'free_form': {
+                            'other_choice': {
                                 'enabled': true,
                                 'display_name': 'Image Location',
-                                'match_regex': '^pangeo/.*$',
+                                'validation_match_regex': '^pangeo/.*$',
                                 'validation_message': 'Must be a pangeo image, matching ^pangeo/.*$',
                                 'kubespawner_override': {
                                     'image': '{value}'

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3054,16 +3054,16 @@ class KubeSpawner(Spawner):
                         f'Expected option {option_name} for profile {profile["slug"]}, not found in posted form'
                     )
 
-    def _get_profile(self, slug: str, profile_list: list):
+    def _get_profile(self, slug: Optional[str], profile_list: list):
         """
         Get the configured profile for given profile slug
 
         Raises an error if no profile exists for the given slug.
 
-        If slug is empty string, return the default profile
+        If slug is empty string or None, return the default profile
         profile_list should already have all its defaults set.
         """
-        if slug != "":
+        if slug:
             for profile in profile_list:
                 if profile['slug'] == slug:
                     return profile

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -17,15 +17,24 @@
         {%- if profile.profile_options %}
           <div>
             {%- for k, option in profile.profile_options.items() %}
-              <div class="option">
-                <label for="profile-option-{{ profile.slug }}-{{ k }}"
-                       class="js-profile-option-label">{{ option.display_name }}</label>
-                <select name="profile-option-{{ profile.slug }}-{{ k }}"
-                        class="form-control js-profile-option-select">
-                  {%- for k, choice in option['choices'].items() %}
-                    <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
-                  {%- endfor %}
-                </select>
+              <div class="js-options-container">
+                <div class="option">
+                  <label for="profile-option-{{ profile.slug }}-{{ k }}"
+                         class="js-profile-option-label">{{ option.display_name }}</label>
+                  <select name="profile-option-{{ profile.slug }}-{{ k }}"
+                          class="form-control js-profile-option-select">
+                    {%- for k, choice in option['choices'].items() %}
+                      <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
+                    {%- endfor %}
+                    {%- if option['allow_other'] %}<option value="other">Other...</option>{%- endif %}
+                  </select>
+                </div>
+                {%- if option['allow_other'] %}
+                  <div class="option hide js-other-input-container">
+                    <label for="profile-option-{{ profile.slug }}-other">Image location:</label>
+                    <input name="profile-option-{{ profile.slug }}-other" class="form-control">
+                  </div>
+                {%- endif %}
               </div>
             {%- endfor %}
           </div>
@@ -41,4 +50,16 @@
       .find('input[type=radio]')
       .prop('checked', true);
   });
+
+  // If the user selects "Other" in the dropdown, show the free text field
+  $('.js-profile-option-select').change(function() {
+    const selectionValue = $(this).val();
+    const $otherInputContainer = $(this).parents('.js-options-container').find('.js-other-input-container');
+    if (selectionValue === 'other') {
+      $otherInputContainer.removeClass('hide');
+    } else {
+      $otherInputContainer.addClass('hide');
+    }
+  });
+
 </script>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -26,21 +26,21 @@
                     {%- for k, choice in option['choices'].items() %}
                       <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                     {%- endfor %}
-                    {%- if option['other_choice'] and option['other_choice']['enabled'] %}
-                      <option value="other-choice">Other...</option>
+                    {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
+                      <option value="unlisted-choice">Other...</option>
                     {%- endif %}
                   </select>
                 </div>
-                {%- if option['other_choice'] and option['other_choice']['enabled'] %}
+                {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
                   <div class="option hidden js-other-input-container">
-                    <label for="profile-option-{{ profile.slug }}-{{ k }}--other-choice">
-                      {{ option['other_choice']['display_name'] }}
+                    <label for="profile-option-{{ profile.slug }}-{{ k }}--unlisted-choice">
+                      {{ option['unlisted_choice']['display_name'] }}
                     </label>
-                    <input data-name="profile-option-{{ profile.slug }}-{{ k }}--other-choice"
-                           {%- if option['other_choice']['validation_regex'] %}
-                           pattern="{{ option['other_choice']['validation_regex'] }}"
+                    <input data-name="profile-option-{{ profile.slug }}-{{ k }}--unlisted-choice"
+                           {%- if option['unlisted_choice']['validation_regex'] %}
+                           pattern="{{ option['unlisted_choice']['validation_regex'] }}"
                            {%- endif %}
-                           title="{{ option['other_choice']['validation_message'] }}"
+                           title="{{ option['unlisted_choice']['validation_message'] }}"
                            class="form-control js-other-input" />
                   </div>
                 {%- endif %}
@@ -65,10 +65,10 @@
     const selectionValue = $(this).val();
     const $otherInputContainer = $(this).parents('.js-options-container').find('.js-other-input-container');
     const $otherInput = $(this).parents('.js-options-container').find('.js-other-input');
-    if (selectionValue === 'other-choice') {
+    if (selectionValue === 'unlisted-choice') {
 
-      // if the Select box is selected with a value that is not 'other-choice',
-      // we remove the "name" attribute for the other-choice input
+      // if the Select box is selected with a value that is not 'unlisted-choice',
+      // we remove the "name" attribute for the unlisted-choice input
       // and vice-versa, so that we only submit valid form values
       // and don't leave the complexity of figuring out which value
       // to use to the back-end.

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -37,7 +37,9 @@
                       {{ option['other_choice']['display_name'] }}
                     </label>
                     <input data-name="profile-option-{{ profile.slug }}-{{ k }}--other-choice"
+                           {%- if option['other_choice']['validation_regex'] %}
                            pattern="{{ option['other_choice']['validation_regex'] }}"
+                           {%- endif %}
                            title="{{ option['other_choice']['validation_message'] }}"
                            class="form-control js-other-input" />
                   </div>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -26,13 +26,16 @@
                     {%- for k, choice in option['choices'].items() %}
                       <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                     {%- endfor %}
-                    {%- if option['allow_other'] %}<option value="other">Other...</option>{%- endif %}
+                    {%- if option['free_form'] and option['free_form']['enabled'] %}<option value="other">Other...</option>{%- endif %}
                   </select>
                 </div>
-                {%- if option['allow_other'] %}
+                {%- if option['free_form'] and option['free_form']['enabled'] %}
                   <div class="option hide js-other-input-container">
-                    <label for="profile-option-{{ profile.slug }}-other">Image location:</label>
-                    <input name="profile-option-{{ profile.slug }}-other" class="form-control">
+                    <label for="profile-option-{{ profile.slug }}-{{ k }}-other">{{ option['free_form']['display_name'] }}</label>
+                    <input name="profile-option-{{ profile.slug }}-{{ k }}-other"
+                           pattern="{{ option['free_form']['match_regex'] }}"
+                           title="{{ option['free_form']['validation_message'] }}"
+                           class="form-control" />
                   </div>
                 {%- endif %}
               </div>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -32,7 +32,7 @@
                   </select>
                 </div>
                 {%- if option['other_choice'] and option['other_choice']['enabled'] %}
-                  <div class="option hide js-other-input-container">
+                  <div class="option hidden js-other-input-container">
                     <label for="profile-option-{{ profile.slug }}-{{ k }}--other-choice">
                       {{ option['other_choice']['display_name'] }}
                     </label>
@@ -78,11 +78,11 @@
       $(this).data('name', $(this).attr('name'));
       $(this).removeAttr('name');
       $otherInput.attr('name', $otherInput.data('name'));
-      $otherInputContainer.removeClass('hide');
+      $otherInputContainer.removeClass('hidden');
     } else {
       $otherInput.removeAttr('name');
       $(this).attr('name', $(this).data('name'));
-      $otherInputContainer.addClass('hide');
+      $otherInputContainer.addClass('hidden');
     }
   });
 

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -26,15 +26,19 @@
                     {%- for k, choice in option['choices'].items() %}
                       <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                     {%- endfor %}
-                    {%- if option['free_form'] and option['free_form']['enabled'] %}<option value="other">Other...</option>{%- endif %}
+                    {%- if option['other_choice'] and option['other_choice']['enabled'] %}
+                      <option value="other">Other...</option>
+                    {%- endif %}
                   </select>
                 </div>
-                {%- if option['free_form'] and option['free_form']['enabled'] %}
+                {%- if option['other_choice'] and option['other_choice']['enabled'] %}
                   <div class="option hide js-other-input-container">
-                    <label for="profile-option-{{ profile.slug }}-{{ k }}-other">{{ option['free_form']['display_name'] }}</label>
-                    <input name="profile-option-{{ profile.slug }}-{{ k }}-other"
-                           pattern="{{ option['free_form']['match_regex'] }}"
-                           title="{{ option['free_form']['validation_message'] }}"
+                    <label for="profile-option-{{ profile.slug }}-{{ k }}-other-choice">
+                      {{ option['other_choice']['display_name'] }}
+                    </label>
+                    <input name="profile-option-{{ profile.slug }}-{{ k }}-other-choice"
+                           pattern="{{ option['other_choice']['validation_match_regex'] }}"
+                           title="{{ option['other_choice']['validation_message'] }}"
                            class="form-control" />
                   </div>
                 {%- endif %}

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -33,10 +33,10 @@
                 </div>
                 {%- if option['other_choice'] and option['other_choice']['enabled'] %}
                   <div class="option hide js-other-input-container">
-                    <label for="profile-option-{{ profile.slug }}-{{ k }}-other-choice">
+                    <label for="profile-option-{{ profile.slug }}-{{ k }}--other-choice">
                       {{ option['other_choice']['display_name'] }}
                     </label>
-                    <input data-name="profile-option-{{ profile.slug }}-{{ k }}-other-choice"
+                    <input data-name="profile-option-{{ profile.slug }}-{{ k }}--other-choice"
                            pattern="{{ option['other_choice']['validation_regex'] }}"
                            title="{{ option['other_choice']['validation_message'] }}"
                            class="form-control js-other-input" />

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -27,7 +27,7 @@
                       <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                     {%- endfor %}
                     {%- if option['other_choice'] and option['other_choice']['enabled'] %}
-                      <option value="other">Other...</option>
+                      <option value="other-choice">Other...</option>
                     {%- endif %}
                   </select>
                 </div>
@@ -63,7 +63,7 @@
     const selectionValue = $(this).val();
     const $otherInputContainer = $(this).parents('.js-options-container').find('.js-other-input-container');
     const $otherInput = $(this).parents('.js-options-container').find('.js-other-input');
-    if (selectionValue === 'other') {
+    if (selectionValue === 'other-choice') {
 
       // if the Select box is selected with a value that is not 'other',
       // we remove the "name" attribute for the other-choice input

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -65,7 +65,7 @@
     const $otherInput = $(this).parents('.js-options-container').find('.js-other-input');
     if (selectionValue === 'other-choice') {
 
-      // if the Select box is selected with a value that is not 'other',
+      // if the Select box is selected with a value that is not 'other-choice',
       // we remove the "name" attribute for the other-choice input
       // and vice-versa, so that we only submit valid form values
       // and don't leave the complexity of figuring out which value
@@ -84,5 +84,13 @@
     }
   });
 
+  // wrapping in a document.ready to make clear this is executed once
+  // on page load
+  $(document).ready(() => {
+    // trigger the `change` event on the select inputs,
+    // so that if "Other" is selected on page load, the corresponding
+    // free-text input shows
+    $('.js-profile-option-select').trigger('change');
+  });
 
 </script>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -37,7 +37,7 @@
                       {{ option['other_choice']['display_name'] }}
                     </label>
                     <input data-name="profile-option-{{ profile.slug }}-{{ k }}-other-choice"
-                           pattern="{{ option['other_choice']['validation_match_regex'] }}"
+                           pattern="{{ option['other_choice']['validation_regex'] }}"
                            title="{{ option['other_choice']['validation_message'] }}"
                            class="form-control js-other-input" />
                   </div>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -64,6 +64,15 @@
     const $otherInputContainer = $(this).parents('.js-options-container').find('.js-other-input-container');
     const $otherInput = $(this).parents('.js-options-container').find('.js-other-input');
     if (selectionValue === 'other') {
+
+      // if the Select box is selected with a value that is not 'other',
+      // we remove the "name" attribute for the other-choice input
+      // and vice-versa, so that we only submit valid form values
+      // and don't leave the complexity of figuring out which value
+      // to use to the back-end.
+
+      // This can probably be done cleaner by completely refactoring
+      // how we send values from the frontend.
       $(this).data('name', $(this).attr('name'));
       $(this).removeAttr('name');
       $otherInput.attr('name', $otherInput.data('name'));

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -36,10 +36,10 @@
                     <label for="profile-option-{{ profile.slug }}-{{ k }}-other-choice">
                       {{ option['other_choice']['display_name'] }}
                     </label>
-                    <input name="profile-option-{{ profile.slug }}-{{ k }}-other-choice"
+                    <input data-name="profile-option-{{ profile.slug }}-{{ k }}-other-choice"
                            pattern="{{ option['other_choice']['validation_match_regex'] }}"
                            title="{{ option['other_choice']['validation_message'] }}"
-                           class="form-control" />
+                           class="form-control js-other-input" />
                   </div>
                 {%- endif %}
               </div>
@@ -62,11 +62,18 @@
   $('.js-profile-option-select').change(function() {
     const selectionValue = $(this).val();
     const $otherInputContainer = $(this).parents('.js-options-container').find('.js-other-input-container');
+    const $otherInput = $(this).parents('.js-options-container').find('.js-other-input');
     if (selectionValue === 'other') {
+      $(this).data('name', $(this).attr('name'));
+      $(this).removeAttr('name');
+      $otherInput.attr('name', $otherInput.data('name'));
       $otherInputContainer.removeClass('hide');
     } else {
+      $otherInput.removeAttr('name');
+      $(this).attr('name', $(this).data('name'));
       $otherInputContainer.addClass('hide');
     }
   });
+
 
 </script>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -18,8 +18,10 @@
           <div>
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
-                <span class="profile-options-label">{{ option.display_name }}</span>
-                <select name="profile-option-{{ profile.slug }}-{{ k }}">
+                <label for="profile-option-{{ profile.slug }}-{{ k }}"
+                       class="js-profile-option-label">{{ option.display_name }}</label>
+                <select name="profile-option-{{ profile.slug }}-{{ k }}"
+                        class="form-control js-profile-option-select">
                   {%- for k, choice in option['choices'].items() %}
                     <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                   {%- endfor %}
@@ -33,7 +35,7 @@
   {%- endfor %}
 </div>
 <script>
-  $('.js-profile-option-select').click(function() {
+  $('.js-profile-option-select, .js-profile-option-label').click(function() {
     // we need this bit of JS to select the profile when a <select> inside is clicked.
     $(this).parents('.js-profile-label')
       .find('input[type=radio]')

--- a/kubespawner/templates/style.css
+++ b/kubespawner/templates/style.css
@@ -27,7 +27,3 @@
   margin-right: 8px;
   min-width: 96px;
 }
-
-.hide {
-  display: none;
-}

--- a/kubespawner/templates/style.css
+++ b/kubespawner/templates/style.css
@@ -27,3 +27,7 @@
   margin-right: 8px;
   min-width: 96px;
 }
+
+.hide {
+  display: none;
+}

--- a/kubespawner/templates/style.css
+++ b/kubespawner/templates/style.css
@@ -22,7 +22,7 @@
   padding-bottom: 12px;
 }
 
-#kubespawner-profiles-list .profile-options-label {
+#kubespawner-profiles-list .profile .option label {
   font-weight: normal;
   margin-right: 8px;
   min-width: 96px;

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,5 +1,6 @@
-from kubespawner import KubeSpawner
 import pytest
+
+from kubespawner import KubeSpawner
 
 
 @pytest.mark.parametrize(
@@ -190,20 +191,21 @@ async def test_find_slug(profile_list, slug, selected_profile):
     spawner.profile_list = profile_list
     assert spawner._get_profile(slug) == selected_profile
 
+
 async def test_find_slug_exception():
     """
     Test that looking for a slug that doesn't exist gives us an exception
     """
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = [
-                {
-                    'display_name': 'profile 1',
-                    'kubespawner_override': {},
-                },
-                {
-                    'display_name': 'profile 2',
-                    'kubespawner_override': {},
-                },
-            ]
+        {
+            'display_name': 'profile 1',
+            'kubespawner_override': {},
+        },
+        {
+            'display_name': 'profile 2',
+            'kubespawner_override': {},
+        },
+    ]
     with pytest.raises(ValueError):
         spawner._get_profile('does-not-exist')

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -140,7 +140,7 @@ async def test_profile_missing_defaults_populated(
 
 
 @pytest.mark.parametrize(
-    "profile_list,slug,selected_profile,exception",
+    "profile_list,slug,selected_profile",
     [
         (
             [
@@ -183,6 +183,27 @@ async def test_profile_missing_defaults_populated(
     ],
 )
 async def test_find_slug(profile_list, slug, selected_profile):
+    """
+    Test that we can find the profile we expect given slugs
+    """
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = profile_list
     assert spawner._get_profile(slug) == selected_profile
+
+async def test_find_slug_exception():
+    """
+    Test that looking for a slug that doesn't exist gives us an exception
+    """
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = [
+                {
+                    'display_name': 'profile 1',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'profile 2',
+                    'kubespawner_override': {},
+                },
+            ]
+    with pytest.raises(ValueError):
+        spawner._get_profile('does-not-exist')

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -189,8 +189,8 @@ async def test_find_slug(profile_list, slug, selected_profile):
     Test that we can find the profile we expect given slugs
     """
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = profile_list
-    assert spawner._get_profile(slug) == selected_profile
+    profile_list = spawner._populate_profile_list_defaults(profile_list)
+    assert spawner._get_profile(slug, profile_list) == selected_profile
 
 
 async def test_find_slug_exception():
@@ -198,7 +198,7 @@ async def test_find_slug_exception():
     Test that looking for a slug that doesn't exist gives us an exception
     """
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = [
+    profile_list = [
         {
             'display_name': 'profile 1',
             'kubespawner_override': {},
@@ -208,5 +208,6 @@ async def test_find_slug_exception():
             'kubespawner_override': {},
         },
     ]
+    profile_list = spawner._populate_profile_list_defaults(profile_list)
     with pytest.raises(ValueError):
-        spawner._get_profile('does-not-exist')
+        spawner._get_profile('does-not-exist', profile_list)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -125,6 +125,7 @@ from kubespawner import KubeSpawner
                 },
             ],
         ),
+        ([], []),
     ],
 )
 async def test_profile_missing_defaults_populated(

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -21,6 +21,7 @@ import pytest
                 {
                     'display_name': 'Something without a slug',
                     'slug': 'something-without-a-slug',
+                    'default': True,
                     'kubespawner_override': {},
                 },
                 {
@@ -39,41 +40,40 @@ import pytest
                 {
                     'display_name': 'Something with choices',
                     'kubespawner_override': {},
+                    'default': True,
                     'profile_options': {
                         'no-defaults': {
                             'display_name': 'Some choice without a default set',
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',
-                                    'kubespawner_override': {}
+                                    'kubespawner_override': {},
                                 },
                                 'option-2': {
                                     'display_name': 'Option 2',
-                                    'kubespawner_override': {}
-                                }
-                            }
+                                    'kubespawner_override': {},
+                                },
+                            },
                         },
                         'only-unlisted': {
                             'display_name': 'Some option without any choices set',
-                            'unlisted_choice': {
-                                'enabled': True
-                            }
+                            'unlisted_choice': {'enabled': True},
                         },
                         'explicit-defaults': {
                             'display_name': 'Some choice with a default set',
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',
-                                    'kubespawner_override': {}
+                                    'kubespawner_override': {},
                                 },
                                 'option-2': {
                                     'display_name': 'Option 2',
                                     'default': True,
-                                    'kubespawner_override': {}
-                                }
-                            }
-                        }
-                    }
+                                    'kubespawner_override': {},
+                                },
+                            },
+                        },
+                    },
                 },
             ],
             [
@@ -85,6 +85,7 @@ import pytest
                 {
                     'display_name': 'Something with choices',
                     'slug': 'something-with-choices',
+                    'default': True,
                     'kubespawner_override': {},
                     'profile_options': {
                         'no-defaults': {
@@ -93,35 +94,33 @@ import pytest
                                 'option-1': {
                                     'display_name': 'Option 1',
                                     'default': True,
-                                    'kubespawner_override': {}
+                                    'kubespawner_override': {},
                                 },
                                 'option-2': {
                                     'display_name': 'Option 2',
-                                    'kubespawner_override': {}
-                                }
-                            }
+                                    'kubespawner_override': {},
+                                },
+                            },
                         },
                         'only-unlisted': {
                             'display_name': 'Some option without any choices set',
-                            'unlisted_choice': {
-                                'enabled': True
-                            }
+                            'unlisted_choice': {'enabled': True},
                         },
                         'explicit-defaults': {
                             'display_name': 'Some choice with a default set',
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',
-                                    'kubespawner_override': {}
+                                    'kubespawner_override': {},
                                 },
                                 'option-2': {
                                     'display_name': 'Option 2',
                                     'default': True,
-                                    'kubespawner_override': {}
-                                }
-                            }
-                        }
-                    }
+                                    'kubespawner_override': {},
+                                },
+                            },
+                        },
+                    },
                 },
             ],
         ),
@@ -138,3 +137,52 @@ async def test_profile_missing_defaults_populated(
         spawner._populate_profile_list_defaults(unfilled_profile_list)
         == filled_profile_list
     )
+
+
+@pytest.mark.parametrize(
+    "profile_list,slug,selected_profile,exception",
+    [
+        (
+            [
+                {
+                    'display_name': 'profile 1',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'profile 2',
+                    'kubespawner_override': {},
+                },
+            ],
+            'profile-2',
+            {
+                'display_name': 'profile 2',
+                'slug': 'profile-2',
+                'kubespawner_override': {},
+            },
+        ),
+        (
+            [
+                {
+                    'display_name': 'profile 1',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'profile 2',
+                    'default': True,
+                    'kubespawner_override': {},
+                },
+            ],
+            '',
+            {
+                'display_name': 'profile 2',
+                'slug': 'profile-2',
+                'default': True,
+                'kubespawner_override': {},
+            },
+        ),
+    ],
+)
+async def test_find_slug(profile_list, slug, selected_profile):
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = profile_list
+    assert spawner._get_profile(slug) == selected_profile

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,140 @@
+from kubespawner import KubeSpawner
+import pytest
+
+
+@pytest.mark.parametrize(
+    "unfilled_profile_list,filled_profile_list",
+    [
+        (
+            [
+                {
+                    'display_name': 'Something without a slug',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'Something with a slug',
+                    'slug': 'sluggity-slug',
+                    'kubespawner_override': {},
+                },
+            ],
+            [
+                {
+                    'display_name': 'Something without a slug',
+                    'slug': 'something-without-a-slug',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'Something with a slug',
+                    'slug': 'sluggity-slug',
+                    'kubespawner_override': {},
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    'display_name': 'Something without choices',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'Something with choices',
+                    'kubespawner_override': {},
+                    'profile_options': {
+                        'no-defaults': {
+                            'display_name': 'Some choice without a default set',
+                            'choices': {
+                                'option-1': {
+                                    'display_name': 'Option 1',
+                                    'kubespawner_override': {}
+                                },
+                                'option-2': {
+                                    'display_name': 'Option 2',
+                                    'kubespawner_override': {}
+                                }
+                            }
+                        },
+                        'only-unlisted': {
+                            'display_name': 'Some option without any choices set',
+                            'unlisted_choice': {
+                                'enabled': True
+                            }
+                        },
+                        'explicit-defaults': {
+                            'display_name': 'Some choice with a default set',
+                            'choices': {
+                                'option-1': {
+                                    'display_name': 'Option 1',
+                                    'kubespawner_override': {}
+                                },
+                                'option-2': {
+                                    'display_name': 'Option 2',
+                                    'default': True,
+                                    'kubespawner_override': {}
+                                }
+                            }
+                        }
+                    }
+                },
+            ],
+            [
+                {
+                    'display_name': 'Something without choices',
+                    'slug': 'something-without-choices',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'Something with choices',
+                    'slug': 'something-with-choices',
+                    'kubespawner_override': {},
+                    'profile_options': {
+                        'no-defaults': {
+                            'display_name': 'Some choice without a default set',
+                            'choices': {
+                                'option-1': {
+                                    'display_name': 'Option 1',
+                                    'default': True,
+                                    'kubespawner_override': {}
+                                },
+                                'option-2': {
+                                    'display_name': 'Option 2',
+                                    'kubespawner_override': {}
+                                }
+                            }
+                        },
+                        'only-unlisted': {
+                            'display_name': 'Some option without any choices set',
+                            'unlisted_choice': {
+                                'enabled': True
+                            }
+                        },
+                        'explicit-defaults': {
+                            'display_name': 'Some choice with a default set',
+                            'choices': {
+                                'option-1': {
+                                    'display_name': 'Option 1',
+                                    'kubespawner_override': {}
+                                },
+                                'option-2': {
+                                    'display_name': 'Option 2',
+                                    'default': True,
+                                    'kubespawner_override': {}
+                                }
+                            }
+                        }
+                    }
+                },
+            ],
+        ),
+    ],
+)
+async def test_profile_missing_defaults_populated(
+    unfilled_profile_list, filled_profile_list
+):
+    """
+    Tests that missing profileList values are populated
+    """
+    spawner = KubeSpawner(_mock=True)
+    assert (
+        spawner._populate_profile_list_defaults(unfilled_profile_list)
+        == filled_profile_list
+    )

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -174,6 +174,26 @@ async def test_profile_missing_defaults_populated(
                     'kubespawner_override': {},
                 },
             ],
+            None,
+            {
+                'display_name': 'profile 2',
+                'slug': 'profile-2',
+                'default': True,
+                'kubespawner_override': {},
+            },
+        ),
+        (
+            [
+                {
+                    'display_name': 'profile 1',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'profile 2',
+                    'default': True,
+                    'kubespawner_override': {},
+                },
+            ],
             '',
             {
                 'display_name': 'profile 2',

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -969,6 +969,26 @@ async def test_user_options_set_from_form_other_choice():
     assert getattr(spawner, 'image') == 'pangeo/test:latest'
 
 
+async def test_user_options_set_from_form_invalid_regex():
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = _test_profiles
+    await spawner.get_options_form()
+    spawner.user_options = spawner.options_from_form(
+        {
+            'profile': [_test_profiles[3]['slug']],
+            'profile-option-test-choices-image-other-choice': ['invalid/foo:latest'],
+        }
+    )
+    assert spawner.user_options == {
+        'image-other-choice': 'invalid/foo:latest',
+        'profile': _test_profiles[3]['slug'],
+    }
+    assert spawner.cpu_limit is None
+
+    with pytest.raises(ValueError):
+        await spawner.load_user_options()
+
+
 async def test_kubespawner_override():
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = _test_profiles

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -993,7 +993,9 @@ async def test_user_options_set_from_form_unlisted_choice():
     spawner.user_options = spawner.options_from_form(
         {
             'profile': [_test_profiles[3]['slug']],
-            'profile-option-test-choices-image--unlisted-choice': ['pangeo/test:latest'],
+            'profile-option-test-choices-image--unlisted-choice': [
+                'pangeo/test:latest'
+            ],
         }
     )
     assert spawner.user_options == {
@@ -1016,7 +1018,9 @@ async def test_user_options_set_from_form_invalid_regex():
     spawner.user_options = spawner.options_from_form(
         {
             'profile': [_test_profiles[3]['slug']],
-            'profile-option-test-choices-image--unlisted-choice': ['invalid/foo:latest'],
+            'profile-option-test-choices-image--unlisted-choice': [
+                'invalid/foo:latest'
+            ],
         }
     )
     assert spawner.user_options == {

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -887,7 +887,7 @@ _test_profiles = [
         'profile_options': {
             'image': {
                 'display_name': 'Image',
-                'other_choice': {
+                'unlisted_choice': {
                     'enabled': True,
                     'display_name': 'Image Location',
                     'validation_regex': '^pangeo/.*$',
@@ -916,7 +916,7 @@ _test_profiles = [
         'profile_options': {
             'image': {
                 'display_name': 'Image',
-                'other_choice': {
+                'unlisted_choice': {
                     'enabled': True,
                     'display_name': 'Image Location',
                     'kubespawner_override': {'image': '{value}'},
@@ -982,9 +982,9 @@ async def test_user_options_set_from_form_choices():
     assert getattr(spawner, 'image') == 'pangeo/pytorch-notebook:master'
 
 
-async def test_user_options_set_from_form_other_choice():
+async def test_user_options_set_from_form_unlisted_choice():
     """
-    Test that when user sends an arbitrary text input in the `other_choice` field,
+    Test that when user sends an arbitrary text input in the `unlisted_choice` field,
     it is process correctly and the correct attribute over-ridden on the spawner.
     """
     spawner = KubeSpawner(_mock=True)
@@ -993,11 +993,11 @@ async def test_user_options_set_from_form_other_choice():
     spawner.user_options = spawner.options_from_form(
         {
             'profile': [_test_profiles[3]['slug']],
-            'profile-option-test-choices-image--other-choice': ['pangeo/test:latest'],
+            'profile-option-test-choices-image--unlisted-choice': ['pangeo/test:latest'],
         }
     )
     assert spawner.user_options == {
-        'image--other-choice': 'pangeo/test:latest',
+        'image--unlisted-choice': 'pangeo/test:latest',
         'profile': _test_profiles[3]['slug'],
     }
     assert spawner.cpu_limit is None
@@ -1007,8 +1007,8 @@ async def test_user_options_set_from_form_other_choice():
 
 async def test_user_options_set_from_form_invalid_regex():
     """
-    Test that if the user input for the `other-choice` field does not match the regex
-    specified in the `validation_match_regex` option for the `other_choice`, a ValueError is raised.
+    Test that if the user input for the `unlisted-choice` field does not match the regex
+    specified in the `validation_match_regex` option for the `unlisted_choice`, a ValueError is raised.
     """
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = _test_profiles
@@ -1016,11 +1016,11 @@ async def test_user_options_set_from_form_invalid_regex():
     spawner.user_options = spawner.options_from_form(
         {
             'profile': [_test_profiles[3]['slug']],
-            'profile-option-test-choices-image--other-choice': ['invalid/foo:latest'],
+            'profile-option-test-choices-image--unlisted-choice': ['invalid/foo:latest'],
         }
     )
     assert spawner.user_options == {
-        'image--other-choice': 'invalid/foo:latest',
+        'image--unlisted-choice': 'invalid/foo:latest',
         'profile': _test_profiles[3]['slug'],
     }
     assert spawner.cpu_limit is None
@@ -1031,7 +1031,7 @@ async def test_user_options_set_from_form_invalid_regex():
 
 async def test_user_options_set_from_form_no_regex():
     """
-    Test that if the `other_choice` object in the profile_options does not contain
+    Test that if the `unlisted_choice` object in the profile_options does not contain
     a `validation_regex` key, no validation is done and the input is correctly processed - i.e. validation_regex is optional.
     """
     spawner = KubeSpawner(_mock=True)
@@ -1041,11 +1041,11 @@ async def test_user_options_set_from_form_no_regex():
     spawner.user_options = spawner.options_from_form(
         {
             'profile': [_test_profiles[4]['slug']],
-            'profile-option-no-regex-image--other-choice': ['invalid/foo:latest'],
+            'profile-option-no-regex-image--unlisted-choice': ['invalid/foo:latest'],
         }
     )
     assert spawner.user_options == {
-        'image--other-choice': 'invalid/foo:latest',
+        'image--unlisted-choice': 'invalid/foo:latest',
         'profile': _test_profiles[4]['slug'],
     }
     assert spawner.cpu_limit is None

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -959,6 +959,11 @@ async def test_user_options_set_from_form():
 
 
 async def test_user_options_set_from_form_choices():
+    """
+    Test that the `choices` field in profile_options is processed correctly -
+    i.e. when a user sends a profile option choice, it is correctly processed
+    in user_options and the value on the spawner correctly over-ridden by the user choice.
+    """
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = _test_profiles
     await spawner.get_options_form()
@@ -978,6 +983,10 @@ async def test_user_options_set_from_form_choices():
 
 
 async def test_user_options_set_from_form_other_choice():
+    """
+    Test that when user sends an arbitrary text input in the `other_choice` field,
+    it is process correctly and the correct attribute over-ridden on the spawner.
+    """
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = _test_profiles
     await spawner.get_options_form()
@@ -997,6 +1006,10 @@ async def test_user_options_set_from_form_other_choice():
 
 
 async def test_user_options_set_from_form_invalid_regex():
+    """
+    Test that if the user input for the `other-choice` field does not match the regex
+    specified in the `validation_match_regex` option for the `other_choice`, a ValueError is raised.
+    """
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = _test_profiles
     await spawner.get_options_form()
@@ -1017,6 +1030,10 @@ async def test_user_options_set_from_form_invalid_regex():
 
 
 async def test_user_options_set_from_form_no_regex():
+    """
+    Test that if the `other_choice` object in the profile_options does not contain
+    a `validation_regex` key, no validation is done and the input is correctly processed - i.e. validation_regex is optional.
+    """
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = _test_profiles
     await spawner.get_options_form()

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -890,7 +890,7 @@ _test_profiles = [
                 'other_choice': {
                     'enabled': True,
                     'display_name': 'Image Location',
-                    'validation_match_regex': '^pangeo/.*$',
+                    'validation_regex': '^pangeo/.*$',
                     'validation_message': 'Must be a pangeo image, matching ^pangeo/.*$',
                     'kubespawner_override': {'image': '{value}'},
                 },
@@ -957,11 +957,11 @@ async def test_user_options_set_from_form_other_choice():
     spawner.user_options = spawner.options_from_form(
         {
             'profile': [_test_profiles[3]['slug']],
-            'profile-option-test-choices-image-other-choice': ['pangeo/test:latest'],
+            'profile-option-test-choices-image--other-choice': ['pangeo/test:latest'],
         }
     )
     assert spawner.user_options == {
-        'image-other-choice': 'pangeo/test:latest',
+        'image--other-choice': 'pangeo/test:latest',
         'profile': _test_profiles[3]['slug'],
     }
     assert spawner.cpu_limit is None
@@ -976,7 +976,7 @@ async def test_user_options_set_from_form_invalid_regex():
     spawner.user_options = spawner.options_from_form(
         {
             'profile': [_test_profiles[3]['slug']],
-            'profile-option-test-choices-image-other-choice': ['invalid/foo:latest'],
+            'profile-option-test-choices-image--other-choice': ['invalid/foo:latest'],
         }
     )
     assert spawner.user_options == {

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -980,7 +980,7 @@ async def test_user_options_set_from_form_invalid_regex():
         }
     )
     assert spawner.user_options == {
-        'image-other-choice': 'invalid/foo:latest',
+        'image--other-choice': 'invalid/foo:latest',
         'profile': _test_profiles[3]['slug'],
     }
     assert spawner.cpu_limit is None


### PR DESCRIPTION
Opening a Draft PR working toward #699 .

This should eventually:

 - Allow specifying an option on profiles to allow a users to specify free-form text for an image (currently a single boolean called `allow_other`, but I think @yuvipanda had some ideas to make that a bit nicer.
 - If `allow_other` is true, show an additional option called "Other" in the dropdown and handle showing a text input when Other is selected
 - Handle the text input value on the backend to actually pull the image onto the cluster, etc.

Currently, have added a simple `allow_other` option and handling it just on the frontend.

@yuvipanda hopefully this is a good starting point for us to work together on implementing handling the value on the backend and improve the semantics of the options.

cc @consideRatio 