### PR TITLE
Fix build with hatch by specifying folder name explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ Issues = "https://github.com/jupyterhub/kubespawner/issues"
 artifacts = [
     "kubespawner/templates/*"
 ]
+# include is required since the project name doesn't match the folder name
+include = ["kubespawner"]
 
 # black is used for autoformatting Python code
 #


### PR DESCRIPTION
I think this resolves at least a part of #816.

I think something changed over time even though I don't find a clear entry in a changelog. Looking at https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection and seeing how @martinclaus resolved this in https://github.com/jupyterhub/ltiauthenticator/pull/185 I went with this change.