### PR TITLE
[bugfix] Using unlisted_choice a second time doesn't work

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3154,11 +3154,12 @@ class KubeSpawner(Spawner):
                         'kubespawner_override'
                     ]
                     for k, v in chosen_option_overrides.items():
-                        chosen_option_overrides[k] = v.format(
-                            value=selected_profile_user_options[
+                        # First time an unlisted choice is set, its default value is `{value}`.
+                        # Subsequent edits of the free form input, will hold the previous value
+                        # set by the user for the override
+                        chosen_option_overrides[k] = selected_profile_user_options[
                                 unlisted_choice_form_key
                             ]
-                        )
                 else:
                     chosen_option_overrides = option['choices'][chosen_option][
                         'kubespawner_override'

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3158,8 +3158,8 @@ class KubeSpawner(Spawner):
                         # Subsequent edits of the free form input, will hold the previous value
                         # set by the user for the override
                         chosen_option_overrides[k] = selected_profile_user_options[
-                                unlisted_choice_form_key
-                            ]
+                            unlisted_choice_form_key
+                        ]
                 else:
                     chosen_option_overrides = option['choices'][chosen_option][
                         'kubespawner_override'

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1007,6 +1007,23 @@ async def test_user_options_set_from_form_unlisted_choice():
     await spawner.load_user_options()
     assert getattr(spawner, 'image') == 'pangeo/test:latest'
 
+    # Test choosing an unlisted choice a second time
+    spawner.user_options = spawner.options_from_form(
+        {
+            'profile': [_test_profiles[3]['slug']],
+            'profile-option-test-choices-image--unlisted-choice': [
+                'pangeo/test:1.2.3'
+            ],
+        }
+    )
+    assert spawner.user_options == {
+        'image--unlisted-choice': 'pangeo/test:1.2.3',
+        'profile': _test_profiles[3]['slug'],
+    }
+    assert spawner.cpu_limit is None
+    await spawner.load_user_options()
+    assert getattr(spawner, 'image') == 'pangeo/test:1.2.3'
+
 
 async def test_user_options_set_from_form_invalid_regex():
     """

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1011,9 +1011,7 @@ async def test_user_options_set_from_form_unlisted_choice():
     spawner.user_options = spawner.options_from_form(
         {
             'profile': [_test_profiles[3]['slug']],
-            'profile-option-test-choices-image--unlisted-choice': [
-                'pangeo/test:1.2.3'
-            ],
+            'profile-option-test-choices-image--unlisted-choice': ['pangeo/test:1.2.3'],
         }
     )
     assert spawner.user_options == {


### PR DESCRIPTION
Multiple usages of the unlisted_choice option result in the same first introduced input to be used. If another pre-selected image is used, that works.

This is ~because we're assuming to find the default `{value}` of the override, which is not the case after the first override was applied.~ EDIT: because we worked on an object that shouldn't be changed instead of a copy by mistake

This PR:
- updated a test to use unlisted_choice a second time to reproduce the bug
- fixes the bug by just overriding whatever was before with the user's input, not assuming anything about the format of the existing value

Reference: https://github.com/2i2c-org/infrastructure/issues/2887