### PR TITLE
add 'safe' slug scheme

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,7 +13,7 @@ management of containerized applications. If you want to run a JupyterHub
 setup that needs to scale across multiple nodes (anything with over ~50
 simultaneous users), Kubernetes is a wonderful way to do it. Features include:
 
-- Easily and elasticly run anywhere between 2 and thousands of nodes with the
+- Easily and elastically run anywhere between 2 and thousands of nodes with the
   same set of powerful abstractions. Scale up and down as required by simply
   adding or removing nodes.
 
@@ -81,5 +81,6 @@ utils
 ```{toctree}
 :maxdepth: 2
 :caption: Reference
+templates
 changelog
 ```

--- a/docs/source/ssl.md
+++ b/docs/source/ssl.md
@@ -8,7 +8,7 @@ If enabled, the Kubespawner will mount the internal_ssl certificates as Kubernet
 
 To enable, use the following settings:
 
-```
+```python
 c.JupyterHub.internal_ssl = True
 
 c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
@@ -16,8 +16,8 @@ c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
 
 Further configuration can be specified with the following (listed with their default values):
 
-```
-c.KubeSpawner.secret_name_template = "jupyter-{username}{servername}"
+```python
+c.KubeSpawner.secret_name_template = "{pod_name}"
 
 c.KubeSpawner.secret_mount_path =  "/etc/jupyterhub/ssl/"
 ```

--- a/docs/source/templates.md
+++ b/docs/source/templates.md
@@ -1,0 +1,156 @@
+(templates)=
+
+# Templated fields
+
+Several fields in KubeSpawner can be resolved as string templates,
+so each user server can get distinct values from the same configuration.
+
+String templates use the Python formatting convention of `f"{fieldname}"`,
+so for example the default `pod_name_template` of `"jupyter-{user_server}"` will produce:
+
+| username         | server name | pod name                                       |
+| ---------------- | ----------- | ---------------------------------------------- |
+| `user`           | `''`        | `jupyter-user`                                 |
+| `user`           | `server`    | `jupyter-user--server`                         |
+| `user@email.com` | `Some Name` | `jupyter-user-email-com--some-name---0c1fe94b` |
+
+## templated properties
+
+Some common templated fields:
+
+- [pod_name_template](#KubeSpawner.pod_name_template)
+- [pvc_name_template](#KubeSpawner.pvc_name_template)
+- [working_dir](#KubeSpawner.working_dir)
+
+## fields
+
+The following fields are available in templates:
+
+| field                    | description                                                                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `{username}`             | the username passed through the configured slug scheme                                                                                                       |
+| `{servername}`           | the name of the server passed through the configured slug scheme (`''` for the user's default server)                                                        |
+| `{user_server}`          | the username and servername together as a single slug. This should be used most places for a unique string for a given user's server (new in kubespawner 7). |
+| `{unescaped_username}`   | the actual username without escaping (no guarantees about value, except as enforced by your Authenticator)                                                   |
+| `{unescaped_servername}` | the actual server name without escaping (no guarantees about value)                                                                                          |
+| `{pod_name}`             | the resolved pod name, often a good choice if you need a starting point for other resources (new in kubespawner 7)                                           |
+| `{pvc_name}`             | the resolved PVC name (new in kubespawner 7)                                                                                                                 |
+| `{namespace}`            | the kubernetes namespace of the server (new in kubespawner 7)                                                                                                |
+| `{hubnamespace}`         | the kubernetes namespace of the Hub                                                                                                                          |
+
+Because there are two escaping schemes for `username`, `servername`, and `user_server`, you can explicitly select one or the other on a per-template-field basis with the prefix `safe_` or `escaped_`:
+
+| field                   | description                                                                                                                                         |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{escaped_username}`    | the username passed through the old 'escape' slug scheme                                                                                            |
+| `{escaped_servername}`  | the server name passed through the 'escape' slug scheme                                                                                             |
+| `{escaped_user_server}` | the username and servername together as a single slug, identical to `"{escaped_username}--{escaped_servername}".rstrip("-")` (new in kubespawner 7) |
+| `{safe_username}`       | the username passed through the 'safe' slug scheme (new in kubespawner 7)                                                                           |
+| `{safe_servername}`     | the server name passed through the 'safe' slug scheme (new in kubespawner 7)                                                                        |
+| `{safe_user_server}`    | the username and server name together as a 'safe' slug (new in kubespawner 7)                                                                       |
+
+These may be useful during a transition upgrading a deployment from an earlier version of kubespawner.
+
+The value of the unprefixed `username`, etc. is goverend by the [](#KubeSpawner.slug_scheme) configuration, and always matches exactly one of these values.
+
+## Template tips
+
+In general, these guidelines should help you pick fields to use in your template strings:
+
+- use `{user_server}` when a string should be unique _per server_ (e.g. pod name)
+- use `{username}` when it should be unique per user, but shared across named servers (sometimes chosen for PVCs)
+- use `{escaped_}` prefix if you need to keep certain values unchanged in a deployment upgrading from kubespawner \< 7
+- `{pod_name}` can be re-used anywhere you want to create more resources associated with a given pod,
+  to avoid repeating yourself
+
+## Changing template configuration
+
+Changing configuration should not generally affect _running_ servers.
+However, when changing a property that may need to persist across user server restarts, special consideration may be required.
+For example, changing `pvc_name` or `working_dir` could result in disconnecting a user's server from data loaded in previous sessions.
+This may be your intention or not! KubeSpawner cannot know.
+
+`pvc_name` is handled specially, to avoid losing access to data.
+If `KubeSpawner.remember_pvc_name` is True, once a server has started, a server's PVC name cannot be changed by configuration.
+Any future launch will use the previous `pvc_name`, regardless of change in configuration.
+If you _want_ to change the names of mounted PVCs, you can set
+
+```python
+c.KubeSpawner.remember_pvc_name = False
+```
+
+This handling isn't general for PVCs, only specifically the default `pvc_name`.
+If you have defined your own volumes, you need to handle changes to these yourself.
+
+## Upgrading from kubespawner \< 7
+
+Prior to kubespawner 7, an escaping scheme was used that ensured values were _unique_,
+but did not always ensure fields were _valid_.
+In particular:
+
+- start/end rules were not enforced
+- length was not enforced
+
+This meant that e.g. usernames that start with a capital letter or were very long could result in servers failing to start because the escaping scheme produced an invalid label.
+To solve this, a new 'safe' scheme has been added in kubespawner 7 for computing template strings,
+which aims to guarantee to always produce valid object names and labels.
+The new scheme is the default in kubespawner 7.
+
+You can select the scheme with:
+
+```python
+c.KubeSpawner.slug_scheme = "escape"  # no changes from kubespawner 6
+c.KubeSpawner.slug_scheme = "safe"  # default for kubespawner 7
+```
+
+The new scheme has the following rules:
+
+- the length of any _single_ template field is limited to 48 characters (the total length of the string is not enforced)
+- the result will only contain lowercase ascii letters, numbers, and `-`
+- it will always start and end with a letter or number
+- if a name is 'safe', it is used unmodified
+- if any escaping is required, a truncated safe subset of characters is used, followed by `---{hash}` where `{hash}` is a checksum of the original input string
+- `-` shall not occur in sequences of more than one consecutive `-`, except where inserted by the escaping mechanism
+- if no safe characters are present, 'x' is used for the 'safe' subset
+
+Since length requirements are applied on a per-field basis, a new `{user_server}` field is added,
+which computes a single valid slug following the above rules which is unique for a given user server.
+The general form is:
+
+```
+{username}--{servername}---{hash}
+```
+
+where
+
+- `--{servername}` is only present for non-empty server names
+- `---{hash}` is only present if escaping is required for _either_ username or servername, and hashes the combination of user and server.
+
+This `{user_server}` is the recommended value to use in pod names, etc.
+In the escape scheme, `{user_server}` is identical to the previous value used in default templates: `{username}--{servername}`,
+so it should be safe to upgrade previous templated using `{username}--{servername}` to `{user_server}` or `{escaped_user_server}`.
+
+In the vast majority of cases (where no escaping is required), the 'safe' scheme produces identical results to the 'escape' scheme.
+Probably the most common case where the two differ is in the presence of single `-` characters, which the `escape` scheme escaped to `-2d`, while the 'safe' scheme does not.
+
+Examples:
+
+| name | escape scheme | safe scheme |
+| username | username | username |
+| has-hyphen | has-2dhyphen | has-hyphen |
+| Capital | `-43apital` (error) | `capital---1a1cf792` |
+| user@email.com | 'user-40email-2ecom' | 'user-email-com---0925f997' |
+| 'a-very-long-name-that-is-too-long-for-sixty-four-character-labels' | 'a-2dvery-2dlong-2dname-2dthat-2dis-2dtoo-2dlong-2dfor-2dsixty-2dfour-2dcharacter-2dlabels' (error) | 'a-very-long-name-that-is-too-long-for---29ac5fd2' |
+| ALLCAPS | '-41-4c-4c-43-41-50-53' (error) | 'allcaps---27c6794c'|
+
+Most changed names won't have a practical effect.
+However, to avoid `pvc_name` changing even though KubeSpawner 6 didn't persist it,
+on first launch (for each server) after upgrade KubeSpawner checks if:
+
+1. `pvc_name_template` produces a different result with `scheme='escape'`
+1. a pvc with the old 'escaped' name exists
+
+and if such a pvc exists, the older name is used instead of the new one (it is then remembered for subsequent launches, according to `remember_pvc_name`).
+This is an attempt to respect the `remember_pvc_name` configuration, even though the old name is not technically recorded.
+We can infer the old value, as long as configuration has not changed.
+This will only work if upgrading KubeSpawer does not _also_ coincide with a change in the `pvc_name_template` configuration.

--- a/docs/source/templates.md
+++ b/docs/source/templates.md
@@ -42,8 +42,8 @@ Because there are two escaping schemes for `username`, `servername`, and `user_s
 
 | field                   | description                                                                                                                                         |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{escaped_username}`    | the username passed through the old 'escape' slug scheme                                                                                            |
-| `{escaped_servername}`  | the server name passed through the 'escape' slug scheme                                                                                             |
+| `{escaped_username}`    | the username passed through the old 'escape' slug scheme (new in kubespawner 7)                                                                     |
+| `{escaped_servername}`  | the server name passed through the 'escape' slug scheme (new in kubespawner 7)                                                                      |
 | `{escaped_user_server}` | the username and servername together as a single slug, identical to `"{escaped_username}--{escaped_servername}".rstrip("-")` (new in kubespawner 7) |
 | `{safe_username}`       | the username passed through the 'safe' slug scheme (new in kubespawner 7)                                                                           |
 | `{safe_servername}`     | the server name passed through the 'safe' slug scheme (new in kubespawner 7)                                                                        |

--- a/docs/source/templates.md
+++ b/docs/source/templates.md
@@ -135,13 +135,14 @@ Probably the most common case where the two differ is in the presence of single 
 
 Examples:
 
-| name | escape scheme | safe scheme |
-| username | username | username |
-| has-hyphen | has-2dhyphen | has-hyphen |
-| Capital | `-43apital` (error) | `capital---1a1cf792` |
-| user@email.com | 'user-40email-2ecom' | 'user-email-com---0925f997' |
-| 'a-very-long-name-that-is-too-long-for-sixty-four-character-labels' | 'a-2dvery-2dlong-2dname-2dthat-2dis-2dtoo-2dlong-2dfor-2dsixty-2dfour-2dcharacter-2dlabels' (error) | 'a-very-long-name-that-is-too-long-for---29ac5fd2' |
-| ALLCAPS | '-41-4c-4c-43-41-50-53' (error) | 'allcaps---27c6794c'|
+| name                                                                | escape scheme                                                                                       | safe scheme                                        |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `username`                                                          | `username`                                                                                          | `username`                                         |
+| `has-hyphen`                                                        | `has-2dhyphen`                                                                                      | `has-hyphen`                                       |
+| `Capital`                                                           | `-43apital` (error)                                                                                 | `capital---1a1cf792`                               |
+| `user@email.com`                                                    | `user-40email-2ecom`                                                                                | `user-email-com---0925f997`                        |
+| `a-very-long-name-that-is-too-long-for-sixty-four-character-labels` | `a-2dvery-2dlong-2dname-2dthat-2dis-2dtoo-2dlong-2dfor-2dsixty-2dfour-2dcharacter-2dlabels` (error) | `a-very-long-name-that-is-too-long-for---29ac5fd2` |
+| `ALLCAPS`                                                           | `-41-4c-4c-43-41-50-53` (error)                                                                     | `allcaps---27c6794c`                               |
 
 Most changed names won't have a practical effect.
 However, to avoid `pvc_name` changing even though KubeSpawner 6 didn't persist it,

--- a/kubespawner/slugs.py
+++ b/kubespawner/slugs.py
@@ -1,4 +1,4 @@
-"""Tools for generating
+"""Tools for generating slugs like k8s object names and labels
 
 Requirements:
 
@@ -10,9 +10,9 @@ import hashlib
 import re
 import string
 
-_alphanum = set(string.ascii_letters + string.digits)
-_alphanum_lower = set(string.ascii_lowercase + string.digits)
-_lower_plus_hyphen = _alphanum_lower | {'-'}
+_alphanum = tuple(string.ascii_letters + string.digits)
+_alphanum_lower = tuple(string.ascii_lowercase + string.digits)
+_lower_plus_hyphen = _alphanum_lower + ('-',)
 
 # patterns _do not_ need to cover length or start/end conditions,
 # which are handled separately
@@ -85,7 +85,7 @@ def strip_and_hash(name):
     """Generate an always-safe, unique string for any input"""
     # make sure we start with a prefix
     # quick, short hash to avoid name collsions
-    name_hash = hashlib.sha256(name).hexdigest()[:8]
+    name_hash = hashlib.sha256(name.encode("utf8")).hexdigest()[:8]
     safe_chars = [c for c in name.lower() if c in _lower_plus_hyphen]
     safe_name = ''.join(safe_chars[:24])
     if not safe_name:

--- a/kubespawner/slugs.py
+++ b/kubespawner/slugs.py
@@ -19,8 +19,8 @@ _lower_plus_hyphen = _alphanum_lower + ('-',)
 _object_pattern = re.compile(r'^[a-z0-9\.-]+$')
 _label_pattern = re.compile(r'^[a-z0-9\.-_]+$', flags=re.IGNORECASE)
 
-# match two or more hyphens
-_hyphen_plus_pattern = re.compile('--+')
+# match anything that's not lowercase alphanumeric (will be stripped, replaced with '-')
+_non_alphanum_pattern = re.compile(r'[^a-z0-9]+')
 
 # length of hash suffix
 _hash_length = 8
@@ -106,13 +106,11 @@ def _extract_safe_name(name, max_length):
     - max length not exceeded
     """
     # compute safe slug from name (don't worry about collisions, hash handles that)
-    # cast to lowercase, exclude all but lower & hyphen
-    # we could keep numbers, but it must not _start_ with a number
-    safe_name = ''.join([c for c in name.lower() if c in _lower_plus_hyphen])
-    # strip leading '-', squash repeated '--' to '-'
-    safe_name = _hyphen_plus_pattern.sub("-", safe_name.lstrip("-"))
-    # truncate to max_length chars, strip trailing '-'
-    safe_name = safe_name[:max_length].rstrip("-")
+    # cast to lowercase
+    # replace any sequence of non-alphanumeric characters with a single '-'
+    safe_name = _non_alphanum_pattern.sub("-", name.lower())
+    # truncate to max_length chars, strip '-' off ends
+    safe_name = safe_name.lstrip("-")[:max_length].rstrip("-")
     if not safe_name:
         # make sure it's non-empty
         safe_name = 'x'

--- a/kubespawner/slugs.py
+++ b/kubespawner/slugs.py
@@ -19,15 +19,23 @@ _lower_plus_hyphen = _alphanum_lower + ('-',)
 _object_pattern = re.compile(r'^[a-z0-9\.-]+$')
 _label_pattern = re.compile(r'^[a-z0-9\.-_]+$', flags=re.IGNORECASE)
 
+# match two or more hyphens
+_hyphen_plus_pattern = re.compile('--+')
+
+# length of hash suffix
+_hash_length = 8
+
 
 def _is_valid_general(
-    s, starts_with=None, ends_with=None, pattern=None, max_length=None
+    s, starts_with=None, ends_with=None, pattern=None, min_length=None, max_length=None
 ):
     """General is_valid check
 
     Checks rules:
     """
-    if not 1 <= len(s) <= max_length:
+    if min_length and len(s) < min_length:
+        return False
+    if max_length and len(s) > max_length:
         return False
     if starts_with and not s.startswith(starts_with):
         return False
@@ -47,12 +55,16 @@ def is_valid_object_name(s):
         ends_with=_alphanum_lower,
         pattern=_object_pattern,
         max_length=255,
+        min_length=1,
     )
 
 
 def is_valid_label(s):
     """is_valid check for label values"""
     # label rules: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+    if not s:
+        # empty strings are valid labels
+        return True
     return _is_valid_general(
         s,
         starts_with=_alphanum,
@@ -77,28 +89,40 @@ def is_valid_default(s):
         starts_with=_alphanum_lower,
         ends_with=_alphanum_lower,
         pattern=_object_pattern,
+        min_length=1,
         max_length=63,
     )
 
 
-def strip_and_hash(name):
-    """Generate an always-safe, unique string for any input"""
-    # make sure we start with a prefix
-    # quick, short hash to avoid name collsions
-    name_hash = hashlib.sha256(name.encode("utf8")).hexdigest()[:8]
-    safe_chars = [c for c in name.lower() if c in _lower_plus_hyphen]
-    safe_name = ''.join(safe_chars[:24])
+def strip_and_hash(name, max_length=32):
+    """Generate an always-safe, unique string for any input
+
+    truncates name to max_length - len(hash_suffix) to fit in max_length
+    after adding hash suffix
+    """
+    name_length = max_length - (_hash_length + 3)
+    if name_length < 1:
+        raise ValueError(f"Cannot make safe names shorter than {_hash_length + 4}")
+    # quick, short hash to avoid name collisions
+    name_hash = hashlib.sha256(name.encode("utf8")).hexdigest()[:_hash_length]
+    # compute safe slug from name (don't worry about collisions, hash handles that)
+    # cast to lowercase, exclude all but lower & hyphen
+    safe_name = ''.join([c for c in name.lower() if c in _lower_plus_hyphen])
+    # strip leading '-'
+    # squash repeated '--' to one
+    safe_name = _hyphen_plus_pattern.sub("-", safe_name.lstrip("-"))
+    # truncate to 24 chars, strip trailing '-'
+    safe_name = safe_name[:name_length].rstrip("-")
     if not safe_name:
+        # make sure it's non-empty
         safe_name = 'x'
-    if safe_name.startswith('-'):
-        # starting with '-' is generally not allowed,
-        # start with 'j-' instead
-        # Question: always do this so it's consistent, instead of as-needed?
-        safe_name = f"j{safe_name}"
-    return f"{safe_name}--{name_hash}"
+    # due to stripping of '-' above,
+    # the result will always have _exactly_ '---', never '--' nor '----'
+    # use '---' to avoid colliding with `{username}--{servername}` template join
+    return f"{safe_name}---{name_hash}"
 
 
-def safe_slug(name, is_valid=is_valid_default):
+def safe_slug(name, is_valid=is_valid_default, max_length=None):
     """Always generate a safe slug
 
     is_valid should be a callable that returns True if a given string follows appropriate rules,
@@ -112,8 +136,9 @@ def safe_slug(name, is_valid=is_valid_default):
     """
     if '--' in name:
         # don't accept any names that could collide with the safe slug
-        return strip_and_hash(name)
-    if is_valid(name):
+        return strip_and_hash(name, max_length=max_length or 32)
+    # allow max_length override for truncated sub-strings
+    if is_valid(name) and (max_length is None or len(name) <= max_length):
         return name
     else:
-        return strip_and_hash(name)
+        return strip_and_hash(name, max_length=max_length or 32)

--- a/kubespawner/slugs.py
+++ b/kubespawner/slugs.py
@@ -5,6 +5,7 @@ Requirements:
 - always valid for arbitary strings
 - no collisions
 """
+
 import hashlib
 import re
 import string

--- a/kubespawner/slugs.py
+++ b/kubespawner/slugs.py
@@ -1,0 +1,118 @@
+"""Tools for generating
+
+Requirements:
+
+- always valid for arbitary strings
+- no collisions
+"""
+import hashlib
+import re
+import string
+
+_alphanum = set(string.ascii_letters + string.digits)
+_alphanum_lower = set(string.ascii_lowercase + string.digits)
+_lower_plus_hyphen = _alphanum_lower | {'-'}
+
+# patterns _do not_ need to cover length or start/end conditions,
+# which are handled separately
+_object_pattern = re.compile(r'^[a-z0-9\.-]+$')
+_label_pattern = re.compile(r'^[a-z0-9\.-_]+$', flags=re.IGNORECASE)
+
+
+def _is_valid_general(
+    s, starts_with=None, ends_with=None, pattern=None, max_length=None
+):
+    """General is_valid check
+
+    Checks rules:
+    """
+    if not 1 <= len(s) <= max_length:
+        return False
+    if starts_with and not s.startswith(starts_with):
+        return False
+    if ends_with and not s.endswith(ends_with):
+        return False
+    if pattern and not pattern.match(s):
+        return False
+    return True
+
+
+def is_valid_object_name(s):
+    """is_valid check for object names"""
+    # object rules: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+    return _is_valid_general(
+        s,
+        starts_with=_alphanum_lower,
+        ends_with=_alphanum_lower,
+        pattern=_object_pattern,
+        max_length=255,
+    )
+
+
+def is_valid_label(s):
+    """is_valid check for label values"""
+    # label rules: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+    return _is_valid_general(
+        s,
+        starts_with=_alphanum,
+        ends_with=_alphanum,
+        pattern=_label_pattern,
+        max_length=63,
+    )
+
+
+def is_valid_default(s):
+    """Strict is_valid
+
+    Returns True if it's valid for _all_ our known uses
+
+    So we can more easily have a single is_valid check.
+
+    - object names have stricter character rules, but have longer max length
+    - labels have short max length, but allow uppercase
+    """
+    return _is_valid_general(
+        s,
+        starts_with=_alphanum_lower,
+        ends_with=_alphanum_lower,
+        pattern=_object_pattern,
+        max_length=63,
+    )
+
+
+def strip_and_hash(name):
+    """Generate an always-safe, unique string for any input"""
+    # make sure we start with a prefix
+    # quick, short hash to avoid name collsions
+    name_hash = hashlib.sha256(name).hexdigest()[:8]
+    safe_chars = [c for c in name.lower() if c in _lower_plus_hyphen]
+    safe_name = ''.join(safe_chars[:24])
+    if not safe_name:
+        safe_name = 'x'
+    if safe_name.startswith('-'):
+        # starting with '-' is generally not allowed,
+        # start with 'j-' instead
+        # Question: always do this so it's consistent, instead of as-needed?
+        safe_name = f"j{safe_name}"
+    return f"{safe_name}--{name_hash}"
+
+
+def safe_slug(name, is_valid=is_valid_default):
+    """Always generate a safe slug
+
+    is_valid should be a callable that returns True if a given string follows appropriate rules,
+    and False if it does not.
+
+    Given a string, if it's already valid, use it.
+    If it's not valid, follow a safe encoding scheme that ensures:
+
+    1. validity, and
+    2. no collisions
+    """
+    if '--' in name:
+        # don't accept any names that could collide with the safe slug
+        return strip_and_hash(name)
+    if is_valid(name):
+        return name
+    else:
+        return strip_and_hash(name)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -196,9 +196,7 @@ class KubeSpawner(Spawner):
         # for transitive values (pod_name, dns_name)
         # but not persistent values (namespace, pvc_name)
         if self.enable_user_namespaces:
