### PR TITLE
pre-select saved user options on the spawn form

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3487,7 +3487,9 @@ class KubeSpawner(Spawner):
             profile_form_template = env.from_string(self.profile_form_template)
         else:
             profile_form_template = env.get_template("form.html")
-        return profile_form_template.render(profile_list=profile_list)
+        return profile_form_template.render(
+            profile_list=profile_list, user_options=self.user_options or {}
+        )
 
     async def _render_options_form_dynamically(self, current_spawner):
         """

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3511,6 +3511,20 @@ class KubeSpawner(Spawner):
         """
         profile_list = self._get_initialized_profile_list(profile_list)
 
+        # user_options may be stale (e.g. profile_list changed since the last spawn)
+        # or set unvalidated via the REST API, so validate them first and fall back
+        # to defaults if invalid.
+        user_options = self.user_options or {}
+        if user_options:
+            try:
+                self._validate_user_options(profile_list)
+            except ValueError as e:
+                self.log.warning(
+                    f"Not pre-selecting saved user_options on the spawn form "
+                    f"because they failed validation: {e}"
+                )
+                user_options = {}
+
         loader = ChoiceLoader(
             [
                 FileSystemLoader(self.additional_profile_form_template_paths),
@@ -3536,7 +3550,7 @@ class KubeSpawner(Spawner):
         else:
             profile_form_template = env.get_template("form.html")
         return profile_form_template.render(
-            profile_list=profile_list, user_options=self.user_options or {}
+            profile_list=profile_list, user_options=self.user_options
         )
 
     async def _render_options_form_dynamically(self, current_spawner):

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -9,7 +9,9 @@
                name="profile"
                id="profile-item-{{ profile.slug }}"
                value="{{ profile.slug }}"
-               {% if profile.default %}checked{% endif %} />
+               {% if user_options.profile == profile.slug %}checked
+               {% elif not user_options.profile and profile.default %}checked
+               {% endif %} />
       </div>
       <div>
         <h3>{{ profile.display_name }}</h3>
@@ -53,6 +55,7 @@
   {%- endfor %}
 </div>
 <script>
+  const userOptions = {{ user_options|tojson }};
   $('.js-profile-option-select, .js-profile-option-label').click(function() {
     // we need this bit of JS to select the profile when a <select> inside is clicked.
     $(this).parents('.js-profile-label')
@@ -89,6 +92,22 @@
   // wrapping in a document.ready to make clear this is executed once
   // on page load
   $(document).ready(() => {
+    // Pre-select options from previously saved user_options
+    const savedProfile = userOptions && userOptions.profile;
+    if (savedProfile) {
+      $(`label[for="profile-item-${savedProfile}"] .js-profile-option-select`).each(function() {
+        // name format: profile-option-{slug}--{optionKey}
+        const optionKey = $(this).attr('name').split('--').pop();
+        const unlistedValue = userOptions[optionKey + '--unlisted-choice'];
+        const savedValue = userOptions[optionKey];
+        if (unlistedValue) {
+          $(this).val('unlisted-choice');
+          $(this).parents('.js-options-container').find('.js-other-input').val(unlistedValue);
+        } else if (savedValue) {
+          $(this).val(savedValue);
+        }
+      });
+    }
     // trigger the `change` event on the select inputs,
     // so that if "Other" is selected on page load, the corresponding
     // free-text input shows

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -22,6 +22,7 @@
                   <label for="profile-option-{{ profile.slug }}--{{ k }}"
                          class="js-profile-option-label">{{ option.display_name }}</label>
                   <select name="profile-option-{{ profile.slug }}--{{ k }}"
+                          id="profile-option-{{ profile.slug }}--{{ k }}"
                           class="form-control js-profile-option-select">
                     {%- for k, choice in option['choices'].items() %}
                       <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
@@ -37,6 +38,7 @@
                       {{ option['unlisted_choice']['display_name'] }}
                     </label>
                     <input data-name="profile-option-{{ profile.slug }}--{{ k }}--unlisted-choice"
+                           id="profile-option-{{ profile.slug }}--{{ k }}--unlisted-choice"
                            {%- if option['unlisted_choice']['validation_regex'] %}
                            pattern="{{ option['unlisted_choice']['validation_regex'] }}"
                            {%- endif %}

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -9,9 +9,7 @@
                name="profile"
                id="profile-item-{{ profile.slug }}"
                value="{{ profile.slug }}"
-               {% if user_options.profile == profile.slug %}checked
-               {% elif not user_options.profile and profile.default %}checked
-               {% endif %} />
+               {% if user_options.profile == profile.slug %}checked {% elif not user_options.profile and profile.default %}checked {% endif %} />
       </div>
       <div>
         <h3>{{ profile.display_name }}</h3>


### PR DESCRIPTION
Preselects user options like profile, image etc if available. This should make sure that the saved options are pre-selected when starting a previously saved named server.

Fixes https://github.com/jupyterhub/kubespawner/issues/917. And would be useful to fix the same downstream issue(https://github.com/2i2c-org/jupyterhub-fancy-profiles/issues/42) in jupyterhub-fancy-profiles