### PR TITLE
add slow_spawn_message progress for slow spawns

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -12,6 +12,7 @@ import os
 import re
 import string
 import sys
+import textwrap
 import warnings
 from functools import partial
 from typing import Optional, Tuple, Type

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2729,9 +2729,7 @@ class KubeSpawner(Spawner):
             ):
                 # don't spam the user, so only update the timer message every few seconds
                 if timer % self.slow_spawn_message_frequency == 0:
-                    patience_message = textwrap.dedent(
-                        self.slow_spawn_message
-                    )
+                    patience_message = textwrap.dedent(self.slow_spawn_message)
                     patience_message = patience_message.format(seconds=timer)
 
                     yield {

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2740,7 +2740,10 @@ class KubeSpawner(Spawner):
 
             # if the timer is greater than self.server_spawn_launch_timer_threshold
             # display a message to the user with an incrementing count in seconds
-            if timer >= self.server_spawn_launcher_timer_threshold and self.server_spawn_launch_timer_enabled:
+            if (
+                timer >= self.server_spawn_launcher_timer_threshold
+                and self.server_spawn_launch_timer_enabled
+            ):
                 # don't spam the user, so only update the timer message every few seconds
                 if timer % self.server_spawn_launch_timer_threshold == 0:
                     patience_message = textwrap.dedent(

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -12,6 +12,7 @@ import os
 import re
 import string
 import sys
+import time
 import textwrap
 import warnings
 from functools import partial
@@ -2703,7 +2704,7 @@ class KubeSpawner(Spawner):
         next_event = 0
 
         # count in seconds to time single user server spawn duration
-        timer = 0
+        start_time = time.perf_counter()
 
         break_while_loop = False
         while True:
@@ -2723,15 +2724,17 @@ class KubeSpawner(Spawner):
 
             # if the timer is greater than self.server_spawn_launch_timer_threshold
             # display a message to the user with an incrementing count in seconds
+            elapsed = time.perf_counter() - start_time
             if (
-                timer >= self.slow_spawn_message_threshold
+                elapsed >= self.slow_spawn_message_threshold
                 and self.slow_spawn_message_threshold > 0
             ):
                 # don't spam the user, so only update the timer message every few seconds
-                if timer % self.slow_spawn_message_frequency == 0:
-                    patience_message = textwrap.dedent(self.slow_spawn_message)
-                    patience_message = patience_message.format(seconds=timer)
-
+                if elapsed % self.slow_spawn_message_frequency == 0:
+                    patience_message = textwrap.dedent(
+                        self.slow_spawn_message
+                    )
+                    patience_message = patience_message.format(seconds=int(elapsed))
                     yield {
                         'message': patience_message,
                     }

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2741,7 +2741,7 @@ class KubeSpawner(Spawner):
             # if the timer is greater than self.server_spawn_launch_timer_threshold
             # display a message to the user with an incrementing count in seconds
             if (
-                timer >= self.server_spawn_launcher_timer_threshold
+                timer >= self.server_spawn_launch_timer_threshold
                 and self.server_spawn_launch_timer_enabled
             ):
                 # don't spam the user, so only update the timer message every few seconds

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1920,8 +1920,7 @@ class KubeSpawner(Spawner):
         config=True,
         help="""
         The injected timing message to display to the user. The variable `{seconds}`
-        will be replaced by the number of seconds the spawn has taken in
-        self.progress().
+        will be replaced by the number of seconds the spawn has currently taken.
         """,
     )
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2704,6 +2704,7 @@ class KubeSpawner(Spawner):
 
         # count in seconds to time single user server spawn duration
         start_time = time.perf_counter()
+        last_message_time = float()
 
         break_while_loop = False
         while True:
@@ -2729,9 +2730,10 @@ class KubeSpawner(Spawner):
                 and self.slow_spawn_message_threshold > 0
             ):
                 # don't spam the user, so only update the timer message every few seconds
-                if elapsed % self.slow_spawn_message_frequency == 0:
+                if elapsed > last_message_time + self.slow_spawn_message_frequency:
                     patience_message = textwrap.dedent(self.slow_spawn_message)
                     patience_message = patience_message.format(seconds=int(elapsed))
