### PR TITLE
Fix typo in docs (missing `)

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -429,7 +429,7 @@ class KubeSpawner(Spawner):
           - a list of the command and arguments
           - `None` (default) to use the Docker image's `CMD`
 
-        If `cmd` is set, it will be augmented with `spawner.get_args(). This will override the `CMD` specified in the Docker image.
+        If `cmd` is set, it will be augmented with `spawner.get_args()`. This will override the `CMD` specified in the Docker image.
         """,
     )
 


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/ee3a241e-c278-442b-8e63-a21ce7eca2d7)