-            self.namespace = self._expand_user_properties(
-                self.user_namespace_template, slug_scheme="safe"
-            )
+            self.namespace = self._expand_user_properties(self.user_namespace_template)
             self.log.info(f"Using user namespace: {self.namespace}")
 
         self.pod_name = self._expand_user_properties(self.pod_name_template)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -187,8 +187,14 @@ class KubeSpawner(Spawner):
         # By now, all the traitlets have been set, so we can use them to
         # compute other attributes
 
-        # namespace, pod_name, dns_name are persisted in state
+        # namespace, pod_name, etc. are persisted in state
+        # so values set here are only _default_ values.
+        # If this Spawner has ever launched before,
+        # these values will be be overridden in `get_state()`
+        #
         # these same assignments should match clear_state
+        # for transitive values (pod_name, dns_name)
+        # but not persistent values (namespace, pvc_name)
         if self.enable_user_namespaces:
             self.namespace = self._expand_user_properties(
                 self.user_namespace_template, slug_scheme="safe"

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -341,20 +341,13 @@ class KubeSpawner(Spawner):
         'escape' scheme:
         
         - does not guarantee correct names, e.g. does not handle capital letters or length
-        - escapes fields one at a time in templates:
-          - `{username}` is the _escaped_ username
-          - `{servername}` is the _escaped_ server name
         
         'safe' scheme:
         
         - should guarantee correct names
-        - escapes the whole string at once
         - escapes only if needed
-        - in templates:
-          - `{username}` is the user's actual name
-          - `{escaped_username}` is the escaped username, used in the previous scheme
-          - `{servername}` is the user's actual name
-          - `{escaped_servername}` is the escaped server name, used in the previous scheme
+        - enforces length requirements
+        - uses hash to avoid collisions when escaping is required
 
         'safe' is the default and preferred as it produces both:
 
@@ -376,11 +369,10 @@ class KubeSpawner(Spawner):
         Note that these are only set when the namespaces are created, not
         later when this setting is updated.
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -393,11 +385,10 @@ class KubeSpawner(Spawner):
         Note that these are only set when the namespaces are created, not
         later when this setting is updated.
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -408,11 +399,10 @@ class KubeSpawner(Spawner):
         Template to use to form the namespace of user's pods (only if
         enable_user_namespaces is True).
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -496,11 +486,10 @@ class KubeSpawner(Spawner):
         The working directory where the Notebook server will be started inside the container.
         Defaults to `None` so the working directory will be the one defined in the Dockerfile.
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -551,17 +540,13 @@ class KubeSpawner(Spawner):
         help="""
         Template to use to form the name of user's pods.
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
-
-        Trailing `-` characters are stripped for safe handling of empty server names (user default servers).
-
         This must be unique within the namespace the pods are being spawned
         in, so if you are running multiple jupyterhubs spawning in the
         same namespace, consider setting this to be something more unique.
+
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
 
         .. versionchanged:: 0.12
             `--` delimiter added to the template,
@@ -579,11 +564,9 @@ class KubeSpawner(Spawner):
 
         e.g. `{pod_name}.notebooks.jupyterhub.svc.cluster.local`,
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
 
         Trailing `-` characters in each domain level are stripped for safe handling of empty server names (user default servers).
 
@@ -626,17 +609,16 @@ class KubeSpawner(Spawner):
         help="""
         Template to use to form the name of user's pvc.
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
 
         Trailing `-` characters are stripped for safe handling of empty server names (user default servers).
 
         This must be unique within the namespace the pvc are being spawned
         in, so if you are running multiple jupyterhubs spawning in the
         same namespace, consider setting this to be something more unique.