+                    last_message_time = elapsed
                     yield {
                         'message': patience_message,
                     }

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1919,7 +1919,7 @@ class KubeSpawner(Spawner):
         "Server launch is taking longer than expected. Please be patient! Current time spent waiting: {seconds} seconds.",
         config=True,
         help="""
-        The injected timing message to display to the user. The variable {seconds}
+        The injected timing message to display to the user. The variable `{seconds}`
         will be replaced by the number of seconds the spawn has taken in
         self.progress().
         """,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2730,7 +2730,7 @@ class KubeSpawner(Spawner):
                 and self.slow_spawn_message_threshold > 0
             ):
                 # don't spam the user, so only update the timer message every few seconds
-                if elapsed > last_message_time + self.slow_spawn_message_frequency:
+                if elapsed >= last_message_time + self.slow_spawn_message_frequency:
                     patience_message = textwrap.dedent(self.slow_spawn_message)
                     patience_message = patience_message.format(seconds=int(elapsed))
                     last_message_time = elapsed

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2762,7 +2762,6 @@ class KubeSpawner(Spawner):
 
             if break_while_loop:
                 break
-
             await asyncio.sleep(1)
 
     async def _start_reflector(

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1896,15 +1896,6 @@ class KubeSpawner(Spawner):
         """,
     )
 
-    server_spawn_launch_delay = Integer(
-        0,
-        config=True,
-        help="""
-        Time in seconds to delay a single-user server launch, which can be
-        useful for debugging.  If set to zero, no delay will take place.
-        """,
-    )
-
     server_spawn_launch_timer_enabled = Bool(
         True,
         config=True,
@@ -3127,13 +3118,6 @@ class KubeSpawner(Spawner):
 
     async def _start(self):
         """Start the user's pod"""
-        # delay single user server spawn if testing
-        if self.server_spawn_launch_delay:
-            self.log.info(
-                "Delaying spawn launch for %s seconds.",
-                str(self.server_spawn_launch_delay),
-            )
-            await asyncio.sleep(self.server_spawn_launch_delay)
 
         # load user options (including profile)
         await self.load_user_options()

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2745,7 +2745,7 @@ class KubeSpawner(Spawner):
                 and self.server_spawn_launch_timer_enabled
             ):
                 # don't spam the user, so only update the timer message every few seconds
-                if timer % self.server_spawn_launch_timer_threshold == 0:
+                if timer % self.server_spawn_launch_timer_frequency == 0:
                     patience_message = textwrap.dedent(
                         self.server_spawn_launch_timer_message
                     )

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2763,7 +2763,7 @@ class KubeSpawner(Spawner):
 
             if break_while_loop:
                 break
-            timer += 1
+
             await asyncio.sleep(1)
 
     async def _start_reflector(

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1896,20 +1896,12 @@ class KubeSpawner(Spawner):
         """,
     )
 
-    server_spawn_launch_timer_enabled = Bool(
-        True,
-        config=True,
-        help="""
-        Enable the spawn progress counter message.
-        """,
-    )
-
     server_spawn_launch_timer_threshold = Integer(
         60,
         config=True,
         help="""
         Time in seconds to wait before injecting a 'please be patient' message
-        to display to the user.
+        to display to the user. If this value is 0, no message will be shown.
         """,
     )
 
@@ -2733,7 +2725,7 @@ class KubeSpawner(Spawner):
             # display a message to the user with an incrementing count in seconds
             if (
                 timer >= self.server_spawn_launch_timer_threshold
-                and self.server_spawn_launch_timer_enabled
+                and self.server_spawn_launch_timer_threshold > 0
             ):
                 # don't spam the user, so only update the timer message every few seconds
                 if timer % self.server_spawn_launch_timer_frequency == 0:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1896,7 +1896,7 @@ class KubeSpawner(Spawner):
         """,
     )
 
