### PR TITLE
Load port from named notebook-port containerPort

### DIFF
--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1798,7 +1798,7 @@ async def test_variable_expansion(ssl_app):
         "pod": await spawner.get_pod_manifest(),
         "pvc": spawner.get_pvc_manifest(),
         "secret": spawner.get_secret_manifest("dummy-owner-ref"),
-        "service": spawner.get_service_manifest("dummy-owner-ref"),
+        "service": spawner.get_service_manifest("dummy-owner-ref", 8888),
     }
 
     for resource_kind, manifest in manifests.items():
@@ -1859,7 +1859,7 @@ async def test_url_changed(kube_ns, kube_client, config, hub_pod, hub):
     await spawner.poll()
     ref_key = f"{spawner.namespace}/{spawner.pod_name}"
     pod = spawner.pod_reflector.pods.get(ref_key, None)
-    assert pod["metadata"]["annotations"]["hub.jupyter.org/port"] == "8888"
+    assert spawner._get_pod_port(pod) == 8888
     url = spawner._get_pod_url(pod)
     assert url == pod_host
     # didn't commit to the db

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1932,8 +1932,15 @@ async def test_ipv6_addr():
     url = spawner._get_pod_url(
         {
             "metadata": {
-                "annotations": {},
                 "name": "jupyter-test",
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "notebook",
+                        "ports": [{"name": "notebook-port", "containerPort": 8888}],
+                    }
+                ]
             },
             "status": {"podIP": "cafe:f00d::"},
         }


### PR DESCRIPTION
avoids changes to self.port (e.g. dynamic or changed config) being interpreted as a changed URL for a running pod

closes #893 

closes #827