### PR TITLE
WIP: Optionally disable k8s service env-var links

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -92,6 +92,7 @@ def make_pod(
     container_security_context=None,
     pod_security_context=None,
     env=None,
+    enable_service_links=True,
     working_dir=None,
     volumes=None,
     volume_mounts=None,
@@ -200,6 +201,9 @@ def make_pod(
 
     env:
         Dictionary of environment variables.
+
+    enable_service_links:
+        Enable service environment variables.
 
     volumes:
         List of dictionaries containing the volumes of various types this pod
@@ -440,6 +444,8 @@ def make_pod(
     if not psc:
         psc = None
     pod.spec.security_context = psc
+
+    pod.spec.enableServiceLinks = enable_service_links
 
     csc = {}
     # populate with uid / gid / privileged / allow_privilege_escalation

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -445,7 +445,7 @@ def make_pod(
         psc = None
     pod.spec.security_context = psc
 
-    pod.spec.enableServiceLinks = enable_service_links
+    pod.spec.enable_service_links = enable_service_links
 
     csc = {}
     # populate with uid / gid / privileged / allow_privilege_escalation

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -431,6 +431,15 @@ class KubeSpawner(Spawner):
         """,
     )
 
+    enable_service_links = Bool(
+        True,
+        config=True,
+        help="""
+        Enable service environment variables. If True environment variables for all
+        Kubernetes services in all namespaces will be injected into the pod.
+        """,
+    )
+
     # FIXME: Don't override 'default_value' ("") or 'allow_none' (False) (Breaking change)
     service_account = Unicode(
         None,
@@ -1994,6 +2003,7 @@ class KubeSpawner(Spawner):
             container_security_context=csc,
             pod_security_context=psc,
             env=self._expand_all(self.get_env()),
+            enable_service_links=self.enable_service_links,
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),
             working_dir=self.working_dir,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -38,6 +38,7 @@ def test_make_simplest_pod():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -76,6 +77,7 @@ def test_make_labeled_pod():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -118,6 +120,7 @@ def test_make_annotated_pod():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -161,6 +164,7 @@ def test_make_pod_with_image_pull_secrets_simplified_format():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -204,6 +208,7 @@ def test_make_pod_with_image_pull_secrets_k8s_native_format():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -251,6 +256,7 @@ def test_set_container_uid_and_gid():
                     "resources": {"limits": {}, "requests": {}},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -297,6 +303,7 @@ def test_set_container_uid_and_pod_fs_gid():
                     "resources": {"limits": {}, "requests": {}},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'securityContext': {
                 'fsGroup': 0,
@@ -346,6 +353,7 @@ def test_set_pod_supplemental_gids():
                     "resources": {"limits": {}, "requests": {}},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'securityContext': {
                 'supplementalGroups': [100],
@@ -394,6 +402,7 @@ def test_privileged_container():
                     'volumeMounts': [],
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -436,6 +445,7 @@ def test_allow_privilege_escalation_container():
                     'volumeMounts': [],
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -493,6 +503,7 @@ def test_pod_security_context_container():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'securityContext': {
                 'supplementalGroups': [200],
@@ -577,6 +588,7 @@ def test_container_security_context_container():
                     },
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -669,6 +681,7 @@ def test_make_pod_resources_all():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -768,6 +781,7 @@ def test_make_pod_with_env():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -860,6 +874,7 @@ def test_make_pod_with_env_dependency_sorted():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -905,6 +920,7 @@ def test_make_pod_with_lifecycle():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -986,6 +1002,7 @@ def test_make_pod_with_init_containers():
                     ],
                 },
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -1031,6 +1048,7 @@ def test_make_pod_with_extra_container_config():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -1088,6 +1106,7 @@ def test_make_pod_with_extra_pod_config():
             ],
             'volumes': [],
             'dnsPolicy': 'ClusterFirstWithHostNet',
+            "enableServiceLinks": True,
             'restartPolicy': 'Always',
             'tolerations': [
                 {
@@ -1147,6 +1166,7 @@ def test_make_pod_with_extra_containers():
                     'command': ['/usr/local/bin/supercronic', '/etc/crontab'],
                 },
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -1208,6 +1228,7 @@ def test_make_pod_with_extra_resources():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -1327,6 +1348,7 @@ def test_make_pod_with_service_account():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
             'serviceAccountName': 'test',
@@ -1367,6 +1389,7 @@ def test_make_pod_with_service_account_and_with_automount_sa_token():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
             'serviceAccountName': 'test',
@@ -1407,6 +1430,7 @@ def test_make_pod_with_service_account_and_with_negative_automount_sa_token():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
             'serviceAccountName': 'test',
@@ -1446,6 +1470,7 @@ def test_make_pod_with_automount_service_account_token():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -1484,6 +1509,7 @@ def test_make_pod_with_negative_automount_service_account_token():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
         },
@@ -1526,6 +1552,7 @@ def test_make_pod_with_scheduler_name():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
             'schedulerName': 'my-custom-scheduler',
@@ -1574,6 +1601,7 @@ def test_make_pod_with_tolerations():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
             'tolerations': tolerations,
@@ -1627,6 +1655,7 @@ def test_make_pod_with_node_affinity_preferred():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             "volumes": [],
             "affinity": {
@@ -1681,6 +1710,7 @@ def test_make_pod_with_node_affinity_required():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             "volumes": [],
             "affinity": {
@@ -1743,6 +1773,7 @@ def test_make_pod_with_pod_affinity_preferred():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             "volumes": [],
             "affinity": {
@@ -1800,6 +1831,7 @@ def test_make_pod_with_pod_affinity_required():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             "volumes": [],
             "affinity": {
@@ -1860,6 +1892,7 @@ def test_make_pod_with_pod_anti_affinity_preferred():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             "volumes": [],
             "affinity": {
@@ -1917,6 +1950,7 @@ def test_make_pod_with_pod_anti_affinity_required():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             "volumes": [],
             "affinity": {
@@ -1964,6 +1998,7 @@ def test_make_pod_with_priority_class_name():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [],
             'priorityClassName': 'my-custom-priority-class',
@@ -3034,6 +3069,7 @@ def test_make_pod_with_ssl():
                     "securityContext": {"allowPrivilegeEscalation": False},
                 }
             ],
+            "enableServiceLinks": True,
             'restartPolicy': 'OnFailure',
             'volumes': [
                 {


### PR DESCRIPTION
By default K8s injects environment variables for _every_ service in the K8s cluster: https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service
This is meant to provide a backwards compatible way of accessing K8s services where in-cluster DNS is not available.

E.g. on mybinder.org:
```
$ env | sort | grep -E _'(SERVICE|PORT)_'

BINDER_PORT_80_TCP_ADDR=10.3.246.84
BINDER_PORT_80_TCP_PORT=80
BINDER_PORT_80_TCP_PROTO=tcp
BINDER_PORT_80_TCP=tcp://10.3.246.84:80
BINDER_SERVICE_HOST=10.3.246.84
BINDER_SERVICE_PORT=80
HUB_PORT_8081_TCP_ADDR=10.3.204.115
HUB_PORT_8081_TCP_PORT=8081
HUB_PORT_8081_TCP_PROTO=tcp
HUB_PORT_8081_TCP=tcp://10.3.204.115:8081
HUB_SERVICE_HOST=10.3.204.115
HUB_SERVICE_PORT=8081
HUB_SERVICE_PORT_HUB=8081
JUPYTERHUB_SERVICE_PREFIX=/user/binder-examples-conda-uhrhszvw/
JUPYTERHUB_SERVICE_URL=http://0.0.0.0:8888/user/binder-examples-conda-uhrhszvw/
KUBERNETES_PORT_443_TCP_ADDR=10.3.0.1
KUBERNETES_PORT_443_TCP_PORT=443
KUBERNETES_PORT_443_TCP_PROTO=tcp
KUBERNETES_PORT_443_TCP=tcp://10.3.0.1:443
KUBERNETES_SERVICE_HOST=10.3.0.1
KUBERNETES_SERVICE_PORT=443
KUBERNETES_SERVICE_PORT_HTTPS=443
OVH2_GRAFANA_PORT_80_TCP_ADDR=10.3.247.169
OVH2_GRAFANA_PORT_80_TCP_PORT=80
OVH2_GRAFANA_PORT_80_TCP_PROTO=tcp
OVH2_GRAFANA_PORT_80_TCP=tcp://10.3.247.169:80
OVH2_GRAFANA_SERVICE_HOST=10.3.247.169
OVH2_GRAFANA_SERVICE_PORT=80
OVH2_GRAFANA_SERVICE_PORT_SERVICE=80
OVH2_INGRESS_NGINX_CONTROLLER_METRICS_PORT_10254_TCP_ADDR=10.3.250.132
OVH2_INGRESS_NGINX_CONTROLLER_METRICS_PORT_10254_TCP_PORT=10254
OVH2_INGRESS_NGINX_CONTROLLER_METRICS_PORT_10254_TCP_PROTO=tcp
OVH2_INGRESS_NGINX_CONTROLLER_METRICS_PORT_10254_TCP=tcp://10.3.250.132:10254
OVH2_INGRESS_NGINX_CONTROLLER_METRICS_SERVICE_HOST=10.3.250.132
OVH2_INGRESS_NGINX_CONTROLLER_METRICS_SERVICE_PORT=10254
OVH2_INGRESS_NGINX_CONTROLLER_METRICS_SERVICE_PORT_METRICS=10254
OVH2_INGRESS_NGINX_CONTROLLER_PORT_443_TCP_ADDR=10.3.235.19
OVH2_INGRESS_NGINX_CONTROLLER_PORT_443_TCP_PORT=443
OVH2_INGRESS_NGINX_CONTROLLER_PORT_443_TCP_PROTO=tcp
OVH2_INGRESS_NGINX_CONTROLLER_PORT_443_TCP=tcp://10.3.235.19:443
OVH2_INGRESS_NGINX_CONTROLLER_PORT_80_TCP_ADDR=10.3.235.19
OVH2_INGRESS_NGINX_CONTROLLER_PORT_80_TCP_PORT=80
OVH2_INGRESS_NGINX_CONTROLLER_PORT_80_TCP_PROTO=tcp
OVH2_INGRESS_NGINX_CONTROLLER_PORT_80_TCP=tcp://10.3.235.19:80
OVH2_INGRESS_NGINX_CONTROLLER_SERVICE_HOST=10.3.235.19
OVH2_INGRESS_NGINX_CONTROLLER_SERVICE_PORT=80
OVH2_INGRESS_NGINX_CONTROLLER_SERVICE_PORT_HTTP=80
OVH2_INGRESS_NGINX_CONTROLLER_SERVICE_PORT_HTTPS=443
OVH2_INGRESS_NGINX_DEFAULTBACKEND_PORT_80_TCP_ADDR=10.3.84.42
OVH2_INGRESS_NGINX_DEFAULTBACKEND_PORT_80_TCP_PORT=80
OVH2_INGRESS_NGINX_DEFAULTBACKEND_PORT_80_TCP_PROTO=tcp
OVH2_INGRESS_NGINX_DEFAULTBACKEND_PORT_80_TCP=tcp://10.3.84.42:80
OVH2_INGRESS_NGINX_DEFAULTBACKEND_SERVICE_HOST=10.3.84.42
OVH2_INGRESS_NGINX_DEFAULTBACKEND_SERVICE_PORT=80
OVH2_INGRESS_NGINX_DEFAULTBACKEND_SERVICE_PORT_HTTP=80
OVH2_KUBE_STATE_METRICS_PORT_8080_TCP_ADDR=10.3.165.12
OVH2_KUBE_STATE_METRICS_PORT_8080_TCP_PORT=8080
OVH2_KUBE_STATE_METRICS_PORT_8080_TCP_PROTO=tcp
OVH2_KUBE_STATE_METRICS_PORT_8080_TCP=tcp://10.3.165.12:8080
OVH2_KUBE_STATE_METRICS_SERVICE_HOST=10.3.165.12
OVH2_KUBE_STATE_METRICS_SERVICE_PORT=8080
OVH2_KUBE_STATE_METRICS_SERVICE_PORT_HTTP=8080
OVH2_PROMETHEUS_NODE_EXPORTER_PORT_9100_TCP_ADDR=10.3.5.41
OVH2_PROMETHEUS_NODE_EXPORTER_PORT_9100_TCP_PORT=9100
OVH2_PROMETHEUS_NODE_EXPORTER_PORT_9100_TCP_PROTO=tcp
OVH2_PROMETHEUS_NODE_EXPORTER_PORT_9100_TCP=tcp://10.3.5.41:9100
OVH2_PROMETHEUS_NODE_EXPORTER_SERVICE_HOST=10.3.5.41
OVH2_PROMETHEUS_NODE_EXPORTER_SERVICE_PORT=9100
OVH2_PROMETHEUS_NODE_EXPORTER_SERVICE_PORT_METRICS=9100
OVH2_PROMETHEUS_SERVER_PORT_80_TCP_ADDR=10.3.110.10
OVH2_PROMETHEUS_SERVER_PORT_80_TCP_PORT=80
OVH2_PROMETHEUS_SERVER_PORT_80_TCP_PROTO=tcp
OVH2_PROMETHEUS_SERVER_PORT_80_TCP=tcp://10.3.110.10:80
OVH2_PROMETHEUS_SERVER_SERVICE_HOST=10.3.110.10
OVH2_PROMETHEUS_SERVER_SERVICE_PORT=80
OVH2_PROMETHEUS_SERVER_SERVICE_PORT_HTTP=80
PROXY_API_PORT_8001_TCP_ADDR=10.3.86.77
PROXY_API_PORT_8001_TCP_PORT=8001
PROXY_API_PORT_8001_TCP_PROTO=tcp
PROXY_API_PORT_8001_TCP=tcp://10.3.86.77:8001
PROXY_API_SERVICE_HOST=10.3.86.77
PROXY_API_SERVICE_PORT=8001
PROXY_PATCHES_PORT_80_TCP_ADDR=10.3.97.135
PROXY_PATCHES_PORT_80_TCP_PORT=80
PROXY_PATCHES_PORT_80_TCP_PROTO=tcp
PROXY_PATCHES_PORT_80_TCP=tcp://10.3.97.135:80
PROXY_PATCHES_SERVICE_HOST=10.3.97.135
PROXY_PATCHES_SERVICE_PORT=80
PROXY_PUBLIC_PORT_80_TCP_ADDR=10.3.186.111
PROXY_PUBLIC_PORT_80_TCP_PORT=80
PROXY_PUBLIC_PORT_80_TCP_PROTO=tcp
PROXY_PUBLIC_PORT_80_TCP=tcp://10.3.186.111:80
PROXY_PUBLIC_SERVICE_HOST=10.3.186.111
PROXY_PUBLIC_SERVICE_PORT=80
PROXY_PUBLIC_SERVICE_PORT_HTTP=80
STATIC_PORT_80_TCP_ADDR=10.3.21.149
STATIC_PORT_80_TCP_PORT=80
STATIC_PORT_80_TCP_PROTO=tcp
STATIC_PORT_80_TCP=tcp://10.3.21.149:80
STATIC_SERVICE_HOST=10.3.21.149
STATIC_SERVICE_PORT=80
```

- `JUPYTERHUB_SERVICE_PREFIX` and `JUPYTERHUB_SERVICE_URL` are set by JupyterHub and are unaffected.
- `KUBERNETES_SERVICE_*` and `KUBERNETES_PORT_*` are [always set regardless of `enableServiceLinks`](https://stackoverflow.com/questions/62472241/enableservicelinks-false-doesnt-disable-kubernetes-clusterip-default-service-en)
- The others seem like they just pollute the user's environment.