### PR TITLE
Delete named PVCs if they contain `{user_server}`

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3807,7 +3807,7 @@ class KubeSpawner(Spawner):
             self.log.info(f"Not deleting pvc for {log_name}: {self.pvc_name}")
             return
 
-        if self.name and '{servername}' not in self.pvc_name_template:
+        if self.name and '{user_server}' not in self.pvc_name_template:
             # named server has the same PVC as the default server
             # don't delete the default server's PVC!
             self.log.info(


### PR DESCRIPTION
`pod_name_template` was updated in 7.0.0, but the logic to detect whether a named server PVC is safe to delete wasn't.