### PR TITLE
Reset cur_delay after listing resources

### DIFF
--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -306,6 +306,7 @@ class ResourceReflector(LoggingConfigurable):
             w = watch.Watch()
             try:
                 resource_version = await self._list_and_update(resource_version)
+                cur_delay = 0.1
                 watch_args = {
                     "label_selector": self.label_selector,
                     "field_selector": self.field_selector,


### PR DESCRIPTION
Reset `cur_delay` when resources are listed, so that it doesn't keep increasing if there are no events.
Detailed info: https://github.com/jupyterhub/kubespawner/issues/868

Edit: fixes #868