### PR TITLE
CI: Cleanup namespaces in parallel

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,7 @@ async def _delete_namespace(client, namespace):
         else:
             print("waiting for %s to delete" % namespace)
             await asyncio.sleep(1)
+    raise Exception(f"Namespace {namespace} not deleted after 20 s")
 
 
 @pytest_asyncio.fixture(scope="session")


### PR DESCRIPTION
Currently if deletion of one namespace fails during cleanup the other namespace won't be deleted. Using asyncio.gather means we can delete in parallel but still receive the first Exception