### PR TITLE
Add modern app.kubernetes.io labels alongside old

### DIFF
--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1986,9 +1986,7 @@ def test_make_ingress_for_ip(reuse_existing_services, target, ip):
     Test specification of the ingress objects
     """
     common_labels = {
-        'app': 'jupyterhub',
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     ingress_extra_labels = {
         'extra/label': 'value1',
@@ -2020,9 +2018,7 @@ def test_make_ingress_for_ip(reuse_existing_services, target, ip):
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2039,9 +2035,7 @@ def test_make_ingress_for_ip(reuse_existing_services, target, ip):
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2062,9 +2056,7 @@ def test_make_ingress_for_ip(reuse_existing_services, target, ip):
                 'extra/annotation': 'value2',
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
                 'extra/label': 'value1',
             },
@@ -2112,8 +2104,7 @@ def test_make_ingress_for_service_reuse_existing_services_enabled(target):
     leads to reusing the same service which was created by KubeSpawner
     """
     common_labels = {
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     endpoint, service, ingress = api_client.sanitize_for_serialization(
         make_ingress(
@@ -2139,8 +2130,7 @@ def test_make_ingress_for_service_reuse_existing_services_enabled(target):
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'component': 'singleuser-server',
-                'heritage': 'jupyterhub',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2201,8 +2191,7 @@ def test_make_ingress_for_service_reuse_existing_services_disabled(
     leads to creating service with type External name pointing to the pod's service
     """
     common_labels = {
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     endpoint, service, ingress = api_client.sanitize_for_serialization(
         make_ingress(
@@ -2227,8 +2216,7 @@ def test_make_ingress_for_service_reuse_existing_services_disabled(
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'component': 'singleuser-server',
-                'heritage': 'jupyterhub',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2250,8 +2238,7 @@ def test_make_ingress_for_service_reuse_existing_services_disabled(
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'component': 'singleuser-server',
-                'heritage': 'jupyterhub',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2315,9 +2302,7 @@ def test_make_ingress_for_service_reuse_existing_services_ignored(
     or `KubeSpawner.enable_user_namespaces=True`
     """
     common_labels = {
-        'app': 'jupyterhub',
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     endpoint, service, ingress = api_client.sanitize_for_serialization(
         make_ingress(
@@ -2342,9 +2327,7 @@ def test_make_ingress_for_service_reuse_existing_services_ignored(
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2366,9 +2349,7 @@ def test_make_ingress_for_service_reuse_existing_services_ignored(
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2412,9 +2393,7 @@ def test_make_ingress_with_subdomain_host(target):
     Test specification of the ingress objects
     """
     common_labels = {
-        'app': 'jupyterhub',
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     _endpoint, _service, ingress = api_client.sanitize_for_serialization(
         make_ingress(
@@ -2436,9 +2415,7 @@ def test_make_ingress_with_subdomain_host(target):
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2483,9 +2460,7 @@ def test_make_ingress_with_specifications(target, ip):
     Test specification of the ingress objects
     """
     common_labels = {
-        'app': 'jupyterhub',
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     ingress_specifications = [
         {
@@ -2517,9 +2492,7 @@ def test_make_ingress_with_specifications(target, ip):
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2536,9 +2509,7 @@ def test_make_ingress_with_specifications(target, ip):
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2558,9 +2529,7 @@ def test_make_ingress_with_specifications(target, ip):
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2621,9 +2590,7 @@ def test_make_ingress_external_name_with_specifications():
     Test specification of the ingress objects
     """
     common_labels = {
-        'app': 'jupyterhub',
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     ingress_specifications = [
         {
@@ -2657,9 +2624,7 @@ def test_make_ingress_external_name_with_specifications():
                 'hub.jupyter.org/proxy-target': 'http://my-pod-name:9000',
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2680,9 +2645,7 @@ def test_make_ingress_external_name_with_specifications():
                 'hub.jupyter.org/proxy-target': 'http://my-pod-name:9000',
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2762,9 +2725,7 @@ def test_make_ingress_with_specifications_and_matching_subdomain_host(target, ho
     Test specification of the ingress objects
     """
     common_labels = {
-        'app': 'jupyterhub',
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     ingress_specifications = [
         {
@@ -2794,9 +2755,7 @@ def test_make_ingress_with_specifications_and_matching_subdomain_host(target, ho
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2861,9 +2820,7 @@ def test_make_ingress_with_specifications_and_not_matching_subdomain_host(target
     Test specification of the ingress objects
     """
     common_labels = {
-        'app': 'jupyterhub',
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'common/label': 'value0',
     }
     ingress_specifications = [
         {
@@ -2893,9 +2850,7 @@ def test_make_ingress_with_specifications_and_not_matching_subdomain_host(target
                 'hub.jupyter.org/proxy-target': target,
             },
             'labels': {
-                'app': 'jupyterhub',
-                'heritage': 'jupyterhub',
-                'component': 'singleuser-server',
+                'common/label': 'value0',
                 'hub.jupyter.org/proxy-route': 'true',
             },
             'name': 'jupyter-test',
@@ -2954,8 +2909,7 @@ def test_make_ingress_with_specifications_and_not_matching_subdomain_host(target
 
 def test_make_namespace():
     labels = {
-        'heritage': 'jupyterhub',
-        'component': 'singleuser-server',
+        'some/label': 'value0',
     }
     namespace = api_client.sanitize_for_serialization(
         make_namespace(name='test-namespace', labels=labels)
@@ -2964,8 +2918,7 @@ def test_make_namespace():
         'metadata': {
             'annotations': {},
             'labels': {
-                'component': 'singleuser-server',
-                'heritage': 'jupyterhub',
+                'some/label': 'value0',
             },
             'name': 'test-namespace',
         },

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -332,7 +332,7 @@ async def test_spawn_start_enable_user_namespaces(
     assert isinstance(status, int)
 
 
-async def test_spawn_component_label(
+async def test_spawn_component_label_and_other_labels(
     kube_ns,
     kube_client,
     config,
@@ -360,7 +360,15 @@ async def test_spawn_component_label(
 
     # component label is same as expected
     pod = pods[0]
+    assert pod.metadata.labels["app.kubernetes.io/component"] == "something"
     assert pod.metadata.labels["component"] == "something"
+
+    # other labels are the same as expected
+    assert pod.metadata.labels["app.kubernetes.io/name"] == "jupyterhub"
+    assert pod.metadata.labels["app.kubernetes.io/managed-by"] == "kubespawner"
+    assert pod.metadata.labels["heritage"] == "jupyterhub"
+    assert pod.metadata.labels["app"] == "jupyterhub"
+    assert pod.metadata.labels["heritage"] == "jupyterhub"
 
     # stop the pod
     await spawner.stop()
@@ -510,6 +518,7 @@ async def test_spawn_services_enabled(
     # verify selector contains component_label, common_labels and extra_labels
     # as well as user and server name
     selector = services[0].spec.selector
+    assert selector["app.kubernetes.io/component"] == "something"
     assert selector["component"] == "something"
     assert selector["some/label"] == "value1"
     assert selector["extra/label"] == "value2"
@@ -1513,9 +1522,12 @@ async def test_get_pvc_manifest():
     assert manifest.metadata.labels == {
         "user": "mock-5fname",
         "hub.jupyter.org/username": "mock-5fname",
+        "app.kubernetes.io/name": "jupyterhub",
+        "app.kubernetes.io/managed-by": "kubespawner",
+        "app.kubernetes.io/component": "singleuser-server",
         "app": "jupyterhub",
-        "component": "singleuser-storage",
         "heritage": "jupyterhub",
+        "component": "singleuser-storage",
     }
     assert manifest.metadata.annotations == {
         "user": "mock-5fname",


### PR DESCRIPTION
This is related to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3404, where I'd long term like to enable us to transition to using modern k8s labelling scheme, where labels outlined in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1867 are used instead of labels used in legacy helm charts.

This change is made to be entirely non-breaking.