### PR TITLE
specify wheel build target for hatch explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ artifacts = [
 # include is required since the project name doesn't match the folder name
 include = ["kubespawner"]
 
+[tool.hatch.build.targets.wheel]
+# packages is required when building wheels since the project name doesn't match
+# the folder name.
+packages = ["kubespawner"]
+
 # black is used for autoformatting Python code
 #
 # ref: https://black.readthedocs.io/en/stable/


### PR DESCRIPTION
I'm submitting a fix for building wheels for this package. 

I'm getting this error when building wheels for my multistage docker build:

```
ValueError: Unable to determine which files to ship inside the wheel using the following heuristics: https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection

The most likely cause of this is that there is no directory that matches the name of your project (jupyterhub_kubespawner).

At least one file selection option must be defined in the `tool.hatch.build.targets.wheel` table, see: https://hatch.pypa.io/latest/config/build/

As an example, if you intend to ship a directory named `foo` that resides within a `src` directory located at the root of your project, you can define the following:

[tool.hatch.build.targets.wheel]
packages = ["src/foo"]
```