+
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
 
         .. versionchanged:: 0.12
             `--` delimiter added to the template,
@@ -674,20 +656,12 @@ class KubeSpawner(Spawner):
     )
 
     secret_name_template = Unicode(
-        'jupyter-{username}{servername}',
+        '{pod_name}',
         config=True,
         help="""
         Template to use to form the name of user's secret.
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
-
-        This must be unique within the namespace the pvc are being spawned
-        in, so if you are running multiple jupyterhubs spawning in the
-        same namespace, consider setting this to be something more unique.
+        Default: same as `pod_name`. It is unlikely that this should be changed.
         """,
     )
 
@@ -757,11 +731,9 @@ class KubeSpawner(Spawner):
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>`__
         for more info on what labels are and why you might want to use them!
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
         """,
     )
 
@@ -778,9 +750,10 @@ class KubeSpawner(Spawner):
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`__
         for more info on what annotations are and why you might want to use them!
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -1123,11 +1096,10 @@ class KubeSpawner(Spawner):
         for more information on the various kinds of volumes available and their options.
         Your kubernetes cluster must already be configured to support the volume types you want to use.
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -1146,11 +1118,10 @@ class KubeSpawner(Spawner):
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/storage/volumes>`__
         for more information on how the `volumeMount` item works.
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -1190,9 +1161,10 @@ class KubeSpawner(Spawner):
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`__
         for more info on what annotations are and why you might want to use them!
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -1208,11 +1180,10 @@ class KubeSpawner(Spawner):
         See `the Kubernetes documentation <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>`__
         for more info on what labels are and why you might want to use them!
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -1270,11 +1241,10 @@ class KubeSpawner(Spawner):
 
            c.KubeSpawner.storage_selector = {'matchLabels':{'content': 'jupyter'}}
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -1406,11 +1376,10 @@ class KubeSpawner(Spawner):
                 "command": ["/usr/local/bin/supercronic", "/etc/crontab"]
             }]
 
