### PR TITLE
Add changelog for 7.0.0

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,7 +6,7 @@
 
 ## 7.0
 
-### [7.0.0] - 2024-10-21
+### [7.0.0] - 2024-10-25
 
 ([full changelog](https://github.com/jupyterhub/kubespawner/compare/6.2.0...7.0.0))
 
@@ -30,6 +30,7 @@
 
 #### Bugs fixed
 
+- Reset cur_delay after listing resources [#869](https://github.com/jupyterhub/kubespawner/pull/869) ([@d-gol](https://github.com/d-gol), [@manics](https://github.com/manics))
 - await asyncio.ensure_future [#860](https://github.com/jupyterhub/kubespawner/pull/860) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - Reflectors watch: close after stop [#859](https://github.com/jupyterhub/kubespawner/pull/859) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - fix some safe slug patterns [#856](https://github.com/jupyterhub/kubespawner/pull/856) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
@@ -49,7 +50,10 @@
 #### Documentation improvements
 
 - Make changelog links consistent [#862](https://github.com/jupyterhub/kubespawner/pull/862) ([@consideRatio](https://github.com/consideRatio))
+- Add changelog for 7.0.0b3 [#861](https://github.com/jupyterhub/kubespawner/pull/861) ([@consideRatio](https://github.com/consideRatio))
+- changelog for 7.0.0b2 [#857](https://github.com/jupyterhub/kubespawner/pull/857) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
 - docs: add example on upgrading slug scheme for a volume mount and list more template fields [#854](https://github.com/jupyterhub/kubespawner/pull/854) ([@consideRatio](https://github.com/consideRatio))
+- Add changelog for 7.0.0b1 [#851](https://github.com/jupyterhub/kubespawner/pull/851) ([@consideRatio](https://github.com/consideRatio), [@minrk](https://github.com/minrk))
 - Fix typo in docs (missing `) [#844](https://github.com/jupyterhub/kubespawner/pull/844) ([@krassowski](https://github.com/krassowski), [@consideRatio](https://github.com/consideRatio))
 
 #### Contributors to this release
@@ -57,9 +61,9 @@
 The following people contributed discussions, new ideas, code and documentation contributions, and review.
 See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
 
-([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2023-11-23&to=2024-10-21&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2023-11-23&to=2024-10-25&type=c))
 
-@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2023-11-23..2024-10-21&type=Issues)) | @dolfinus ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Adolfinus+updated%3A2023-11-23..2024-10-21&type=Issues)) | @harsimranmaan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aharsimranmaan+updated%3A2023-11-23..2024-10-21&type=Issues)) | @jabbera ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajabbera+updated%3A2023-11-23..2024-10-21&type=Issues)) | @josefhandl ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajosefhandl+updated%3A2023-11-23..2024-10-21&type=Issues)) | @jwclark ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajwclark+updated%3A2023-11-23..2024-10-21&type=Issues)) | @krassowski ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Akrassowski+updated%3A2023-11-23..2024-10-21&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2023-11-23..2024-10-21&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2023-11-23..2024-10-21&type=Issues)) | @moschlar ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amoschlar+updated%3A2023-11-23..2024-10-21&type=Issues)) | @Ph0tonic ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3APh0tonic+updated%3A2023-11-23..2024-10-21&type=Issues)) | @sgaist ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Asgaist+updated%3A2023-11-23..2024-10-21&type=Issues)) | @shenghu ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ashenghu+updated%3A2023-11-23..2024-10-21&type=Issues)) | @sunu ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Asunu+updated%3A2023-11-23..2024-10-21&type=Issues)) | @willh-cmyk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Awillh-cmyk+updated%3A2023-11-23..2024-10-21&type=Issues)) | @yuvipanda ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ayuvipanda+updated%3A2023-11-23..2024-10-21&type=Issues))
+@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2023-11-23..2024-10-25&type=Issues)) | @d-gol ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ad-gol+updated%3A2023-11-23..2024-10-25&type=Issues)) | @dolfinus ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Adolfinus+updated%3A2023-11-23..2024-10-25&type=Issues)) | @harsimranmaan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aharsimranmaan+updated%3A2023-11-23..2024-10-25&type=Issues)) | @jabbera ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajabbera+updated%3A2023-11-23..2024-10-25&type=Issues)) | @josefhandl ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajosefhandl+updated%3A2023-11-23..2024-10-25&type=Issues)) | @jwclark ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajwclark+updated%3A2023-11-23..2024-10-25&type=Issues)) | @krassowski ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Akrassowski+updated%3A2023-11-23..2024-10-25&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2023-11-23..2024-10-25&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2023-11-23..2024-10-25&type=Issues)) | @moschlar ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amoschlar+updated%3A2023-11-23..2024-10-25&type=Issues)) | @Ph0tonic ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3APh0tonic+updated%3A2023-11-23..2024-10-25&type=Issues)) | @sgaist ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Asgaist+updated%3A2023-11-23..2024-10-25&type=Issues)) | @shenghu ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ashenghu+updated%3A2023-11-23..2024-10-25&type=Issues)) | @sunu ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Asunu+updated%3A2023-11-23..2024-10-25&type=Issues)) | @willh-cmyk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Awillh-cmyk+updated%3A2023-11-23..2024-10-25&type=Issues)) | @yuvipanda ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ayuvipanda+updated%3A2023-11-23..2024-10-25&type=Issues))
 
 ### [6.2.0] - 2023-11-23
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,44 +6,9 @@
 
 ## 7.0
 
-### [7.0.0b3] - 2024-10-11
+### [7.0.0] - 2024-10-21
 
-([full changelog](https://github.com/jupyterhub/kubespawner/compare/7.0.0b2...7.0.0b3))
-
-#### Bugs fixed
-
-- await asyncio.ensure_future [#860](https://github.com/jupyterhub/kubespawner/pull/860) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
-- Reflectors watch: close after stop [#859](https://github.com/jupyterhub/kubespawner/pull/859) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
-
-#### Contributors to this release
-
-The following people contributed discussions, new ideas, code and documentation contributions, and review.
-See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
-
-([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2024-10-02&to=2024-10-11&type=c))
-
-@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2024-10-02..2024-10-11&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2024-10-02..2024-10-11&type=Issues))
-
-### [7.0.0b2] - 2024-10-02
-
-([full changelog](https://github.com/jupyterhub/kubespawner/compare/7.0.0b1...7.0.0b2))
-
-#### Bugs fixed
-
-- fix some safe slug patterns [#856](https://github.com/jupyterhub/kubespawner/pull/856) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
-
-#### Contributors to this release
-
-The following people contributed discussions, new ideas, code and documentation contributions, and review.
-See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
-
-([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2024-09-23&to=2024-10-02&type=c))
-
-@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2024-09-23..2024-10-02&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2024-09-23..2024-10-02&type=Issues))
-
-### [7.0.0b1] - 2024-09-23
-
-([full changelog](https://github.com/jupyterhub/kubespawner/compare/6.2.0...7.0.0b1))
+([full changelog](https://github.com/jupyterhub/kubespawner/compare/6.2.0...7.0.0))
 
 #### Breaking changes
 
@@ -53,6 +18,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 
 #### New features added
 
+- Add escape_slug as a utility function alongside safe_slug [#865](https://github.com/jupyterhub/kubespawner/pull/865) ([@consideRatio](https://github.com/consideRatio), [@minrk](https://github.com/minrk))
 - Add KubeSpawner.version_info [#852](https://github.com/jupyterhub/kubespawner/pull/852) ([@consideRatio](https://github.com/consideRatio))
 - Add modern app.kubernetes.io labels alongside old [#835](https://github.com/jupyterhub/kubespawner/pull/835) ([@consideRatio](https://github.com/consideRatio), [@sgaist](https://github.com/sgaist), [@manics](https://github.com/manics), [@yuvipanda](https://github.com/yuvipanda), [@minrk](https://github.com/minrk))
 - add 'safe' slug scheme [#744](https://github.com/jupyterhub/kubespawner/pull/744) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio), [@Ph0tonic](https://github.com/Ph0tonic), [@yuvipanda](https://github.com/yuvipanda), [@manics](https://github.com/manics))
@@ -64,6 +30,9 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 
 #### Bugs fixed
 
+- await asyncio.ensure_future [#860](https://github.com/jupyterhub/kubespawner/pull/860) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
+- Reflectors watch: close after stop [#859](https://github.com/jupyterhub/kubespawner/pull/859) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
+- fix some safe slug patterns [#856](https://github.com/jupyterhub/kubespawner/pull/856) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
 - specify wheel build target for hatch explicitly [#832](https://github.com/jupyterhub/kubespawner/pull/832) ([@willh-cmyk](https://github.com/willh-cmyk), [@consideRatio](https://github.com/consideRatio))
 - Ensure Kubespawner internal SSL secret is correctly encoded as base64 [#828](https://github.com/jupyterhub/kubespawner/pull/828) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - Don't attempt to expand callable environment variables [#826](https://github.com/jupyterhub/kubespawner/pull/826) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
@@ -79,32 +48,18 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 
 #### Documentation improvements
 
+- Make changelog links consistent [#862](https://github.com/jupyterhub/kubespawner/pull/862) ([@consideRatio](https://github.com/consideRatio))
 - docs: add example on upgrading slug scheme for a volume mount and list more template fields [#854](https://github.com/jupyterhub/kubespawner/pull/854) ([@consideRatio](https://github.com/consideRatio))
 - Fix typo in docs (missing `) [#844](https://github.com/jupyterhub/kubespawner/pull/844) ([@krassowski](https://github.com/krassowski), [@consideRatio](https://github.com/consideRatio))
-
-#### Continuous integration improvements
-
-- build(deps): bump jupyterhub/action-k3s-helm from 3 to 4 [#822](https://github.com/jupyterhub/kubespawner/pull/822) ([@consideRatio](https://github.com/consideRatio))
-- build(deps): bump codecov/codecov-action from 3 to 4 [#821](https://github.com/jupyterhub/kubespawner/pull/821) ([@consideRatio](https://github.com/consideRatio))
-- build(deps): bump actions/setup-python from 4 to 5 [#814](https://github.com/jupyterhub/kubespawner/pull/814) ([@consideRatio](https://github.com/consideRatio))
-
-#### Other merged PRs
-
-- [pre-commit.ci] pre-commit autoupdate [#848](https://github.com/jupyterhub/kubespawner/pull/848) ([@consideRatio](https://github.com/consideRatio))
-- [pre-commit.ci] pre-commit autoupdate [#842](https://github.com/jupyterhub/kubespawner/pull/842) ([@yuvipanda](https://github.com/yuvipanda))
-- [pre-commit.ci] pre-commit autoupdate [#838](https://github.com/jupyterhub/kubespawner/pull/838) ([@consideRatio](https://github.com/consideRatio))
-- [pre-commit.ci] pre-commit autoupdate [#830](https://github.com/jupyterhub/kubespawner/pull/830) ([@consideRatio](https://github.com/consideRatio))
-- [pre-commit.ci] pre-commit autoupdate [#823](https://github.com/jupyterhub/kubespawner/pull/823) ([@consideRatio](https://github.com/consideRatio))
-- [pre-commit.ci] pre-commit autoupdate [#812](https://github.com/jupyterhub/kubespawner/pull/812) ([@consideRatio](https://github.com/consideRatio))
 
 #### Contributors to this release
 
 The following people contributed discussions, new ideas, code and documentation contributions, and review.
 See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
 
-([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2023-11-23&to=2024-09-23&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterhub/kubespawner/graphs/contributors?from=2023-11-23&to=2024-10-21&type=c))
 
-@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2023-11-23..2024-09-23&type=Issues)) | @dolfinus ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Adolfinus+updated%3A2023-11-23..2024-09-23&type=Issues)) | @harsimranmaan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aharsimranmaan+updated%3A2023-11-23..2024-09-23&type=Issues)) | @jabbera ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajabbera+updated%3A2023-11-23..2024-09-23&type=Issues)) | @josefhandl ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajosefhandl+updated%3A2023-11-23..2024-09-23&type=Issues)) | @jwclark ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajwclark+updated%3A2023-11-23..2024-09-23&type=Issues)) | @krassowski ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Akrassowski+updated%3A2023-11-23..2024-09-23&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2023-11-23..2024-09-23&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2023-11-23..2024-09-23&type=Issues)) | @moschlar ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amoschlar+updated%3A2023-11-23..2024-09-23&type=Issues)) | @Ph0tonic ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3APh0tonic+updated%3A2023-11-23..2024-09-23&type=Issues)) | @sgaist ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Asgaist+updated%3A2023-11-23..2024-09-23&type=Issues)) | @shenghu ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ashenghu+updated%3A2023-11-23..2024-09-23&type=Issues)) | @sunu ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Asunu+updated%3A2023-11-23..2024-09-23&type=Issues)) | @willh-cmyk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Awillh-cmyk+updated%3A2023-11-23..2024-09-23&type=Issues)) | @yuvipanda ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ayuvipanda+updated%3A2023-11-23..2024-09-23&type=Issues))
+@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3AconsideRatio+updated%3A2023-11-23..2024-10-21&type=Issues)) | @dolfinus ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Adolfinus+updated%3A2023-11-23..2024-10-21&type=Issues)) | @harsimranmaan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aharsimranmaan+updated%3A2023-11-23..2024-10-21&type=Issues)) | @jabbera ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajabbera+updated%3A2023-11-23..2024-10-21&type=Issues)) | @josefhandl ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajosefhandl+updated%3A2023-11-23..2024-10-21&type=Issues)) | @jwclark ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ajwclark+updated%3A2023-11-23..2024-10-21&type=Issues)) | @krassowski ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Akrassowski+updated%3A2023-11-23..2024-10-21&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amanics+updated%3A2023-11-23..2024-10-21&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Aminrk+updated%3A2023-11-23..2024-10-21&type=Issues)) | @moschlar ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Amoschlar+updated%3A2023-11-23..2024-10-21&type=Issues)) | @Ph0tonic ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3APh0tonic+updated%3A2023-11-23..2024-10-21&type=Issues)) | @sgaist ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Asgaist+updated%3A2023-11-23..2024-10-21&type=Issues)) | @shenghu ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ashenghu+updated%3A2023-11-23..2024-10-21&type=Issues)) | @sunu ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Asunu+updated%3A2023-11-23..2024-10-21&type=Issues)) | @willh-cmyk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Awillh-cmyk+updated%3A2023-11-23..2024-10-21&type=Issues)) | @yuvipanda ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fkubespawner+involves%3Ayuvipanda+updated%3A2023-11-23..2024-10-21&type=Issues))
 
 ### [6.2.0] - 2023-11-23
 
