### PR TITLE
ci: update python and k8s versions to test with, include py312

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,13 +50,13 @@ jobs:
               kubernetes_asyncio==24.2.3
 
           # Test with modern python and k8s versions
-          - python: "3.9"
-            k3s: stable
-          - python: "3.10"
-            k3s: latest
+          - python: "3.11"
+            k3s: v1.27
+          - python: "3.12"
+            k3s: v1.28
 
           # Test with latest python and JupyterHub in main branch
-          - python: "3.11"
+          - python: "3.X"
             k3s: latest
             test_dependencies: git+https://github.com/jupyterhub/jupyterhub
 


### PR DESCRIPTION
Nice, Python 3.12 works out of the box it seems!