-        `{username}`, `{userid}`, `{servername}`, `{hubnamespace}`,
-        `{unescaped_username}`, and `{unescaped_servername}` will be expanded if
-        found within strings of this configuration. The username and servername
-        come escaped to follow the `DNS label standard
-        <https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names>`__.
+        .. seealso::
+
+          :ref:`templates` for information on fields available in template strings.
+
         """,
     )
 
@@ -2330,8 +2299,9 @@ class KubeSpawner(Spawner):
         """
         state = super().get_state()
         state["kubespawner_version"] = __version__
-        # these should only be persisted if our pod is running
+        # pod_name, dns_name should only be persisted if our pod is running
         # but we don't have a sync check for that
+        # is that true for namespace as well? (namespace affects pvc)
         state['pod_name'] = self.pod_name
         state['namespace'] = self.namespace
         state['dns_name'] = self.dns_name
@@ -2415,13 +2385,11 @@ class KubeSpawner(Spawner):
         super().clear_state()
         # this should be the same initialization as __init__ / trait defaults
         # this allows changing config to take effect after a server restart
-        if self.enable_user_namespaces:
-            self.namespace = self._expand_user_properties(self.user_namespace_template)
-
         self.pod_name = self._expand_user_properties(self.pod_name_template)
         self.dns_name = self.dns_name_template.format(
             namespace=self.namespace, name=self.pod_name
         )
