### PR TITLE
Fix #761 expand pvc_name outside of init

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2746,7 +2746,9 @@ class KubeSpawner(Spawner):
 
                 if self.internal_ssl:
                     # internal ssl, create secret object
-                    secret_manifest = self.get_secret_manifest(owner_reference, secret_name)
+                    secret_manifest = self.get_secret_manifest(
+                        owner_reference, secret_name
+                    )
                     await exponential_backoff(
                         partial(
                             self._ensure_not_exists,


### PR DESCRIPTION
Partial fix for #761 by moving the expansion of `pvc_name` and `secret_name` outside of `__init__`.

\cc @yuvipanda