### PR TITLE
docs: add detail to internal_ssl + fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ simultaneous users), Kubernetes is a wonderful way to do it. Features include:
   lock-in. You can even spread out your cluster across
   [multiple clouds at the same time](https://kubernetes.io/docs/user-guide/federation/).
 
-In general, Kubernetes provides a ton of well-thought-out, useful features -
+In general, Kubernetes provides a ton of well thought out, useful features -
 and you can use all of them along with this spawner.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jupyterhub/kubespawner/test.yaml?logo=github&label=tests)](https://github.com/jupyterhub/kubespawner/actions)
 [![Code coverage](https://codecov.io/gh/jupyterhub/kubespawner/branch/main/graph/badge.svg)](https://codecov.io/gh/jupyterhub/kubespawner)
 
-The _kubespawner_ (also known as JupyterHub Kubernetes Spawner) enables JupyterHub to spawn
+The _kubespawner_ (also known as the JupyterHub Kubernetes Spawner) enables JupyterHub to spawn
 single-user notebook servers on a [Kubernetes](https://kubernetes.io/)
 cluster.
 
@@ -51,7 +51,7 @@ simultaneous users), Kubernetes is a wonderful way to do it. Features include:
   lock-in. You can even spread out your cluster across
   [multiple clouds at the same time](https://kubernetes.io/docs/user-guide/federation/).
 
-In general, Kubernetes provides a ton of well thought out, useful features -
+In general, Kubernetes provides a ton of well-thought-out, useful features -
 and you can use all of them along with this spawner.
 
 ## Requirements

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,7 +2,7 @@
 
 # Kubespawner
 
-The _kubespawner_ (also known as JupyterHub Kubernetes Spawner) enables JupyterHub to spawn
+The _kubespawner_ (also known as the JupyterHub Kubernetes Spawner) enables JupyterHub to spawn
 single-user notebook servers on a [Kubernetes](https://kubernetes.io/)
 cluster.
 
@@ -47,7 +47,7 @@ simultaneous users), Kubernetes is a wonderful way to do it. Features include:
 
 - Internal SSL configuration supported
 
-In general, Kubernetes provides a ton of well thought out, useful features -
+In general, Kubernetes provides a ton of well-thought-out, useful features -
 and you can use all of them along with this spawner.
 
 ## Requirements

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -47,7 +47,7 @@ simultaneous users), Kubernetes is a wonderful way to do it. Features include:
 
 - Internal SSL configuration supported
 
-In general, Kubernetes provides a ton of well-thought-out, useful features -
+In general, Kubernetes provides a ton of well thought out, useful features -
 and you can use all of them along with this spawner.
 
 ## Requirements

--- a/docs/source/ssl.md
+++ b/docs/source/ssl.md
@@ -7,6 +7,7 @@ If enabled, the Kubespawner will mount the internal_ssl certificates as Kubernet
 ## Setup
 
 To enable, use the following settings:
+
 ```
 c.JupyterHub.internal_ssl = True
 
@@ -14,10 +15,11 @@ c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
 ```
 
 Further configuration can be specified with the following (listed with their default values):
+
 ```
 c.KubeSpawner.secret_name_template = "jupyter-{username}{servername}"
 
 c.KubeSpawner.secret_mount_path =  "/etc/jupyterhub/ssl/"
 ```
 
-The Kubespawner sets the `JUPYTERHUB_SSL_KEYFILE`, `JUPYTERHUB_SSL_CERTFILE` and `JUPYTERHUB_SSL_CLIENT_CA` environment variables, with the appropriate paths, on the user's notebook server. 
+The Kubespawner sets the `JUPYTERHUB_SSL_KEYFILE`, `JUPYTERHUB_SSL_CERTFILE` and `JUPYTERHUB_SSL_CLIENT_CA` environment variables, with the appropriate paths, on the user's notebook server.

--- a/docs/source/ssl.md
+++ b/docs/source/ssl.md
@@ -1,13 +1,23 @@
 # Internal SSL
 
-JupyterHub 1.0 introduces internal_ssl configuration for encryption and authentication of all internal communication.
+JupyterHub 1.0 introduces the internal_ssl configuration for encryption and authentication of all internal communication via mutual TLS.
 
-Kubespawner can mount the internal_ssl certificates as Kubernetes secrets into the jupyter user's pod.
+If enabled, the Kubespawner will mount the internal_ssl certificates as Kubernetes secrets into the jupyter user's pod.
 
 ## Setup
 
+To enable, use the following settings:
 ```
 c.JupyterHub.internal_ssl = True
 
 c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
 ```
+
+Further configuration can be specified with the following (listed with their default values):
+```
+c.KubeSpawner.secret_name_template = "jupyter-{username}{servername}"
+
+c.KubeSpawner.secret_mount_path =  "/etc/jupyterhub/ssl/"
+```
+
+The Kubespawner sets the `JUPYTERHUB_SSL_KEYFILE`, `JUPYTERHUB_SSL_CERTFILE` and `JUPYTERHUB_SSL_CLIENT_CA` environment variables, with the appropriate paths, on the user's notebook server. 


### PR DESCRIPTION
Correct minor typos in the README and docs as well as adding more detail to the `internal_ssl` page.