### PR TITLE
Allow profile_list to be assigned a dictionary

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3573,7 +3573,9 @@ class KubeSpawner(Spawner):
             return self._render_options_form_dynamically
         else:
             # Return the rendered string, as it does not change
-            return self._render_options_form(self._sorted_dict_values(self.profile_list))
+            return self._render_options_form(
+                self._sorted_dict_values(self.profile_list)
+            )
 
     @default('options_from_form')
     def _options_from_form_default(self):

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1736,24 +1736,30 @@ class KubeSpawner(Spawner):
     )
 
     profile_list = Union(
-        trait_types=[List(trait=Dict()), Callable()],
+        trait_types=[List(trait=Dict()), Callable(), Dict()],
         config=True,
         help="""
-        List of profiles to offer for selection by the user.
+        Callable, List or Dict of profiles to offer for selection by the user.
 
-        Signature is: `List(Dict())`, where each item is a dictionary that has two keys:
+        - If a list, then each item is a dictionary.
+        - If it's a dictionary, then its keys are "slugs" - machine
+        readable strings that identify a profile. The values are dictionaries.
+
+        In both cases, the inner, dictionaries representing the profiles,
+        have the following keys:
 
         - `display_name`: the human readable display name (should be HTML safe)
         - `default`: (Optional Bool) True if this is the default selected option
         - `description`: Optional description of this profile displayed to the user.
         - `slug`: (Optional) the machine readable string to identify the
-          profile (missing slugs are generated from display_name)
+          profile (missing slugs are generated from display_name, and might not match the
+          outer "slug" key, in case profile_list is a dict. This is ok.)
         - `kubespawner_override`: a dictionary with overrides to apply to the KubeSpawner
           settings. Each value can be either the final value to change or a callable that
           take the `KubeSpawner` instance as parameter and return the final value. This can
           be further overridden by 'profile_options'
-          If the traitlet being overriden is a *dictionary*, the dictionary
-          will be *recursively updated*, rather than overriden. If you want to
+          If the traitlet being overridden is a *dictionary*, the dictionary
+          will be *recursively updated*, rather than overridden. If you want to
           remove a key, set its value to `None`
         - `profile_options`: A dictionary of sub-options that allow users to further customize the
           selected profile. By default, these are rendered as a dropdown with the label
@@ -1801,8 +1807,8 @@ class KubeSpawner(Spawner):
               and value can be either the final value or a callable that returns the final
               value when called with the spawner instance as the only parameter. The callable
               may be async.
-              If the traitlet being overriden is a *dictionary*, the dictionary
-              will be *recursively updated*, rather than overriden. If you want to
+              If the traitlet being overridden is a *dictionary*, the dictionary
+              will be *recursively updated*, rather than overridden. If you want to
               remove a key, set its value to `None`
 
         kubespawner setting overrides work in the following manner, with items further in the
@@ -1814,7 +1820,7 @@ class KubeSpawner(Spawner):
            profile, applied linearly based on the ordering of the option in the profile
            definition configuration
 
-        Example::
+        List example::
 
             c.KubeSpawner.profile_list = [
                 {
@@ -1862,6 +1868,48 @@ class KubeSpawner(Spawner):
                     },
                 },
             ]
+        Dict example::
+
+            c.KubeSpawner.profile_list = {
+                "demo-1": {
+                    'display_name': 'Demo - profile_list entry 1',
+                    'description': 'Demo description for profile_list entry 1, and it should look good even though it is a bit lengthy.',
+                    'slug': 'demo-1',
+                    'default': True,
+                    'profile_options': {
+                        'image': {
+                            'display_name': 'Image',
+                            'choices': {
+                                'base': {
+                                    'display_name': 'jupyter/base-notebook:latest',
+                                    'kubespawner_override': {
+                                        'image': 'jupyter/base-notebook:latest'
+                                    },
+                                },
+                            },
+                            'unlisted_choice': {
+                                'enabled': True,
+                                'display_name': 'Other image',
+                                'display_name_in_choices': 'Enter image manually',
+                                'validation_regex': '^jupyter/.+:.+$',
+                                'validation_message': 'Must be an image matching ^jupyter/<name>:<tag>$',
+                                'kubespawner_override': {'image': '{value}'},
+                            },
+                        },
+                    },
+                    'kubespawner_override': {
+                        'default_url': '/lab',
+                    },
+                },
+                demo-2: {
+                    'display_name': 'Demo - profile_list entry 2',
+                    'slug': 'demo-2',
+                    'kubespawner_override': {
+                        'extra_resource_guarantees': {"nvidia.com/gpu": "1"},
+                    },
+                },
+            }
+
 
         Instead of a list of dictionaries, this could also be a callable that takes as one
         parameter the current spawner instance and returns a list of dictionaries. The
@@ -3525,7 +3573,7 @@ class KubeSpawner(Spawner):
             return self._render_options_form_dynamically
         else:
             # Return the rendered string, as it does not change
-            return self._render_options_form(self.profile_list)
+            return self._render_options_form(self._sorted_dict_values(self.profile_list))
 
     @default('options_from_form')
     def _options_from_form_default(self):
@@ -3818,9 +3866,10 @@ class KubeSpawner(Spawner):
         Override in subclasses to support other options.
         """
         # get an initialized profile list
-        profile_list = self.profile_list
+        profile_list = self._sorted_dict_values(self.profile_list)
         if callable(profile_list):
             profile_list = await maybe_future(profile_list(self))
+
         profile_list = self._get_initialized_profile_list(profile_list)
 
         # validate user_options against initialized profile_list

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1016,9 +1016,8 @@ async def test_init_containers_as_dict():
     assert init_containers[0].image == 'mock_image_1'
     assert init_containers[1].image == 'mock_image_2'
 
-
-_test_profiles = [
-    {
+_test_profiles_dict = {
+    'training-python': {
         'display_name': 'Training Env - Python',
         'slug': 'training-python',
         'default': True,
@@ -1029,7 +1028,7 @@ _test_profiles = [
             'environment': {'override': 'override-value'},
         },
     },
-    {
+    'training-datascience':{
         'display_name': 'Training Env - Datascience',
         'slug': 'training-datascience',
         'kubespawner_override': {
@@ -1038,7 +1037,7 @@ _test_profiles = [
             'mem_limit': 8 * 1024 * 1024 * 1024,
         },
     },
-    {
+    'training-r':{
         'display_name': 'Training Env - R',
         'slug': 'training-r',
         'kubespawner_override': {
@@ -1048,7 +1047,7 @@ _test_profiles = [
             'environment': {'override': 'override-value', "to-remove": None},
         },
     },
-    {
+    'test-choices': {
         'display_name': 'Test choices',
         'slug': 'test-choices',
         'profile_options': {
@@ -1077,7 +1076,7 @@ _test_profiles = [
             },
         },
     },
-    {
+    'no-regex': {
         'display_name': 'Test choices no regex',
         'slug': 'no-regex',
         'profile_options': {
@@ -1104,62 +1103,77 @@ _test_profiles = [
             },
         },
     },
-]
+}
 
+def get_idx_based_on_profile_list_type(prf, idx):
+    if type(prf) == dict:
+        return _test_profiles_list[idx]['slug']
+    return idx
 
-async def test_user_options_set_from_form():
+_test_profiles_list = list(_test_profiles_dict.values())
+
+@pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
+async def test_user_options_set_from_form(test_profiles):
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = _test_profiles
+    spawner.profile_list = test_profiles
     # render the form
     await spawner.get_options_form()
+
+    idx = get_idx_based_on_profile_list_type(test_profiles, 1)
+
     spawner.user_options = spawner.options_from_form(
-        {'profile': [_test_profiles[1]['slug']]}
+        {'profile': [test_profiles[idx]['slug']]}
     )
     assert spawner.user_options == {
-        'profile': _test_profiles[1]['slug'],
+        'profile': test_profiles[idx]['slug'],
     }
     # nothing should be loaded yet
     assert spawner.cpu_limit is None
     await spawner.load_user_options()
-    for key, value in _test_profiles[1]['kubespawner_override'].items():
+    for key, value in test_profiles[idx]['kubespawner_override'].items():
         assert getattr(spawner, key) == value
 
-
-async def test_user_options_set_from_form_choices():
+@pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
+async def test_user_options_set_from_form_choices(test_profiles):
     """
     Test that the `choices` field in profile_options is processed correctly -
     i.e. when a user sends a profile option choice, it is correctly processed
     in user_options and the value on the spawner correctly over-ridden by the user choice.
     """
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = _test_profiles
+    spawner.profile_list = test_profiles
     await spawner.get_options_form()
+
+    idx = get_idx_based_on_profile_list_type(test_profiles, 3)
     spawner.user_options = spawner.options_from_form(
         {
-            'profile': [_test_profiles[3]['slug']],
+            'profile': [test_profiles[idx]['slug']],
             'profile-option-test-choices--image': ['pytorch'],
         }
     )
     assert spawner.user_options == {
         'image': 'pytorch',
-        'profile': _test_profiles[3]['slug'],
+        'profile': test_profiles[idx]['slug'],
     }
     assert spawner.cpu_limit is None
     await spawner.load_user_options()
     assert getattr(spawner, 'image') == 'pangeo/pytorch-notebook:master'
 
-
-async def test_user_options_set_from_form_unlisted_choice():
+@pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
+async def test_user_options_set_from_form_unlisted_choice(test_profiles):
     """
     Test that when user sends an arbitrary text input in the `unlisted_choice` field,
     it is process correctly and the correct attribute over-ridden on the spawner.
     """
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = _test_profiles
+    spawner.profile_list = test_profiles
     await spawner.get_options_form()
+
+    idx = get_idx_based_on_profile_list_type(test_profiles, 3)
+
     spawner.user_options = spawner.options_from_form(
         {
-            'profile': [_test_profiles[3]['slug']],
+            'profile': [test_profiles[idx]['slug']],
             'profile-option-test-choices--image--unlisted-choice': [
                 'pangeo/test:latest'
             ],
@@ -1167,7 +1181,7 @@ async def test_user_options_set_from_form_unlisted_choice():
     )
     assert spawner.user_options == {
         'image--unlisted-choice': 'pangeo/test:latest',
-        'profile': _test_profiles[3]['slug'],
+        'profile': test_profiles[idx]['slug'],
     }
     assert spawner.cpu_limit is None
     await spawner.load_user_options()
@@ -1176,7 +1190,7 @@ async def test_user_options_set_from_form_unlisted_choice():
     # Test choosing an unlisted choice a second time
     spawner.user_options = spawner.options_from_form(
         {
-            'profile': [_test_profiles[3]['slug']],
+            'profile': [test_profiles[idx]['slug']],
             'profile-option-test-choices--image--unlisted-choice': [
                 'pangeo/test:1.2.3'
             ],
@@ -1184,24 +1198,28 @@ async def test_user_options_set_from_form_unlisted_choice():
     )
     assert spawner.user_options == {
         'image--unlisted-choice': 'pangeo/test:1.2.3',
-        'profile': _test_profiles[3]['slug'],
+        'profile': test_profiles[idx]['slug'],
     }
     assert spawner.cpu_limit is None
     await spawner.load_user_options()
     assert getattr(spawner, 'image') == 'pangeo/test:1.2.3'
 
 
-async def test_user_options_set_from_form_invalid_regex():
+@pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
+async def test_user_options_set_from_form_invalid_regex(test_profiles):
     """
     Test that if the user input for the `unlisted-choice` field does not match the regex
     specified in the `validation_match_regex` option for the `unlisted_choice`, a ValueError is raised.
     """
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = _test_profiles
+    spawner.profile_list = test_profiles
     await spawner.get_options_form()
+
+    idx = get_idx_based_on_profile_list_type(test_profiles, 3)
+
     spawner.user_options = spawner.options_from_form(
         {
-            'profile': [_test_profiles[3]['slug']],
+            'profile': [test_profiles[idx]['slug']],
             'profile-option-test-choices--image--unlisted-choice': [
                 'invalid/foo:latest'
             ],
@@ -1209,52 +1227,57 @@ async def test_user_options_set_from_form_invalid_regex():
     )
     assert spawner.user_options == {
         'image--unlisted-choice': 'invalid/foo:latest',
-        'profile': _test_profiles[3]['slug'],
+        'profile': test_profiles[idx]['slug'],
     }
     assert spawner.cpu_limit is None
 
     with pytest.raises(ValueError):
         await spawner.load_user_options()
 
-
-async def test_user_options_set_from_form_no_regex():
+@pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
+async def test_user_options_set_from_form_no_regex(test_profiles):
     """
     Test that if the `unlisted_choice` object in the profile_options does not contain
     a `validation_regex` key, no validation is done and the input is correctly processed - i.e. validation_regex is optional.
     """
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = _test_profiles
+    spawner.profile_list = test_profiles
     await spawner.get_options_form()
-    # print(_test_profiles[4])
+
+    idx = get_idx_based_on_profile_list_type(test_profiles, 4)
+
     spawner.user_options = spawner.options_from_form(
         {
-            'profile': [_test_profiles[4]['slug']],
+            'profile': [test_profiles[idx]['slug']],
             'profile-option-no-regex--image--unlisted-choice': ['invalid/foo:latest'],
         }
     )
     assert spawner.user_options == {
         'image--unlisted-choice': 'invalid/foo:latest',
-        'profile': _test_profiles[4]['slug'],
+        'profile': test_profiles[idx]['slug'],
     }
     assert spawner.cpu_limit is None
     await spawner.load_user_options()
     assert getattr(spawner, 'image') == 'invalid/foo:latest'
 
-
-async def test_kubespawner_override():
+@pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
+async def test_kubespawner_override(test_profiles):
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = _test_profiles
+    spawner.profile_list = test_profiles
     # Set a base environment
     # to-remove will be removed because we set its value to None
     # in the override
     spawner.environment = {"existing": "existing-value", "to-remove": "does-it-matter"}
     # render the form, select first option
     await spawner.get_options_form()
+
+    idx = get_idx_based_on_profile_list_type(test_profiles, 2)
+
     spawner.user_options = spawner.options_from_form(
-        {'profile': [_test_profiles[2]['slug']]}
+        {'profile':  test_profiles[idx]['slug']}
     )
     assert spawner.user_options == {
-        'profile': _test_profiles[2]['slug'],
+        'profile': test_profiles[idx]['slug'],
     }
     await spawner.load_user_options()
     assert spawner.environment == {
@@ -1262,28 +1285,32 @@ async def test_kubespawner_override():
         "override": "override-value",
     }
 
-
-async def test_user_options_api():
+@pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
+async def test_user_options_api(test_profiles):
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = _test_profiles
+    spawner.profile_list = test_profiles
+
+    idx = get_idx_based_on_profile_list_type(test_profiles, 1)
     # set user_options directly (e.g. via api)
-    spawner.user_options = {'profile': _test_profiles[1]['slug']}
+    spawner.user_options = {'profile': test_profiles[idx]['slug']}
 
     # nothing should be loaded yet
     assert spawner.cpu_limit is None
     await spawner.load_user_options()
-    for key, value in _test_profiles[1]['kubespawner_override'].items():
+    for key, value in test_profiles[idx]['kubespawner_override'].items():
         assert getattr(spawner, key) == value
 
-
-async def test_default_profile():
+@pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
+async def test_default_profile(test_profiles):
     spawner = KubeSpawner(_mock=True)
-    spawner.profile_list = _test_profiles
+    spawner.profile_list = test_profiles
     spawner.user_options = {}
+    idx = get_idx_based_on_profile_list_type(test_profiles, 1)
+
     # nothing should be loaded yet
     assert spawner.cpu_limit is None
     await spawner.load_user_options()
-    for key, value in _test_profiles[0]['kubespawner_override'].items():
+    for key, value in test_profiles[idx]['kubespawner_override'].items():
         assert getattr(spawner, key) == value
 
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1016,6 +1016,7 @@ async def test_init_containers_as_dict():
     assert init_containers[0].image == 'mock_image_1'
     assert init_containers[1].image == 'mock_image_2'
 
+
 _test_profiles_dict = {
     'training-python': {
         'display_name': 'Training Env - Python',
@@ -1028,7 +1029,7 @@ _test_profiles_dict = {
             'environment': {'override': 'override-value'},
         },
     },
-    'training-datascience':{
+    'training-datascience': {
         'display_name': 'Training Env - Datascience',
         'slug': 'training-datascience',
         'kubespawner_override': {
@@ -1037,7 +1038,7 @@ _test_profiles_dict = {
             'mem_limit': 8 * 1024 * 1024 * 1024,
         },
     },
-    'training-r':{
+    'training-r': {
         'display_name': 'Training Env - R',
         'slug': 'training-r',
         'kubespawner_override': {
@@ -1105,12 +1106,15 @@ _test_profiles_dict = {
     },
 }
 
+
 def get_idx_based_on_profile_list_type(prf, idx):
     if type(prf) == dict:
         return _test_profiles_list[idx]['slug']
     return idx
 
+
 _test_profiles_list = list(_test_profiles_dict.values())
+
 
 @pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
 async def test_user_options_set_from_form(test_profiles):
@@ -1132,6 +1136,7 @@ async def test_user_options_set_from_form(test_profiles):
     await spawner.load_user_options()
     for key, value in test_profiles[idx]['kubespawner_override'].items():
         assert getattr(spawner, key) == value
+
 
 @pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
 async def test_user_options_set_from_form_choices(test_profiles):
@@ -1158,6 +1163,7 @@ async def test_user_options_set_from_form_choices(test_profiles):
     assert spawner.cpu_limit is None
     await spawner.load_user_options()
     assert getattr(spawner, 'image') == 'pangeo/pytorch-notebook:master'
+
 
 @pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
 async def test_user_options_set_from_form_unlisted_choice(test_profiles):
@@ -1234,6 +1240,7 @@ async def test_user_options_set_from_form_invalid_regex(test_profiles):
     with pytest.raises(ValueError):
         await spawner.load_user_options()
 
+
 @pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
 async def test_user_options_set_from_form_no_regex(test_profiles):
     """
@@ -1260,6 +1267,7 @@ async def test_user_options_set_from_form_no_regex(test_profiles):
     await spawner.load_user_options()
     assert getattr(spawner, 'image') == 'invalid/foo:latest'
 
+
 @pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
 async def test_kubespawner_override(test_profiles):
     spawner = KubeSpawner(_mock=True)
@@ -1274,7 +1282,7 @@ async def test_kubespawner_override(test_profiles):
     idx = get_idx_based_on_profile_list_type(test_profiles, 2)
 
     spawner.user_options = spawner.options_from_form(
-        {'profile':  test_profiles[idx]['slug']}
+        {'profile': [test_profiles[idx]['slug']]}
     )
     assert spawner.user_options == {
         'profile': test_profiles[idx]['slug'],
@@ -1284,6 +1292,7 @@ async def test_kubespawner_override(test_profiles):
         "existing": "existing-value",
         "override": "override-value",
     }
+
 
 @pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
 async def test_user_options_api(test_profiles):
@@ -1300,12 +1309,13 @@ async def test_user_options_api(test_profiles):
     for key, value in test_profiles[idx]['kubespawner_override'].items():
         assert getattr(spawner, key) == value
 
+
 @pytest.mark.parametrize("test_profiles", [_test_profiles_list, _test_profiles_dict])
 async def test_default_profile(test_profiles):
     spawner = KubeSpawner(_mock=True)
     spawner.profile_list = test_profiles
     spawner.user_options = {}
-    idx = get_idx_based_on_profile_list_type(test_profiles, 1)
+    idx = get_idx_based_on_profile_list_type(test_profiles, 0)
 
     # nothing should be loaded yet
     assert spawner.cpu_limit is None


### PR DESCRIPTION
This is a continuation of #843 and #845 and adds dictionary support for `profile_lists`.

Didn't want to make this a breaking change and update the name of the traitlet, though in its current form it assumes lists and might be confusing.

How do folks feel about renaming it?

Ref: https://github.com/2i2c-org/infrastructure/issues/6941