+        # reset namespace as well?
 
     async def poll(self):
         """

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1455,6 +1455,9 @@ class KubeSpawner(Spawner):
         kubespawner 7 changed the scheme for computing names and labels to be more reliably valid.
         In order to preserve backward compatibility, the old names must be handled in some places.
 
+        Currently, this only affects `pvc_name`
+        and has no effect when `remember_pvc_name` is False.
+
         You can safely disable this if no PVCs were created or running servers were started
         before upgrading to kubespawner 7.
         """,
@@ -3107,6 +3110,7 @@ class KubeSpawner(Spawner):
         if self.storage_pvc_ensure:
             if (
                 self.handle_legacy_names
+                and self.remember_pvc_name
                 and not self._pvc_exists
                 and self._state_kubespawner_version == "unknown"
             ):

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1975,8 +1975,11 @@ class KubeSpawner(Spawner):
             ns[attr_name] = getattr(self, attr_name, f"{attr_name}_unavailable!")
 
         rendered = template.format(**ns)
-        # strip trailing '-' in case of old '{username}--{servername}' template
-        rendered = rendered.rstrip("-")
+        # strip trailing - delimiter in case of empty servername and old {username}--{servername} template
+        # but only if trailing '-' is added by the template rendering,
+        # and not in the template itself
+        if not template.endswith("-"):
+            rendered = rendered.rstrip("-")
         return rendered
 
     def _expand_env(self, env):