-    server_spawn_launch_timer_threshold = Integer(
+    slow_spawn_message_threshold = Integer(
         60,
         config=True,
         help="""
@@ -1905,7 +1905,7 @@ class KubeSpawner(Spawner):
         """,
     )
 
-    server_spawn_launch_timer_frequency = Integer(
+    slow_spawn_message_frequency = Integer(
         5,
         config=True,
         help="""
@@ -1914,7 +1914,7 @@ class KubeSpawner(Spawner):
         """,
     )
 
-    server_spawn_launch_timer_message = Unicode(
+    slow_spawn_message = Unicode(
         "Server launch is taking longer than expected. Please be patient! Current time spent waiting: {seconds} seconds.",
         config=True,
         help="""
@@ -2724,13 +2724,13 @@ class KubeSpawner(Spawner):
             # if the timer is greater than self.server_spawn_launch_timer_threshold
             # display a message to the user with an incrementing count in seconds
             if (
-                timer >= self.server_spawn_launch_timer_threshold
-                and self.server_spawn_launch_timer_threshold > 0
+                timer >= self.slow_spawn_message_threshold
+                and self.slow_spawn_message_threshold > 0
             ):
                 # don't spam the user, so only update the timer message every few seconds
-                if timer % self.server_spawn_launch_timer_frequency == 0:
+                if timer % self.slow_spawn_message_frequency == 0:
                     patience_message = textwrap.dedent(
-                        self.server_spawn_launch_timer_message
+                        self.slow_spawn_message
                     )
                     patience_message = patience_message.format(seconds=timer)
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1931,9 +1931,7 @@ class KubeSpawner(Spawner):
     )
 
     spawn_launcher_timer_message = Unicode(
-        """
-        Server launch is taking longer than expected. Please be patient!
-        """,
+        "Server launch is taking longer than expected. Please be patient!",
         config=True,
         help="""
         The injected 'please be patient' message to display to the user.

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2704,7 +2704,7 @@ class KubeSpawner(Spawner):
 
         # timers for deciding when to show slow spawn patience message
         start_time = time.perf_counter()
-        last_message_time = float()
+        last_message_time = start_time
 
         break_while_loop = False
         while True:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1896,45 +1896,48 @@ class KubeSpawner(Spawner):
         """,
     )
 
-    spawn_launcher_delay = Integer(
+    server_spawn_launch_delay = Integer(
         0,
         config=True,
         help="""
-        Time in seconds to delay a single-user server launch, useful for debugging.
-        If set to zero, no delay will take place.
+        Time in seconds to delay a single-user server launch, which can be
+        useful for debugging.  If set to zero, no delay will take place.
         """,
     )
 
-    spawn_launcher_timer_enabled = Bool(
+    server_spawn_launch_timer_enabled = Bool(
         True,
         config=True,
         help="""
-        Enable the spawn delay patience message.
+        Enable the spawn progress counter message.
         """,
     )
 
-    spawn_launcher_timer = Integer(
+    server_spawn_launch_timer_threshold = Integer(
         60,
         config=True,
         help="""
-        Time in seconds to wait before injecting a 'please be patient' message to display
-        to the user.
+        Time in seconds to wait before injecting a 'please be patient' message
+        to display to the user.
         """,
     )
 
-    spawn_launcher_timer_frequency = Integer(
+    server_spawn_launch_timer_frequency = Integer(
         5,
         config=True,
         help="""
-        Display the patience message every 5 seconds.
+        Sets a delay of N seconds between updates to the message buffer, so
+        that we don't spam the user with too many messages.
         """,
     )
 
-    spawn_launcher_timer_message = Unicode(
-        "Server launch is taking longer than expected. Please be patient!",
+    server_spawn_launch_timer_message = Unicode(
+        "Server launch is taking longer than expected. Please be patient! Current time spent waiting: XXX seconds.",
         config=True,
         help="""
-        The injected 'please be patient' message to display to the user.
+        The injected timing message to display to the user. The string XXX
+        will be replaced by the number of seconds the spawn has taken in
+        self.progress().
         """,
     )
 
@@ -2715,6 +2718,8 @@ class KubeSpawner(Spawner):
         start_future = self._start_future
         progress = 0
         next_event = 0
+
+        # count in seconds to time single user server spawn duration
         timer = 0
 
         break_while_loop = False
@@ -2733,17 +2738,16 @@ class KubeSpawner(Spawner):
             if start_future and start_future.done():
                 break_while_loop = True
 
-            # check the timer, and if we're over self.spawn_launcher_timer ask the
-            # user to be patient
-            if timer >= self.spawn_launcher_timer and self.spawn_launcher_timer_enabled:
-                # display only every X seconds
-                if timer % self.spawn_launcher_timer_frequency == 0:
+            # if the timer is greater than self.server_spawn_launch_timer_threshold
+            # display a message to the user with an incrementing count in seconds
+            if timer >= self.server_spawn_launcher_timer_threshold and self.server_spawn_launch_timer_enabled:
+                # don't spam the user, so only update the timer message every few seconds
+                if timer % self.server_spawn_launch_timer_threshold == 0:
                     patience_message = textwrap.dedent(
-                        self.spawn_launcher_timer_message
+                        self.server_spawn_launch_timer_message
                     )
-                    patience_message += (
-                        " Current time spent waiting: %i seconds" % timer
-                    )
+                    patience_message.replace('XXX', str(timer))
+
                     yield {
                         'message': patience_message,
                     }
@@ -3120,9 +3124,9 @@ class KubeSpawner(Spawner):
 
     async def _start(self):
         """Start the user's pod"""
-        # delay spawn if testing
-        if self.spawn_launcher_delay:
-            await asyncio.sleep(self.spawn_launcher_delay)
+        # delay single user server spawn if testing
+        if self.server_spawn_launch_delay:
+            await asyncio.sleep(self.server_spawn_launch_delay)
 
         # load user options (including profile)
         await self.load_user_options()

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1895,6 +1895,50 @@ class KubeSpawner(Spawner):
         """,
     )
 
+    spawn_launcher_delay = Integer(
+        0,
+        config=True,
+        help="""
+        Time in seconds to delay a single-user server launch, useful for debugging.
+        If set to zero, no delay will take place.
+        """
+    )
+
+    spawn_launcher_timer_enabled = Bool(
+        True,
+        config=True,
+        help="""
+        Enable the spawn delay patience message.
+        """
+    )
+
+    spawn_launcher_timer = Integer(
+        60,
+        config=True,
+        help="""
+        Time in seconds to wait before injecting a 'please be patient' message to display
+        to the user.
+        """
+    )
+
+    spawn_launcher_timer_frequency = Integer(
+        5,
+        config=True,
+        help="""
+        Display the patience message every 5 seconds.
+        """
+    )
+
+    spawn_launcher_timer_message = Unicode(
+        """
+        Server launch is taking longer than expected. Please be patient!
+        """,
+        config=True,
+        help="""
+        The injected 'please be patient' message to display to the user.
+        """
+    )
+
     # deprecate redundant and inconsistent singleuser_ and user_ prefixes:
     _deprecated_traits_09 = [
         "singleuser_working_dir",
@@ -2672,6 +2716,7 @@ class KubeSpawner(Spawner):
         start_future = self._start_future
         progress = 0
         next_event = 0
+        timer = 0
 
         break_while_loop = False
         while True:
@@ -2688,6 +2733,15 @@ class KubeSpawner(Spawner):
             # .sleep() and missed something.
             if start_future and start_future.done():
                 break_while_loop = True
+
+            # check the timer, and if we're over self.spawn_launcher_timer ask the
+            # user to be patient
+            if timer >= self.spawn_launcher_timer and self.spawn_launcher_timer_enabled:
+                # display only every X seconds
+                if timer % self.spawn_launcher_timer_frequency == 0:
+                    patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
+                    patience_message += " Current time spent waiting: %i seconds" % timer
+                    yield { 'message': patience_message, }
 
             events = self.events
             len_events = len(events)
@@ -2715,6 +2769,7 @@ class KubeSpawner(Spawner):
 
             if break_while_loop:
                 break
+            timer += 1
             await asyncio.sleep(1)
 
     async def _start_reflector(
@@ -3060,6 +3115,9 @@ class KubeSpawner(Spawner):
 
     async def _start(self):
         """Start the user's pod"""
+        # delay spawn if testing
+        if self.spawn_launcher_delay:
+            await asyncio.sleep(self.spawn_launcher_delay)
 
         # load user options (including profile)
         await self.load_user_options()

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2704,7 +2704,7 @@ class KubeSpawner(Spawner):
 
         # timers for deciding when to show slow spawn patience message
         start_time = time.perf_counter()
-        last_message_time = start_time
+        last_message_time = 0
 
         break_while_loop = False
         while True:

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -12,8 +12,8 @@ import os
 import re
 import string
 import sys
-import time
 import textwrap
+import time
 import warnings
 from functools import partial
 from typing import Optional, Tuple, Type
@@ -2731,9 +2731,7 @@ class KubeSpawner(Spawner):
             ):
                 # don't spam the user, so only update the timer message every few seconds
                 if elapsed % self.slow_spawn_message_frequency == 0:
-                    patience_message = textwrap.dedent(
-                        self.slow_spawn_message
-                    )
+                    patience_message = textwrap.dedent(self.slow_spawn_message)
                     patience_message = patience_message.format(seconds=int(elapsed))
                     yield {
                         'message': patience_message,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3131,7 +3131,7 @@ class KubeSpawner(Spawner):
         if self.server_spawn_launch_delay:
             self.log.info(
                 "Delaying spawn launch for %s seconds.",
-                str(self.server_spawn_launch_delay)
+                str(self.server_spawn_launch_delay),
             )
             await asyncio.sleep(self.server_spawn_launch_delay)
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3129,6 +3129,10 @@ class KubeSpawner(Spawner):
         """Start the user's pod"""
         # delay single user server spawn if testing
         if self.server_spawn_launch_delay:
+            self.log.info(
+                "Delaying spawn launch for %s seconds.",
+                str(self.server_spawn_launch_delay)
+            )
             await asyncio.sleep(self.server_spawn_launch_delay)
 
         # load user options (including profile)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1901,7 +1901,7 @@ class KubeSpawner(Spawner):
         help="""
         Time in seconds to delay a single-user server launch, useful for debugging.
         If set to zero, no delay will take place.
-        """
+        """,
     )
 
     spawn_launcher_timer_enabled = Bool(
@@ -1909,7 +1909,7 @@ class KubeSpawner(Spawner):
         config=True,
         help="""
         Enable the spawn delay patience message.
-        """
+        """,
     )
 
     spawn_launcher_timer = Integer(
@@ -1918,7 +1918,7 @@ class KubeSpawner(Spawner):
         help="""
         Time in seconds to wait before injecting a 'please be patient' message to display
         to the user.
-        """
+        """,
     )
 
     spawn_launcher_timer_frequency = Integer(
@@ -1926,7 +1926,7 @@ class KubeSpawner(Spawner):
         config=True,
         help="""
         Display the patience message every 5 seconds.
-        """
+        """,
     )
 
     spawn_launcher_timer_message = Unicode(
@@ -1936,7 +1936,7 @@ class KubeSpawner(Spawner):
         config=True,
         help="""
         The injected 'please be patient' message to display to the user.
-        """
+        """,
     )
 
     # deprecate redundant and inconsistent singleuser_ and user_ prefixes:
@@ -2739,9 +2739,15 @@ class KubeSpawner(Spawner):
             if timer >= self.spawn_launcher_timer and self.spawn_launcher_timer_enabled:
                 # display only every X seconds
                 if timer % self.spawn_launcher_timer_frequency == 0:
-                    patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
-                    patience_message += " Current time spent waiting: %i seconds" % timer
-                    yield { 'message': patience_message, }
+                    patience_message = textwrap.dedent(
+                        self.spawn_launcher_timer_message
+                    )
+                    patience_message += (
+                        " Current time spent waiting: %i seconds" % timer
+                    )
+                    yield {
+                        'message': patience_message,
+                    }
 
             events = self.events
             len_events = len(events)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1923,10 +1923,10 @@ class KubeSpawner(Spawner):
     )
 
     server_spawn_launch_timer_message = Unicode(
-        "Server launch is taking longer than expected. Please be patient! Current time spent waiting: XXX seconds.",
+        "Server launch is taking longer than expected. Please be patient! Current time spent waiting: {seconds} seconds.",
         config=True,
         help="""
-        The injected timing message to display to the user. The string XXX
+        The injected timing message to display to the user. The variable {seconds}
         will be replaced by the number of seconds the spawn has taken in
         self.progress().
         """,
@@ -2740,7 +2740,7 @@ class KubeSpawner(Spawner):
                     patience_message = textwrap.dedent(
                         self.server_spawn_launch_timer_message
                     )
-                    patience_message.replace('XXX', str(timer))
+                    patience_message = patience_message.format(seconds=timer)
 
                     yield {
                         'message': patience_message,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2702,7 +2702,7 @@ class KubeSpawner(Spawner):
         progress = 0
         next_event = 0
 
-        # count in seconds to time single user server spawn duration
+        # timers for deciding when to show slow spawn patience message
         start_time = time.perf_counter()
         last_message_time = float()
 


### PR DESCRIPTION
this PR  adds a configurable message to present to users after an amount of time has passed, imploring patience.

~~adding a delay was useful in debugging some grafana metrics (https://github.com/berkeley-dsep-infra/datahub/issues/4237, https://github.com/berkeley-dsep-infra/datahub/pull/4241).~~

the 'patience message' was added as users would believe that hubs were down/not working/etc when it took longer than a couple of minutes to launch their notebooks, particularly when a new GCP node was spinning up during peak usage times (https://github.com/berkeley-dsep-infra/datahub/issues/3845, https://github.com/berkeley-dsep-infra/datahub/pull/3963).

this has been incredibly useful for us at UC Berkeley and has saved both us and our users many hours of unnecessary support and debugging requests due to slow launches. 

ref:  https://github.com/jupyterhub/kubespawner/issues/651