### PR TITLE
await asyncio.ensure_future

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2802,7 +2802,7 @@ class KubeSpawner(Spawner):
 
         if previous_reflector:
             # we replaced the reflector, stop the old one
-            asyncio.ensure_future(previous_reflector.stop())
+            await asyncio.ensure_future(previous_reflector.stop())
 
         # wait for first load
         await current_reflector.first_load_future
@@ -3254,7 +3254,7 @@ class KubeSpawner(Spawner):
                     ref_key,
                 )
                 self.log.error("Pods: %s", sorted(self.pod_reflector.pods.keys()))
-                asyncio.ensure_future(self._start_watching_pods(replace=True))
+                await asyncio.ensure_future(self._start_watching_pods(replace=True))
             raise
 
         pod = self.pod_reflector.pods[ref_key]
@@ -3379,7 +3379,7 @@ class KubeSpawner(Spawner):
             self.log.error(
                 "Pod %s did not disappear, restarting pod reflector", ref_key
             )
-            asyncio.ensure_future(self._start_watching_pods(replace=True))
+            await asyncio.ensure_future(self._start_watching_pods(replace=True))
             raise
 
     @default('env_keep')


### PR DESCRIPTION
All other calls to `asyncio.ensure_future` were either awaited or in one case saved to a member variable, so I've awaited the remaining calls in spawner.py but I'm not sure how to thoroughly test this. I didn't notice any problems when testing this on a small local Z2JH deployment.
```
$ git grep -n -A2 ensure_future -- kubespawner/spawner.py

kubespawner/spawner.py:2805:            await asyncio.ensure_future(previous_reflector.stop())
kubespawner/spawner.py-2806-
kubespawner/spawner.py-2807-        # wait for first load
--
kubespawner/spawner.py:2867:        futures = [asyncio.ensure_future(task) for task in tasks]
kubespawner/spawner.py-2868-        try:
kubespawner/spawner.py-2869-            await asyncio.gather(*futures)
--
kubespawner/spawner.py:2886:        self._start_future = asyncio.ensure_future(self._start())
kubespawner/spawner.py-2887-        return self._start_future
kubespawner/spawner.py-2888-
--
kubespawner/spawner.py:3089:        start_futures = [asyncio.ensure_future(task) for task in start_tasks]
kubespawner/spawner.py-3090-        try:
kubespawner/spawner.py-3091-            await asyncio.gather(*start_futures)
--
kubespawner/spawner.py:3257:                await asyncio.ensure_future(self._start_watching_pods(replace=True))
kubespawner/spawner.py-3258-            raise
kubespawner/spawner.py-3259-
--
kubespawner/spawner.py:3382:            await asyncio.ensure_future(self._start_watching_pods(replace=True))
kubespawner/spawner.py-3383-            raise
kubespawner/spawner.py-3384-

```

Related to https://github.com/jupyterhub/kubespawner/issues/858