--- a/tests/test_slugs.py
+++ b/tests/test_slugs.py
@@ -1,0 +1,21 @@
+import pytest
+
+from kubespawner.slugs import safe_slug
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("jupyter-alex", "jupyter-alex"),
+        ("jupyter-Alex", "jupyter-alex--3a1c285c"),
+        ("jupyter-üni", "jupyter-ni--a5aaf5dd"),
+        ("endswith-", "endswith---165f1166"),
+        ("-start", "j-start--f587e2dc"),
+        ("j-start--f587e2dc", "j-start--f587e2dc--f007ef7c"),
+        ("x" * 65, "xxxxxxxxxxxxxxxxxxxxxxxx--9537c5fd"),
+        ("x" * 66, "xxxxxxxxxxxxxxxxxxxxxxxx--6eb879f1"),
+    ],
+)
+def test_safe_slug(name, expected):
+    slug = safe_slug(name)
+    assert slug == expected

--- a/tests/test_slugs.py
+++ b/tests/test_slugs.py
@@ -10,6 +10,8 @@ from kubespawner.slugs import is_valid_label, safe_slug
         ("jupyter-Alex", "jupyter-alex---3a1c285c"),
         ("jupyter-üni", "jupyter-ni---a5aaf5dd"),
         ("endswith-", "endswith---165f1166"),
