### PR TITLE
Fix traitlets warning

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1697,7 +1697,6 @@ class KubeSpawner(Spawner):
     )
 
     additional_profile_form_template_paths = List(
-        default=[],
         help="""
         Additional paths to search for jinja2 templates when rendering profile_form.
 


### PR DESCRIPTION
The `additional_profile_form_template_paths` List traitlet is incorrectly specifying a default value as `default=[]`. Traitlets now uses `default_value` as the kwarg instead of `default`. It could be changed to that, but the default is an empty list anyway.

The warning can be seen at the end of `pytest` runs, including in GHA, [see for example](https://github.com/jupyterhub/kubespawner/actions/runs/11699861402/job/32582672078#step:6:223)

```
=============================== warnings summary ===============================
../../../../../opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/traitlets/traitlets.py:3615
  /opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/traitlets/traitlets.py:3615: DeprecationWarning: metadata {'default': []} was set from the constructor. With traitlets 4.1, metadata should be set using the .tag() method, e.g., Int().tag(key1='value1', key2='value2')
    super().__init__(trait=trait, default_value=default_value, **kwargs)
```