### PR TITLE
Unlisted choice improvements

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -49,6 +49,7 @@ c.KubeSpawner.profile_list = [
                 'unlisted_choice': {
                     'enabled': True,
                     'display_name': 'Image Location',
+                    'other_text': 'Enter Image manually',
                     'validation_regex': '^pangeo/.*$',
                     'validation_message': 'Must be a pangeo image, matching ^pangeo/.*$',
                     'kubespawner_override': {'image': '{value}'},

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3143,19 +3143,22 @@ class KubeSpawner(Spawner):
             # Get selected options or default to the first option if none is passed
             for option_name, option in profile.get('profile_options').items():
                 unlisted_choice_form_key = f'{option_name}--unlisted-choice'
+                has_unlisted_choice_key = (option.get('unlisted_choice', {}).get('enabled', False)
+                    and unlisted_choice_form_key in selected_profile_user_options)
+                has_unlisted_choice_value = (option.get('unlisted_choice', {}).get('enabled', False)
+                    and unlisted_choice_form_key in selected_profile_user_options
+                    and selected_profile_user_options[unlisted_choice_form_key] != '')
                 chosen_option = selected_profile_user_options.get(option_name, None)
                 # If none was selected get the default. At least one choice is
                 # guaranteed to have the default set
                 if not chosen_option:
-                    for choice_name, choice in option['choices'].items():
-                        if choice.get('default', False):
-                            chosen_option = choice_name
+                    if not has_unlisted_choice_value:
+                        for choice_name, choice in option['choices'].items():
+                            if choice.get('default', False):
+                                chosen_option = choice_name
 
                 # Handle override for unlisted_choice free text specified by user
-                if (
-                    option.get('unlisted_choice', {}).get('enabled', False)
-                    and unlisted_choice_form_key in selected_profile_user_options
-                ):
+                if has_unlisted_choice_key:
                     chosen_option_overrides = option['unlisted_choice'][
                         'kubespawner_override'
                     ]

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -20,19 +20,30 @@
               <div class="js-options-container">
                 <div class="option">
                   <label for="profile-option-{{ profile.slug }}-{{ k }}"
-                         class="js-profile-option-label">{{ option.display_name }}</label>
+                        class="js-profile-option-label {%- if not option['choices'] %} hidden {%- endif %}">
+                        {{ option.display_name }}
+                  </label>
                   <select name="profile-option-{{ profile.slug }}-{{ k }}"
-                          class="form-control js-profile-option-select">
-                    {%- for k, choice in option['choices'].items() %}
-                      <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
-                    {%- endfor %}
-                    {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
-                      <option value="unlisted-choice">Other...</option>
+                          class="form-control js-profile-option-select {%- if not option['choices'] %} hidden {%- endif %}">
+                    {%- if option['choices'] %}
+                      {%- for k, choice in option['choices'].items() %}
+                        <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
+                      {%- endfor %}
                     {%- endif %}
-                  </select>
+                    {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
+                      <option value="unlisted-choice">
+                        {%- if option['unlisted_choice']['other_text'] %}
+                          {{ option['unlisted_choice']['other_text'] }}
+                        {%- else %}
+                          Other...
+                        {%- endif %}
+                      </option>
+                    {%- endif %}
+                    </select>
                 </div>
                 {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
-                  <div class="option hidden js-other-input-container">
+                  <div class="option js-other-input-container
+                    {%- if option['choices'] %} hidden {%- endif %}">
                     <label for="profile-option-{{ profile.slug }}-{{ k }}--unlisted-choice">
                       {{ option['unlisted_choice']['display_name'] }}
                     </label>


### PR DESCRIPTION
Towards #756 and #757 -

 - Allows for an `other_text` option inside `unlisted_choice` which allows user to specify a custom text in the select drop-down
 - Hide select drop-down and label if no choices are defined
 - Handles no choices in backend processing

I might have underestimated the complexity in hiding the select dropdown if there are no `choices` present, and that bit seems to have gotten a bit ugly. Will leave some comments in the code to see if there's things we can improve.

@yuvipanda @consideRatio @GeorgianaElena - firstly, thank you so much for fixing up issues with the `unlisted_choices` work, and many apologies for the delay in getting to these fixes. I am not super happy with the implementation in this PR, and I'll leave some more notes with the code. I did a bit of testing though, and it *seems* to me like it all works as expected.

If this approach seems ok to you all, I think what might be pending:

 - Create an example profile option to not have any `choices` but have an `unlisted_choice` to make testing easier
 - Create a test with no `choices` to make sure the backend handling is covered with tests.