+        ("user@email.com", "user-email-com---0925f997"),
+        ("user-_@_emailß.com", "user-email-com---7e3a7efd"),
         ("-start", "start---f587e2dc"),
         ("username--servername", "username-servername---d957f1de"),
         ("start---f587e2dc", "start-f587e2dc---cc5bb9c9"),

--- a/tests/test_slugs.py
+++ b/tests/test_slugs.py
@@ -1,21 +1,61 @@
 import pytest
 
-from kubespawner.slugs import safe_slug
+from kubespawner.slugs import is_valid_label, safe_slug
 
 
 @pytest.mark.parametrize(
     "name, expected",
     [
         ("jupyter-alex", "jupyter-alex"),
-        ("jupyter-Alex", "jupyter-alex--3a1c285c"),
-        ("jupyter-üni", "jupyter-ni--a5aaf5dd"),
+        ("jupyter-Alex", "jupyter-alex---3a1c285c"),
+        ("jupyter-üni", "jupyter-ni---a5aaf5dd"),
         ("endswith-", "endswith---165f1166"),
-        ("-start", "j-start--f587e2dc"),
-        ("j-start--f587e2dc", "j-start--f587e2dc--f007ef7c"),
-        ("x" * 65, "xxxxxxxxxxxxxxxxxxxxxxxx--9537c5fd"),
-        ("x" * 66, "xxxxxxxxxxxxxxxxxxxxxxxx--6eb879f1"),
+        ("-start", "start---f587e2dc"),
+        ("username--servername", "username-servername---d957f1de"),
+        ("start---f587e2dc", "start-f587e2dc---cc5bb9c9"),
+        pytest.param("x" * 63, "x" * 63, id="x63"),
+        pytest.param("x" * 64, "xxxxxxxxxxxxxxxxxxxxx---7ce10097", id="x64"),
+        pytest.param("x" * 65, "xxxxxxxxxxxxxxxxxxxxx---9537c5fd", id="x65"),
+        ("", "x---e3b0c442"),
     ],
 )
 def test_safe_slug(name, expected):
     slug = safe_slug(name)