@@ -965,10 +920,8 @@ Change highlights:
 - Update Kubernetes Python client to 6.0 (supporting Kubernetes 1.10 APIs)
 - Numerous bugfixes
 
-[unreleased]: https://github.com/jupyterhub/kubespawner/compare/7.0.0b3...HEAD
-[7.0.0b3]: https://github.com/jupyterhub/kubespawner/compare/7.0.0b2...7.0.0b3
-[7.0.0b2]: https://github.com/jupyterhub/kubespawner/compare/7.0.0b1...7.0.0b2
-[7.0.0b1]: https://github.com/jupyterhub/kubespawner/compare/6.2.0...7.0.0b1
+[unreleased]: https://github.com/jupyterhub/kubespawner/compare/7.0.0...HEAD
+[7.0.0]: https://github.com/jupyterhub/kubespawner/compare/6.2.0...7.0.0
 [6.2.0]: https://github.com/jupyterhub/kubespawner/compare/6.1.0...6.2.0
 [6.1.0]: https://github.com/jupyterhub/kubespawner/compare/6.0.0...6.1.0
 [6.0.0]: https://github.com/jupyterhub/kubespawner/compare/5.0.0...6.0.0


### PR DESCRIPTION
I'm trying to tie up things for z2jh 4, but I'm not sure if kubespawner is ready yet. Should kubespawner 7 include upgrade docs on things that z2jh references with regards to the new default slug scheme?

@manics @minrk overall I feel my momentum run low with z2jh 4 release efforts, but I think what remains is upgrade related docs and possibly https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3548

- closes #850 