### PR TITLE
WIP: Try unpinning pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,7 @@ test = [
     "kubernetes>=11",
     "pytest>=5.4",
     "pytest-cov",
-    # FIXME: unpin pytest-asyncio
-    "pytest-asyncio>=0.17,<0.23",
+    "pytest-asyncio",
 ]
 
 [project.urls]


### PR DESCRIPTION
It's still broken. This is a reminder that we'll need to update KubeSpawner at some point to work with the latest pytest-asyncio.