### PR TITLE
Allow dropdown text for unlisted choice to be configurable

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3238,7 +3238,8 @@ class KubeSpawner(Spawner):
                 profile['slug'] = slugify(profile['display_name'])
 
             # ensure each option in profile_options has a default choice if
-            # pre-defined choices are available
+            # pre-defined choices are available, and initialize an
+            # unlisted_choice dictionary
             for option_config in profile.get('profile_options', {}).values():
                 if option_config.get('choices') and not any(
                     c.get('default') for c in option_config['choices'].values()

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1605,8 +1605,8 @@ class KubeSpawner(Spawner):
                             },
                             'unlisted_choice': {
                                 'enabled': True,
-                                'other_text': 'Enter image manually',
                                 'display_name': 'Other image',
+                                'display_name_in_choices': 'Enter image manually',
                                 'validation_regex': '^jupyter/.+:.+$',
                                 'validation_message': 'Must be an image matching ^jupyter/<name>:<tag>$',
                                 'kubespawner_override': {'image': '{value}'},
@@ -3244,7 +3244,9 @@ class KubeSpawner(Spawner):
                     # pre-defined choices were provided without a default choice
                     default_choice = list(option_config['choices'].keys())[0]
                     option_config['choices'][default_choice]["default"] = True
-
+                if option_config.get('unlisted_choice'):
+                    if not 'display_name_in_choices' in option_config.get('unlisted_choice'):
+                        option_config['unlisted_choice']['display_name_in_choices'] = "Other..."
         # ensure there is one default profile
         if not any(p.get("default") for p in profile_list):
             profile_list[0]["default"] = True

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1543,6 +1543,7 @@ class KubeSpawner(Spawner):
             selected "Other" as a choice:
             - `enabled`: Boolean, whether the free form input should be enabled
             - `display_name`: String, label for input field
+            - `other_text`: Optional, text to show in Select Dropdown for Other option
             - `validation_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
             - `validation_message`: Optional, validation message for the regex. Should describe the required
                input format in a human-readable way.
@@ -1604,6 +1605,7 @@ class KubeSpawner(Spawner):
                             },
                             'unlisted_choice': {
                                 'enabled': True,
+                                'other_text': 'Enter image manually',
                                 'display_name': 'Other image',
                                 'validation_regex': '^jupyter/.+:.+$',
                                 'validation_message': 'Must be an image matching ^jupyter/<name>:<tag>$',

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1543,7 +1543,9 @@ class KubeSpawner(Spawner):
             selected "Other" as a choice:
             - `enabled`: Boolean, whether the free form input should be enabled
             - `display_name`: String, label for input field
-            - `other_text`: Optional, text to show in Select Dropdown for Other option
+            - `display_name_in_choices`: Optional, display name for the choice
+              to specify an unlisted choice in the dropdown list of pre-defined
+              choices. Defaults to "Other...".
             - `validation_regex`: Optional, regex that the free form input should match - eg. ^pangeo/.*$
             - `validation_message`: Optional, validation message for the regex. Should describe the required
                input format in a human-readable way.

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3244,13 +3244,9 @@ class KubeSpawner(Spawner):
                     # pre-defined choices were provided without a default choice
                     default_choice = list(option_config['choices'].keys())[0]
                     option_config['choices'][default_choice]["default"] = True
-                if option_config.get('unlisted_choice'):
-                    if not 'display_name_in_choices' in option_config.get(
-                        'unlisted_choice'
-                    ):
-                        option_config['unlisted_choice'][
-                            'display_name_in_choices'
-                        ] = "Other..."
+                unlisted_choice = option_config.setdefault("unlisted_choice", {})
+                unlisted_choice.setdefault("enabled", False)
+                unlisted_choice.setdefault("display_name_in_choices", "Other...")
         # ensure there is one default profile
         if not any(p.get("default") for p in profile_list):
             profile_list[0]["default"] = True

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3245,8 +3245,12 @@ class KubeSpawner(Spawner):
                     default_choice = list(option_config['choices'].keys())[0]
                     option_config['choices'][default_choice]["default"] = True
                 if option_config.get('unlisted_choice'):
-                    if not 'display_name_in_choices' in option_config.get('unlisted_choice'):
-                        option_config['unlisted_choice']['display_name_in_choices'] = "Other..."
+                    if not 'display_name_in_choices' in option_config.get(
+                        'unlisted_choice'
+                    ):
+                        option_config['unlisted_choice'][
+                            'display_name_in_choices'
+                        ] = "Other..."
         # ensure there is one default profile
         if not any(p.get("default") for p in profile_list):
             profile_list[0]["default"] = True

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3246,7 +3246,8 @@ class KubeSpawner(Spawner):
                     option_config['choices'][default_choice]["default"] = True
                 unlisted_choice = option_config.setdefault("unlisted_choice", {})
                 unlisted_choice.setdefault("enabled", False)
-                unlisted_choice.setdefault("display_name_in_choices", "Other...")
+                if unlisted_choice["enabled"]:
+                    unlisted_choice.setdefault("display_name_in_choices", "Other...")
         # ensure there is one default profile
         if not any(p.get("default") for p in profile_list):
             profile_list[0]["default"] = True

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -31,7 +31,7 @@
                     {%- endif %}
                   </select>
                 </div>
-                {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
+                {%- if option['unlisted_choice']['enabled'] %}
                   <div class="option hidden js-other-input-container">
                     <label for="profile-option-{{ profile.slug }}--{{ k }}--unlisted-choice">
                       {{ option['unlisted_choice']['display_name'] }}

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -27,7 +27,13 @@
                       <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                     {%- endfor %}
                     {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
-                      <option value="unlisted-choice">Other...</option>
+                      <option value="unlisted-choice">
+                        {%- if option['unlisted_choice']['other_text'] %}
+                          {{ option['unlisted_choice']['other_text'] }}
+                        {%- else %}
+                          Other...
+                        {%- endif %}
+                      </option>
                     {%- endif %}
                   </select>
                 </div>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -27,9 +27,7 @@
                       <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                     {%- endfor %}
                     {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
-                      <option value="unlisted-choice">
-                        {{ option['unlisted_choice']['display_name_in_choices'] }}
-                      </option>
+                      <option value="unlisted-choice">{{ option['unlisted_choice']['display_name_in_choices'] }}</option>
                     {%- endif %}
                   </select>
                 </div>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -26,7 +26,7 @@
                     {%- for k, choice in option['choices'].items() %}
                       <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
                     {%- endfor %}
-                    {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
+                    {%- if option['unlisted_choice']['enabled'] %}
                       <option value="unlisted-choice">{{ option['unlisted_choice']['display_name_in_choices'] }}</option>
                     {%- endif %}
                   </select>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -28,11 +28,7 @@
                     {%- endfor %}
                     {%- if option['unlisted_choice'] and option['unlisted_choice']['enabled'] %}
                       <option value="unlisted-choice">
-                        {%- if option['unlisted_choice']['other_text'] %}
-                          {{ option['unlisted_choice']['other_text'] }}
-                        {%- else %}
-                          Other...
-                        {%- endif %}
+                        {{ option['unlisted_choice']['display_name_in_choices'] }}
                       </option>
                     {%- endif %}
                   </select>

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -105,7 +105,7 @@ from kubespawner import KubeSpawner
                         },
                         'only-unlisted': {
                             'display_name': 'Some option without any choices set',
-                            'unlisted_choice': {'enabled': True},
+                            'unlisted_choice': {'enabled': True, 'display_name_in_choices': 'Other...'},
                         },
                         'explicit-defaults': {
                             'display_name': 'Some choice with a default set',

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -105,7 +105,10 @@ from kubespawner import KubeSpawner
                         },
                         'only-unlisted': {
                             'display_name': 'Some option without any choices set',
-                            'unlisted_choice': {'enabled': True, 'display_name_in_choices': 'Other...'},
+                            'unlisted_choice': {
+                                'enabled': True,
+                                'display_name_in_choices': 'Other...',
+                            },
                         },
                         'explicit-defaults': {
                             'display_name': 'Some choice with a default set',

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -91,6 +91,9 @@ from kubespawner import KubeSpawner
                     'profile_options': {
                         'no-defaults': {
                             'display_name': 'Some choice without a default set',
+                            'unlisted_choice': {
+                                'enabled': False
+                            },
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',
@@ -112,6 +115,9 @@ from kubespawner import KubeSpawner
                         },
                         'explicit-defaults': {
                             'display_name': 'Some choice with a default set',
+                            'unlisted_choice': {
+                                'enabled': False
+                            },
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -91,9 +91,7 @@ from kubespawner import KubeSpawner
                     'profile_options': {
                         'no-defaults': {
                             'display_name': 'Some choice without a default set',
-                            'unlisted_choice': {
-                                'enabled': False
-                            },
+                            'unlisted_choice': {'enabled': False},
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',
@@ -115,9 +113,7 @@ from kubespawner import KubeSpawner
                         },
                         'explicit-defaults': {
                             'display_name': 'Some choice with a default set',
-                            'unlisted_choice': {
-                                'enabled': False
-                            },
+                            'unlisted_choice': {'enabled': False},
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',


### PR DESCRIPTION
## PR Summary

The profile's in `profile_list` can provide `profile_options`, for example to choose a pre-defined image from a list or opt to specify an `unlisted_choice` - not part of this list. This pr adds the `unlisted_choice.display_name_in_choices` configuration to specify how the option/choice added to the list of pre-defined entries should be presented.

Before, it looked like:

![image](https://github.com/jupyterhub/kubespawner/assets/3837114/8a2170d9-d4fd-4b6e-a5cd-1b914d2f683a)

After, it can be configured to look like:

![image](https://github.com/jupyterhub/kubespawner/assets/3837114/dbc868eb-e711-4d9a-b85e-2da0c5114aba)

---

cc @yuvipanda @consideRatio @GeorgianaElena 

#757 should be a bit more straightforward than #756, so made this a separate smaller PR, correctly updated with latest `main`.

Here we just add an option to the `unlisted_choice` options dictionary and output that in the select instead of `Other...` if present.

I have called that option `other_text`, but that doesn't sound great to me, so if anyone has a better recommendation for naming, please let know / go ahead and make the change.

I'm not sure if I missed adding documentation for this new option somewhere.

Many apologies for the delay getting to this, please let me know if this looks fine. I'll make a separate PR toward #756.

Thank you!