### PR TITLE
Unconditionally put servername in annotations

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2245,6 +2245,7 @@ class KubeSpawner(Spawner):
         # Annotations don't need to be escaped
         annotations = {
             'hub.jupyter.org/username': self.user.name,
+            'hub.jupyter.org/servername': self.name,
             "hub.jupyter.org/kubespawner-version": __version__,
             "hub.jupyter.org/jupyterhub-version": jupyterhub.__version__,
         }
@@ -2377,8 +2378,6 @@ class KubeSpawner(Spawner):
         annotations = self._build_common_annotations(
             self._expand_all(self.extra_annotations)
         )
-        # Unconditionally put servername on the pods
-        annotations['hub.jupyter.org/servername'] = self.name
 
         return make_pod(
             name=self.pod_name,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2243,11 +2243,12 @@ class KubeSpawner(Spawner):
 
     def _build_common_annotations(self, extra_annotations):
         # Annotations don't need to be escaped
-        annotations = {'hub.jupyter.org/username': self.user.name}
-        if self.name:
-            annotations['hub.jupyter.org/servername'] = self.name
-        annotations["hub.jupyter.org/kubespawner-version"] = __version__
-        annotations["hub.jupyter.org/jupyterhub-version"] = jupyterhub.__version__
+        annotations = {
+            'hub.jupyter.org/username': self.user.name,
+            'hub.jupyter.org/servername': self.name,
+            "hub.jupyter.org/kubespawner-version": __version__,
+            "hub.jupyter.org/jupyterhub-version": jupyterhub.__version__
+        }
 
         annotations.update(extra_annotations)
         return annotations

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2246,7 +2246,7 @@ class KubeSpawner(Spawner):
         annotations = {
             'hub.jupyter.org/username': self.user.name,
             "hub.jupyter.org/kubespawner-version": __version__,
-            "hub.jupyter.org/jupyterhub-version": jupyterhub.__version__
+            "hub.jupyter.org/jupyterhub-version": jupyterhub.__version__,
         }
 
         annotations.update(extra_annotations)

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2245,7 +2245,6 @@ class KubeSpawner(Spawner):
         # Annotations don't need to be escaped
         annotations = {
             'hub.jupyter.org/username': self.user.name,
-            'hub.jupyter.org/servername': self.name,
             "hub.jupyter.org/kubespawner-version": __version__,
             "hub.jupyter.org/jupyterhub-version": jupyterhub.__version__
         }
@@ -2378,6 +2377,8 @@ class KubeSpawner(Spawner):
         annotations = self._build_common_annotations(
             self._expand_all(self.extra_annotations)
         )
+        # Unconditionally put servername on the pods
+        annotations['hub.jupyter.org/servername'] = self.name
 
         return make_pod(
             name=self.pod_name,

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1680,6 +1680,7 @@ async def test_get_pvc_manifest():
     assert manifest.metadata.labels == {
         "user": slug,
         "hub.jupyter.org/username": slug,
+        "hub.jupyter.org/servername": "",
         "app.kubernetes.io/name": "jupyterhub",
         "app.kubernetes.io/managed-by": "kubespawner",
         "app.kubernetes.io/component": "singleuser-server",


### PR DESCRIPTION
- Matches behavior of what we do with servername in labels
- Labels are escaped while annotations are not, making annotations suitable for filtering in metrics and dashboards