### PR TITLE
Add KubeSpawner.add_custom_event

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -309,6 +309,14 @@ class KubeSpawner(Spawner):
         """,
     )
 
+    custom_event_queue = List(
+        [],
+        config=False,
+        help="""
+        Queue of custom events to be reported to the user on the spawn page.
+        """,
+    )
+
     enable_user_namespaces = Bool(
         False,
         config=True,
@@ -2558,6 +2566,28 @@ class KubeSpawner(Spawner):
         )
         # reset namespace as well?
 
+    def add_custom_event(
+        self, eventTime, lastTimestamp, message, type, involvedObject, metadata
+    ):
+        """Add an event to the event queue
+
+        This is used to add custom events that are not part of the normal
+        kubernetes event stream.
+        """
+        if not self.events_enabled:
+            return
+
+        event = {
+            "eventTime": eventTime,
+            "lastTimestamp": lastTimestamp,
+            "message": message,
+            "type": type,
+            "involvedObject": involvedObject,
+            "metadata": metadata,
+        }
+
+        self.custom_event_queue.append(event)
+
     async def poll(self):
         """
         Check if the pod is still running.
@@ -2651,6 +2681,12 @@ class KubeSpawner(Spawner):
                 events = []
             else:
                 events.append(event)
+
+        for event in self.custom_event_queue:
+            events.append(event)
+
+        self.custom_event_queue = []
+
         return events
 
     async def progress(self):

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -38,13 +38,7 @@ from traitlets import (
     List,
 )
 from traitlets import Type as TypeTrait
-from traitlets import (
-    Unicode,
-    Union,
-    default,
-    observe,
-    validate,
-)
+from traitlets import Unicode, Union, default, observe, validate
 
 from . import __version__
 from .clients import load_config, shared_client

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -12,9 +12,9 @@ import os
 import re
 import string
 import sys
-import uuid
 import textwrap
 import time
+import uuid
 import warnings
 from datetime import datetime, timezone
 from functools import partial

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -12,7 +12,9 @@ import os
 import re
 import string
 import sys
+import uuid
 import warnings
+from datetime import datetime, timezone
 from functools import partial
 from typing import Optional, Tuple, Type
 from urllib.parse import urlparse
@@ -2575,7 +2577,13 @@ class KubeSpawner(Spawner):
         # reset namespace as well?
 
     def add_custom_event(
-        self, eventTime, lastTimestamp, message, type, involvedObject, metadata
+        self,
+        message,
+        type="Normal",
+        eventTime=None,
+        lastTimestamp=None,
+        involvedObject=None,
+        metadata=None,
     ):
         """Add an event to the event queue
 
@@ -2584,6 +2592,15 @@ class KubeSpawner(Spawner):
         """
         if not self.events_enabled:
             return
+
+        if eventTime is None and lastTimestamp is None:
+            lastTimestamp = datetime.now(timezone.utc).isoformat()
+
+        if involvedObject is None:
+            involvedObject = {"name": self.pod_name}
+
+        if metadata is None:
+            metadata = {"uid": uuid.uuid4().hex}
 
         event = {
             "eventTime": eventTime,


### PR DESCRIPTION
Add: add_custom_event method, custom_event_queue trait, 
Update: events property to handle custom events

Adjust KubeSpawner class so you can easily include custom messages for the user during the spawning process, for instance like so (When using hooks inside of a jupyterhub config):
```
import time
from datetime import datetime, timezone

def modify_pod_hook(spawner, pod):
    spawner.add_custom_event(
        eventTime=str(datetime.now(timezone.utc)),
        lastTimestamp
        message="Test event. This is a test event inside of modify_pod_hook.",
        type="Custom",
        involvedObject: {"name": spawner.pod_name},
        metadata: {"uid": str(time.time())}
    )
    return pod

```

Closes #899 