### PR TITLE
use sync client in test_objects

### DIFF
--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -3,7 +3,7 @@ Test functions used to create k8s objects
 """
 
 import pytest
-from kubernetes_asyncio.client import ApiClient
+from kubernetes.client import ApiClient
 
 from kubespawner.objects import make_ingress, make_namespace, make_pod, make_pvc
 


### PR DESCRIPTION
async client cannot be instantiated outside asyncio loop

validation doesn't require async client

fixes tests that have started to fail with latest kubernetes_asyncio (see #744)