### PR TITLE
Ensure Kubespawner internal SSL secret is correctly encoded as base64

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -1014,15 +1014,10 @@ def make_secret(
         encoded = base64.b64encode(file.read().encode("utf-8"))
         secret.data['ssl.crt'] = encoded.decode("utf-8")
 
-    with open(cert_paths['cafile']) as file:
-        encoded = base64.b64encode(file.read().encode("utf-8"))
+    with open(cert_paths['cafile']) as ca_file, open(hub_ca) as hub_ca_file:
+        cas = ca_file.read().strip("\n") + "\n" + hub_ca_file.read()
+        encoded = base64.b64encode(cas.encode("utf-8"))
         secret.data["notebooks-ca_trust.crt"] = encoded.decode("utf-8")
-
-    with open(hub_ca) as file:
-        encoded = base64.b64encode(file.read().encode("utf-8"))
-        secret.data["notebooks-ca_trust.crt"] = secret.data[
-            "notebooks-ca_trust.crt"
-        ] + encoded.decode("utf-8")
 
     return secret
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -366,32 +366,6 @@ async def test_spawn_component_label(
     await spawner.stop()
 
 
-async def test_spawner_internal_ssl_secret(
-    ssl_app,
-    config,
-):
-    """
-    Validate that certificates are correctly encoded as base64
-    https://github.com/jupyterhub/kubespawner/pull/828
-    """
-    spawner = KubeSpawner(
-        config=config,
-        user=MockUser(name="ssl"),
-        internal_ssl=True,
-        internal_trust_bundles=ssl_app.internal_trust_bundles,
-        internal_certs_location=ssl_app.internal_certs_location,
-        _mock=True,
-    )
-    # initialize ssl config
-    hub_paths = await spawner.create_certs()
-
-    spawner.cert_paths = await spawner.move_certs(hub_paths)
-
-    manifest = spawner.get_secret_manifest(None)
-    for _, secret in manifest.data.items():
-        base64.b64decode(secret, validate=True)
-
-
 async def test_spawn_internal_ssl(
     kube_ns,
     kube_client,
@@ -417,6 +391,12 @@ async def test_spawn_internal_ssl(
     hub_paths = await spawner.create_certs()
 
     spawner.cert_paths = await spawner.move_certs(hub_paths)
+
+    # Validate that certificates are correctly encoded
+    # https://github.com/jupyterhub/kubespawner/pull/828
+    manifest = spawner.get_secret_manifest(None)
+    for _, secret in manifest.data.items():
+        base64.b64decode(secret, validate=True)
 
     # start the spawner
     url = await spawner.start()

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -370,6 +370,10 @@ async def test_spawner_internal_ssl_secret(
     ssl_app,
     config,
 ):
+    """
+    Validate that certificates are correctly encoded as base64
+    https://github.com/jupyterhub/kubespawner/pull/828
+    """
     spawner = KubeSpawner(
         config=config,
         user=MockUser(name="ssl"),
@@ -383,7 +387,6 @@ async def test_spawner_internal_ssl_secret(
 
     spawner.cert_paths = await spawner.move_certs(hub_paths)
 
-    # Validate that certificates were correctly encoded as base64
     manifest = spawner.get_secret_manifest(None)
     for _, secret in manifest.data.items():
         base64.b64decode(secret, validate=True)


### PR DESCRIPTION
`test_spawn_internal_ssl` is failing on the main branch.

This additional (currently failing) test suggests the certificates in the Kubernetes secret is not correctly encoded as base64:
```
_______________________ test_spawner_internal_ssl_secret _______________________
ssl_app = <jupyterhub.app.JupyterHub object at 0x7f7b728bbb10>
config = {'KubeSpawner': {'namespace': 'kubespawner-test', 'cmd': ['jupyterhub-singleuser'], 'start_timeout': 180, 'environment': {'JUPYTERHUB_API_TOKEN': 'test-secret-token', 'JUPYTERHUB_CLIENT_ID': 'ignored'}}}
    async def test_spawner_internal_ssl_secret(
        ssl_app,
        config,
    ):
        spawner = KubeSpawner(
            config=config,
            user=MockUser(name="ssl"),
            internal_ssl=True,
            internal_trust_bundles=ssl_app.internal_trust_bundles,
            internal_certs_location=ssl_app.internal_certs_location,
            _mock=True,
        )
        # initialize ssl config
        hub_paths = await spawner.create_certs()
    
        spawner.cert_paths = await spawner.move_certs(hub_paths)
    
        # Validate that certificates were correctly encoded as base64
        manifest = spawner.get_secret_manifest(None)
        for _, secret in manifest.data.items():
>           base64.b64decode(secret, validate=True)
/home/runner/work/kubespawner/kubespawner/tests/test_spawner.py:389: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
s = b'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKekNDQWcrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFSTVE4d0RRWURWUVFEREFa...VrNkF0K2ZjTzRSa3lmYVl5VzhzRmpHbGhrSjZOelB0bmdGRWZLK0R0YkxkalR4YzkvOElxCmhCSWVidmc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K'
altchars = None, validate = True
    def b64decode(s, altchars=None, validate=False):
        """Decode the Base64 encoded bytes-like object or ASCII string s.
    
        Optional altchars must be a bytes-like object or ASCII string of length 2
        which specifies the alternative alphabet used instead of the '+' and '/'
        characters.
    
        The result is returned as a bytes object.  A binascii.Error is raised if
        s is incorrectly padded.
    
        If validate is False (the default), characters that are neither in the
        normal base-64 alphabet nor the alternative alphabet are discarded prior
        to the padding check.  If validate is True, these non-alphabet characters
        in the input result in a binascii.Error.
        For more information about the strict base64 check, see:
    
        https://docs.python.org/3.11/library/binascii.html#binascii.a2b_base64
        """
        s = _bytes_from_decode_data(s)
        if altchars is not None:
            altchars = _bytes_from_decode_data(altchars)
            assert len(altchars) == 2, repr(altchars)
            s = s.translate(bytes.maketrans(altchars, b'+/'))
>       return binascii.a2b_base64(s, strict_mode=validate)
E       binascii.Error: Excess data after padding
/opt/hostedtoolcache/Python/3.11.8/x64/lib/python3.11/base64.py:88: Error
```

This seems to be caused by the base64 encoded `notebooks-ca_trust.crt` containing a `==` in the middle, followed by more encoded data. `==` should only appear as padding at the end.

