### PR TITLE
Dynamically retrieve podCIDR for routing in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,14 +81,14 @@ rules on your computer. We will now walk you through the steps to get going:
 
     ```bash
     # Linux
-    sudo ip route add 172.17.0.0/16 via $(minikube ip)
+    sudo ip route add $(kubectl get node minikube -o jsonpath="{.spec.podCIDR}") via $(minikube ip)
     # later on you can undo this with
-    sudo ip route del 172.17.0.0/16
+    sudo ip route del $(kubectl get node minikube -o jsonpath="{.spec.podCIDR}")
 
     # MACOS
-    sudo route -n add -net 172.17.0.0/16 $(minikube ip)
+    sudo route -n add -net $(kubectl get node minikube -o jsonpath="{.spec.podCIDR}") $(minikube ip)
     # later on you can undo this with
-    sudo route delete -net 172.17.0.0
+    sudo route delete -net $(kubectl get node minikube -o jsonpath="{.spec.podCIDR}")
     ```
 
     ### Troubleshooting


### PR DESCRIPTION
The CIDR from which pod IPs are allocated can change depending on platform and driver used for `minikube`. On my machine, it's 10.244.0.0/24. This changes the instructions to determine the podCIDR dynamically by talking to kubernetes, rather than hardcoding it in.

I personally prefer just repeating the command here rather than using an environment variable, as it means the single line can be just copy pasted.