### PR TITLE
docs: add example on upgrading slug scheme for a volume mount and list more template fields

### DIFF
--- a/docs/source/templates.md
+++ b/docs/source/templates.md
@@ -16,10 +16,22 @@ so for example the default `pod_name_template` of `"jupyter-{user_server}"` will
 
 ## templated properties
 
-Some common templated fields:
+Templated fields include:
 
+- [extra_annotations](#KubeSpawner.extra_annotations)
+- [extra_containers](#KubeSpawner.extra_containers)
+- [extra_labels](#KubeSpawner.extra_labels)
+- [pod_connect_ip](#KubeSpawner.pod_connect_ip)
 - [pod_name_template](#KubeSpawner.pod_name_template)
 - [pvc_name_template](#KubeSpawner.pvc_name_template)
+- [storage_extra_annotations](#KubeSpawner.storage_extra_annotations)
+- [storage_extra_labels](#KubeSpawner.storage_extra_labels)
+- [storage_selector](#KubeSpawner.storage_selector)
+- [user_namespace_annotations](#KubeSpawner.user_namespace_annotations)
+- [user_namespace_labels](#KubeSpawner.user_namespace_labels)
+- [user_namespace_template](#KubeSpawner.user_namespace_template)
+- [volume_mounts](#KubeSpawner.volume_mounts)
+- [volumes](#KubeSpawner.volumes)
 - [working_dir](#KubeSpawner.working_dir)
 
 ## fields

--- a/docs/source/templates.md
+++ b/docs/source/templates.md
@@ -103,6 +103,21 @@ c.KubeSpawner.slug_scheme = "escape"  # no changes from kubespawner 6
 c.KubeSpawner.slug_scheme = "safe"  # default for kubespawner 7
 ```
 
+You can also adjust individual template fields to expand independent of
+configured slug scheme. If you for example previously have mounted a folder
+named `{username}` for a single NFS volume with all user's home folders, a
+change of slug scheme could lead to mounting a different folder. To avoid this,
+you can stick with the previous behavior for the volume mount specifically by
+referencing `{escaped_username}` instead.
+
+```python
+c.KubeSpawner.volume_mounts = {
+    "name": "home",
+    "mountPath": "/home/jovyan",
+    "subPath": "{escaped_username}",  # matches "{username}" in kubespawner 6
+}
+```
+
 The new scheme has the following rules:
 
 - the length of any _single_ template field is limited to 48 characters (the total length of the string is not enforced)


### PR DESCRIPTION
Extracted from a changelog PR as this offloads whats needed to be written there.