### PR TITLE
Reflectors watch: close after stop

### DIFF
--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -389,6 +389,7 @@ class ResourceReflector(LoggingConfigurable):
                 self.log.debug("%s watcher timeout", self.kind)
             finally:
                 w.stop()
+                await w.close()
                 if self._stopping:
                     self.log.info("%s watcher stopped: outer", self.kind)
                     break


### PR DESCRIPTION
I'm trying to track down the
```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fcfe6bbc690>
```
warning in https://github.com/lsc-sde/lsc-sde/issues/93#issuecomment-2399981874

I don't know if this is the cause, but based on the context manager code in
https://github.com/tomplus/kubernetes_asyncio/blob/v21.7.1/kubernetes_asyncio/watch/watch.py#L212-L216
we should call `close()` anyway.