### PR TITLE
Expand only environment variables set via Spawner.environment

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2014,7 +2014,7 @@ class KubeSpawner(Spawner):
             allow_privilege_escalation=self.allow_privilege_escalation,
             container_security_context=csc,
             pod_security_context=psc,
-            env=self._expand_all(self.get_env()),
+            env=self.get_env(),  # Expansion is handled by get_env
             volumes=self._expand_all(self.volumes),
             volume_mounts=self._expand_all(self.volume_mounts),
             working_dir=self.working_dir,
@@ -2168,6 +2168,11 @@ class KubeSpawner(Spawner):
         # deprecate image
         env['JUPYTER_IMAGE_SPEC'] = self.image
         env['JUPYTER_IMAGE'] = self.image
+
+        # Explicitly expand *and* set all the admin specified variables only.
+        # This allows JSON-like strings set by JupyterHub itself to not be
+        # expanded. https://github.com/jupyterhub/kubespawner/issues/743
+        env.update(self._expand_all(self.environment))
 
         return env
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1290,6 +1290,17 @@ async def test_pod_name_no_named_servers():
     assert spawner.pod_name == "jupyter-user"
 
 
+async def test_jupyterhub_supplied_env():
+    cookie_options = {"samesite": "None", "secure": True}
+    c = Config()
+
+    c.KubeSpawner.environment = {"HELLO": "It's {username}"}
+    spawner = KubeSpawner(config=c, _mock=True, cookie_options=cookie_options)
+
+    assert spawner.get_env()["JUPYTERHUB_COOKIE_OPTIONS"] == json.dumps(cookie_options)
+    assert spawner.get_env()["HELLO"] == "It's mock-5fname"
+
+
 async def test_pod_name_named_servers():
     c = Config()
     c.JupyterHub.allow_named_servers = True


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/kubespawner/issues/743

I've added a unit test to catch this as well