### PR TITLE
Improve exception handling for listing Kubernetes resources

### DIFF
--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -5,7 +5,7 @@ import json
 import time
 from functools import partial
 
-from kubernetes_asyncio import watch, client
+from kubernetes_asyncio import client, watch
 from traitlets import Any, Bool, Dict, Int, Unicode
 from traitlets.config import LoggingConfigurable
 from urllib3.exceptions import ReadTimeoutError
@@ -231,12 +231,13 @@ class ResourceReflector(LoggingConfigurable):
 
         initial_resources_raw = await list_method(**kwargs)
         if not initial_resources_raw.ok:
-            self.log.error(f'Error when calling Kubernetes API.'
+            self.log.error(
+                f'Error when calling Kubernetes API.'
                 f' Status: {initial_resources_raw.status} {initial_resources_raw.reason}.'
-                f' Message: {(await initial_resources_raw.json())["message"]}')
+                f' Message: {(await initial_resources_raw.json())["message"]}'
+            )
             raise client.ApiException(
-                status=initial_resources_raw.status,
-                reason=initial_resources_raw.reason
+                status=initial_resources_raw.status, reason=initial_resources_raw.reason
             )
 
         # This is an atomic operation on the dictionary!

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -234,12 +234,14 @@ class ResourceReflector(LoggingConfigurable):
             if not initial_resources_raw.ok:
                 raise client.ApiException(
                     status=initial_resources_raw.status,
-                    reason=initial_resources_raw.reason
+                    reason=initial_resources_raw.reason,
                 )
         except client.ApiException:
-            self.log.exception(f'An error occurred when calling Kubernetes API.'
+            self.log.exception(
+                f'An error occurred when calling Kubernetes API.'
                 f' Status: {initial_resources_raw.status} {initial_resources_raw.reason}.'
-                f' Message: {(await initial_resources_raw.json())["message"]}')
+                f' Message: {(await initial_resources_raw.json())["message"]}'
+            )
             raise
 
         # This is an atomic operation on the dictionary!

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -5,7 +5,7 @@ import json
 import time
 from functools import partial
 
-from kubernetes_asyncio import watch
+from kubernetes_asyncio import watch, client
 from traitlets import Any, Bool, Dict, Int, Unicode
 from traitlets.config import LoggingConfigurable
 from urllib3.exceptions import ReadTimeoutError
@@ -228,7 +228,17 @@ class ResourceReflector(LoggingConfigurable):
             kwargs["namespace"] = self.namespace
 
         list_method = getattr(self.api, self.list_method_name)
+
         initial_resources_raw = await list_method(**kwargs)
+        if not initial_resources_raw.ok:
+            self.log.error(f'Error when calling Kubernetes API.'
+                f' Status: {initial_resources_raw.status} {initial_resources_raw.reason}.'
+                f' Message: {(await initial_resources_raw.json())["message"]}')
+            raise client.ApiException(
+                status=initial_resources_raw.status,
+                reason=initial_resources_raw.reason
+            )
+
         # This is an atomic operation on the dictionary!
         initial_resources = json.loads(await initial_resources_raw.read())
         self.resources = {


### PR DESCRIPTION
When the Kubernetes API fails to list Kubernetes resources in the reflector (for example too strict permissions), no relevant error message appears in the logs, and the program fails. I'm adding a check to see if the call is successful. If not, an error with the API is printed, and an exception is thrown.

This is what the previous logs look like (`enable_user_namespaces = True`):
```
[I 2024-05-02 13:20:03.726 JupyterHub spawner:188] Using user namespace: user-jhu
[E 2024-05-02 13:20:03.739 JupyterHub reflector:412] Initial list of pods failed
    Traceback (most recent call last):
      File "/opt/kubespawner/kubespawner/reflector.py", line 410, in start
        await self._list_and_update()
      File "/opt/kubespawner/kubespawner/reflector.py", line 249, in _list_and_update
        for p in initial_resources["items"]
    KeyError: 'items'
    
[E 2024-05-02 13:20:03.739 JupyterHub spawner:2411] Reflector with key ('pods', None) failed to start.
    Traceback (most recent call last):
      File "/opt/kubespawner/kubespawner/spawner.py", line 2409, in catch_reflector_start
        await func
      File "/opt/kubespawner/kubespawner/reflector.py", line 410, in start
        await self._list_and_update()
      File "/opt/kubespawner/kubespawner/reflector.py", line 249, in _list_and_update
        for p in initial_resources["items"]
    KeyError: 'items'
```

...and this now:
```
[I 2024-05-02 13:20:26.046 JupyterHub spawner:188] Using user namespace: user-jhu
[E 2024-05-02 13:20:26.059 JupyterHub reflector:237] Error when calling Kubernetes API. Status: 403 Forbidden. Message: pods is forbidden: User "system:serviceaccount:default:jupyterhub-spawner-sa" cannot list resource "pods" in API group "" in the namespace "user-jhu"
[E 2024-05-02 13:20:26.059 JupyterHub reflector:412] Initial list of pods failed
    Traceback (most recent call last):
      File "/opt/kubespawner/kubespawner/reflector.py", line 410, in start
        await self._list_and_update()
      File "/opt/kubespawner/kubespawner/reflector.py", line 240, in _list_and_update
        raise client.ApiException(
    kubernetes_asyncio.client.exceptions.ApiException: (403)
    Reason: Forbidden
    
    
[E 2024-05-02 13:20:26.059 JupyterHub spawner:2411] Reflector with key ('pods', None) failed to start.
    Traceback (most recent call last):
      File "/opt/kubespawner/kubespawner/spawner.py", line 2409, in catch_reflector_start
        await func
      File "/opt/kubespawner/kubespawner/reflector.py", line 410, in start
        await self._list_and_update()
      File "/opt/kubespawner/kubespawner/reflector.py", line 240, in _list_and_update
        raise client.ApiException(
    kubernetes_asyncio.client.exceptions.ApiException: (403)
    Reason: Forbidden
```