### PR TITLE
enable k8s client verify_ssl param

### DIFF
--- a/kubespawner/clients.py
+++ b/kubespawner/clients.py
@@ -67,7 +67,7 @@ def shared_client(ClientType, *args, **kwargs):
 
 
 @lru_cache()
-def load_config(host=None, ssl_ca_cert=None):
+def load_config(host=None, ssl_ca_cert=None, verify_ssl=None):
     """
     Loads global configuration for the Python client we use to communicate with
     a Kubernetes API server, and optionally tweaks that configuration based on
@@ -97,4 +97,8 @@ def load_config(host=None, ssl_ca_cert=None):
     if host:
         global_conf = Configuration.get_default_copy()
         global_conf.host = host
+        Configuration.set_default(global_conf)
+    if verify_ssl is not None:
+        global_conf = Configuration.get_default_copy()
+        global_conf.verify_ssl = verify_ssl
         Configuration.set_default(global_conf)

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -298,7 +298,8 @@ class KubeIngressProxy(Proxy):
     )
 
     k8s_api_verify_ssl = Bool(
-        True,
+        None,
+        allow_none=True,
         config=True,
         help="""
         SSL/TLS verification

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -302,7 +302,8 @@ class KubeIngressProxy(Proxy):
         allow_none=True,
         config=True,
         help="""
-        SSL/TLS verification
+        Verify TLS certificates when connecting to the k8s master.
+        
         Set this to false to skip verifying SSL certificate when calling API
         from https server.
         """,

--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -297,9 +297,23 @@ class KubeIngressProxy(Proxy):
         """,
     )
 
+    k8s_api_verify_ssl = Bool(
+        True,
+        config=True,
+        help="""
+        SSL/TLS verification
+        Set this to false to skip verifying SSL certificate when calling API
+        from https server.
+        """,
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        load_config(host=self.k8s_api_host, ssl_ca_cert=self.k8s_api_ssl_ca_cert)
+        load_config(
+            host=self.k8s_api_host,
+            ssl_ca_cert=self.k8s_api_ssl_ca_cert,
+            verify_ssl=self.k8s_api_verify_ssl,
+        )
         self.core_api = shared_client('CoreV1Api')
         self.networking_api = shared_client('NetworkingV1Api')
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -201,8 +201,22 @@ class KubeSpawner(Spawner):
         # The attribute needs to exist, even though it is unset to start with
         self._start_future = None
 
-        load_config(host=self.k8s_api_host, ssl_ca_cert=self.k8s_api_ssl_ca_cert)
+        load_config(
+            host=self.k8s_api_host,
+            ssl_ca_cert=self.k8s_api_ssl_ca_cert,
+            verify_ssl=self.k8s_api_verify_ssl,
+        )
         self.api = shared_client("CoreV1Api")
+
+    k8s_api_verify_ssl = Bool(
+        True,
+        config=True,
+        help="""
+        SSL/TLS verification
+        Set this to false to skip verifying SSL certificate when calling API
+        from https server.
+        """,
+    )
 
     k8s_api_ssl_ca_cert = Unicode(
         "",

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -213,7 +213,8 @@ class KubeSpawner(Spawner):
         allow_none=True,
         config=True,
         help="""
-        SSL/TLS verification
+        Verify TLS certificates when connecting to the k8s master.
+        
         Set this to false to skip verifying SSL certificate when calling API
         from https server.
         """,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -209,7 +209,8 @@ class KubeSpawner(Spawner):
         self.api = shared_client("CoreV1Api")
 
     k8s_api_verify_ssl = Bool(
-        True,
+        None,
+        allow_none=True,
         config=True,
         help="""
         SSL/TLS verification


### PR DESCRIPTION
When the k8s cluster uses self signed certificates, Python may not be able to verify the validity of the root certificate, resulting in client calls failing. We can modify by verify_ssl parameter skip certificate validation。

Fixes #799