### PR TITLE
Stop use of nested label tags in HTML

### DIFF
--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -18,8 +18,8 @@
           <div>
             {%- for k, option in profile.profile_options.items() %}
               <div class="option">
-                <label for="profile-option-{{ profile.slug }}-{{ k }}"
-                       class="js-profile-option-label">{{ option.display_name }}</label>
+                <span for="profile-option-{{ profile.slug }}-{{ k }}"
+                      class="js-profile-option-label">{{ option.display_name }}</span>
                 <select name="profile-option-{{ profile.slug }}-{{ k }}"
                         class="form-control js-profile-option-select">
                   {%- for k, choice in option['choices'].items() %}

--- a/kubespawner/templates/style.css
+++ b/kubespawner/templates/style.css
@@ -22,7 +22,7 @@
   padding-bottom: 12px;
 }
 
-#kubespawner-profiles-list .profile .option label {
+#kubespawner-profiles-list .profile .option span {
   font-weight: normal;
   margin-right: 8px;
   min-width: 96px;


### PR DESCRIPTION
- Closes #734 

There is a slight adjustment in the alignment as part of changing the nested `<label>` tag into a `<span>` tag, but I think that is preferred. In the gif below we see the difference switched back and forth. With this PR it becomes as it is when the label is put lower compared to what it was before, aligning better with the text in the dropdown lists.

![alignment](https://github.com/jupyterhub/kubespawner/assets/3837114/fd80e1e1-b529-4138-b703-8a574639e7f5)