+    assert slug == expected
+
+
+@pytest.mark.parametrize(
+    "max_length, length, expected",
+    [
+        (16, 16, "x" * 16),
+        (16, 17, "xxxxx---d04fd59f"),
+        (11, 16, "error"),
+        (12, 16, "x---9c572959"),
+    ],
+)
+def test_safe_slug_max_length(max_length, length, expected):
+    name = "x" * length
+    if expected == "error":
+        with pytest.raises(ValueError):
+            safe_slug(name, max_length=max_length)
+        return
+
+    slug = safe_slug(name, max_length=max_length)
+    assert slug == expected
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("", ""),
+        ("x", "x"),
+        ("-x", "x---a4209624"),
+        ("x-", "x---c8b60efc"),
+        pytest.param("x" * 63, "x" * 63, id="x64"),
+        pytest.param("x" * 64, "xxxxxxxxxxxxxxxxxxxxx---7ce10097", id="x64"),
+        pytest.param("x" * 65, "xxxxxxxxxxxxxxxxxxxxx---9537c5fd", id="x65"),
+    ],
+)
+def test_safe_slug_label(name, expected):
+    slug = safe_slug(name, is_valid=is_valid_label)
     assert slug == expected

--- a/tests/test_slugs.py
+++ b/tests/test_slugs.py
@@ -53,7 +53,7 @@ def test_safe_slug_max_length(max_length, length, expected):
         ("x", "x"),
         ("-x", "x---a4209624"),
         ("x-", "x---c8b60efc"),
-        pytest.param("x" * 63, "x" * 63, id="x64"),
+        pytest.param("x" * 63, "x" * 63, id="x63"),
         pytest.param("x" * 64, "xxxxxxxxxxxxxxxxxxxxx---7ce10097", id="x64"),
         pytest.param("x" * 65, "xxxxxxxxxxxxxxxxxxxxx---9537c5fd", id="x65"),
     ],

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1418,7 +1418,7 @@ async def test_pod_name_escaping():
 
     spawner = KubeSpawner(config=c, user=user, orm_spawner=orm_spawner, _mock=True)
 
-    assert spawner.pod_name == "jupyter-some-5fuser--test-2dserver-21"
+    assert spawner.pod_name == "jupyter-someuser---7d3a4d4e--test-server---cb54a9af"
 
 
 async def test_pod_name_custom_template():
@@ -1442,15 +1442,15 @@ async def test_pod_name_collision():
     user2 = MockUser()
     user2.name = "user-has"
     orm_spawner2 = Spawner()
-    orm_spawner2.name = "2ddash"
+    orm_spawner2.name = "dash"
 
     spawner = KubeSpawner(user=user1, orm_spawner=orm_spawner1, _mock=True)
-    assert spawner.pod_name == "jupyter-user-2dhas-2ddash"
-    assert spawner.pvc_name == "claim-user-2dhas-2ddash"
+    assert spawner.pod_name == "jupyter-user-has-dash"
+    assert spawner.pvc_name == "claim-user-has-dash"
     named_spawner = KubeSpawner(user=user2, orm_spawner=orm_spawner2, _mock=True)
-    assert named_spawner.pod_name == "jupyter-user-2dhas--2ddash"
+    assert named_spawner.pod_name == "jupyter-user-has--dash"
     assert spawner.pod_name != named_spawner.pod_name
-    assert named_spawner.pvc_name == "claim-user-2dhas--2ddash"
+    assert named_spawner.pvc_name == "claim-user-has--dash"
     assert spawner.pvc_name != named_spawner.pvc_name
 
 


### PR DESCRIPTION
closes #737
closes #498 

implements scheme [described here](https://github.com/jupyterhub/kubespawner/issues/498#issuecomment-1578423254).

- always produces valid values
- uses names, etc. as-is, when valid (no more `-2d`)
- uses stripped `name---hash` when needed
- new behavior is enabled by default, opt-out for backward compatibility via `KubeSpawner.slug_scheme = 'escape'`

Potential issues to address:

- escaping is applied to the final template result, rather than individual strings. This ensures correct values, but means the hash is a function of the full template string, not just the username (or servername). Dealing with length is tricky if we need to hash bits at a time.
- Not everything is a kubernetes field, e.g. working directory should probably get special handling? It has different rules than the label fields
- a breaking change for users to change schemes (just like changing the template config), but at least we don't make the change for them