### PR TITLE
Omit ImagePullPolicy by default

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -140,7 +140,7 @@ def make_pod(
     image_pull_policy:
         Image pull policy - one of None, 'Always', 'IfNotPresent' or 'Never'. Decides
         when kubernetes will check for a newer version of image and pull it when
-        running a pod. If set to None, it will omitted from the spec.
+        running a pod. If set to None, it will be omitted from the spec.
 
     image_pull_secrets:
         Image pull secrets - a list of references to Kubernetes Secret resources

--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -80,7 +80,7 @@ def make_pod(
     cmd,
     port,
     image,
-    image_pull_policy,
+    image_pull_policy=None,
     image_pull_secrets=None,
     node_selector=None,
     uid=None,
@@ -138,9 +138,9 @@ def make_pod(
         arguments
 
     image_pull_policy:
-        Image pull policy - one of 'Always', 'IfNotPresent' or 'Never'. Decides
+        Image pull policy - one of None, 'Always', 'IfNotPresent' or 'Never'. Decides
         when kubernetes will check for a newer version of image and pull it when
-        running a pod.
+        running a pod. If set to None, it will omitted from the spec.
 
     image_pull_secrets:
         Image pull secrets - a list of references to Kubernetes Secret resources

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -721,21 +721,16 @@ class KubeSpawner(Spawner):
     )
 
     image_pull_policy = Unicode(
-        'IfNotPresent',
+        None,
+        allow_none=True,
         config=True,
         help="""
         The image pull policy of the docker container specified in
         `image`.
 
-        Defaults to `IfNotPresent` which causes the Kubelet to NOT pull the image
-        specified in KubeSpawner.image if it already exists, except if the tag
-        is `:latest`. For more information on image pull policy,
-        refer to `the Kubernetes documentation <https://kubernetes.io/docs/concepts/containers/images/>`__.
-
-
-        This configuration is primarily used in development if you are
-        actively changing the `image_spec` and would like to pull the image
-        whenever a user container is spawned.
+        Defaults to `None`, which means it is omitted. This leads to it behaving
+        like 'Always' when a tag is absent or 'latest', and 'IfNotPresent' when
+        the tag is specified to be something else.
         """,
     )
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -730,7 +730,7 @@ class KubeSpawner(Spawner):
 
         Defaults to `None`, which means it is omitted. This leads to it behaving
         like 'Always' when a tag is absent or 'latest', and 'IfNotPresent' when
-        the tag is specified to be something else.
+        the tag is specified to be something else, per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting.
         """,
     )
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -19,7 +19,6 @@ def test_make_simplest_pod():
             image='jupyter/singleuser:latest',
             cmd=['jupyterhub-singleuser'],
             port=8888,
-            image_pull_policy='IfNotPresent',
         )
     ) == {
         "metadata": {"name": "test", "labels": {}, "annotations": {}},
@@ -30,7 +29,6 @@ def test_make_simplest_pod():
                     "env": [],
                     "name": "notebook",
                     "image": "jupyter/singleuser:latest",
-                    "imagePullPolicy": "IfNotPresent",
                     "args": ["jupyterhub-singleuser"],
                     "ports": [{"name": "notebook-port", "containerPort": 8888}],
                     'volumeMounts': [],


### PR DESCRIPTION
Our documentation says that if ':latest' is used as a tag in an image, ImagePullPolicy will be automatically set by Kubernetes to 'Always'. This cites https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting.

However, that's only true if the imagePullPolicy is *omitted*! But we actually *do* set it, to 'IfNotPresent', so this behavior is actually not what we get. This came to light when a user noticed that on nodes with images already present, ':latest' was not taking effect. Looking at the pod definition, we see:

```yaml
image: quay.io/henrykmodzelewski/2i2c-eosc211:latest
imagePullPolicy: IfNotPresent
```

This PR just omits imagePullPolicy by default, so we *actually* get the behavior we said we were getting.