### PR TITLE
Rework of profile_list backend validation for readability and details

### DIFF
--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -272,7 +272,12 @@ async def test_empty_user_options_and_profile_options_api():
 
     # nothing should be loaded yet
     assert spawner.cpu_limit is None
+
+    # this shouldn't error
     await spawner.load_user_options()
+
+    # implicit defaults should be used
+    assert spawner.image == "pangeo/pangeo-notebook:ebeb9dd"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

I've failed to isolate the changes in this PR in smaller commits, but below are some highlights.

- Revised docstrings
- Some kubespawner internal functions was async for no reason so I made them non-async
- Some kubespawner internal fucntions got their signatures tweaked
- Fixed bug making warnings not be emitted about unregonized options passed via web forms

## Review together with my comments

In the "Files changed" view you can see comments I've made on the changes in various sections. I think that may be the easiest way to review this PRs changes.