### PR TITLE
Fix Failing Tests on latest k3s on Main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,27 +59,7 @@ jobs:
 
           # Test with latest python and newer kubernetes to see where it fails
           - python: "3.12"
-            k3s: v1.30
-
-          # Test with latest python and newer kubernetes to see where it fails
-          - python: "3.12"
-            k3s: v1.31
-
-          # Test with latest python and newer kubernetes to see where it fails
-          - python: "3.12"
             k3s: v1.32
-
-          # Test with latest python and newer kubernetes to see where it fails
-          - python: "3.12"
-            k3s: v1.33
-
-          # Test with latest python and newer kubernetes to see where it fails
-          - python: "3.12"
-            k3s: v1.34
-
-          # Test with latest python and newer kubernetes to see where it fails
-          - python: "3.12"
-            k3s: v1.35
 
           # Test with specific python, kubernetes and latest jupyterhub
           - python: "3.11"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,27 +59,27 @@ jobs:
 
           # Test with latest python and newer kubernetes to see where it fails
           - python: latest
-            k3s: 1.30
+            k3s: v1.30
 
           # Test with latest python and newer kubernetes to see where it fails
           - python: latest
-            k3s: 1.31
+            k3s: v1.31
 
           # Test with latest python and newer kubernetes to see where it fails
           - python: latest
-            k3s: 1.32
+            k3s: v1.32
 
           # Test with latest python and newer kubernetes to see where it fails
           - python: latest
-            k3s: 1.33
+            k3s: v1.33
 
           # Test with latest python and newer kubernetes to see where it fails
           - python: latest
-            k3s: 1.34
+            k3s: v1.34
 
           # Test with latest python and newer kubernetes to see where it fails
           - python: latest
-            k3s: 1.35
+            k3s: v1.35
 
           # Test with specific python, kubernetes and latest jupyterhub
           - python: "3.11"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
             k3s: v1.28
 
           # Test with latest python and latest kubernetes
-          - python: "3.X"
+          - python: "3.12"
             k3s: latest
 
           # Test with specific python, kubernetes and latest jupyterhub

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,27 +58,27 @@ jobs:
             k3s: latest
 
           # Test with latest python and newer kubernetes to see where it fails
-          - python: latest
+          - python: "3.12"
             k3s: v1.30
 
           # Test with latest python and newer kubernetes to see where it fails
-          - python: latest
+          - python: "3.12"
             k3s: v1.31
 
           # Test with latest python and newer kubernetes to see where it fails
-          - python: latest
+          - python: "3.12"
             k3s: v1.32
 
           # Test with latest python and newer kubernetes to see where it fails
-          - python: latest
+          - python: "3.12"
             k3s: v1.33
 
           # Test with latest python and newer kubernetes to see where it fails
-          - python: latest
+          - python: "3.12"
             k3s: v1.34
 
           # Test with latest python and newer kubernetes to see where it fails
-          - python: latest
+          - python: "3.12"
             k3s: v1.35
 
           # Test with specific python, kubernetes and latest jupyterhub

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,8 +50,6 @@ jobs:
               kubernetes_asyncio==24.2.3
 
           # Test with modern python and k8s versions
-          - python: "3.11"
-            k3s: v1.27
           - python: "3.12"
             k3s: v1.28
 
@@ -60,8 +58,8 @@ jobs:
             k3s: latest
 
           # Test with specific python, kubernetes and latest jupyterhub
-          - python: "3.12"
-            k3s: v1.28
+          - python: "3.11"
+            k3s: v1.27
             test_dependencies: git+https://github.com/jupyterhub/jupyterhub
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,17 +49,13 @@ jobs:
               jupyterhub==4.0.0
               kubernetes_asyncio==24.2.3
 
-          # Test with modern python and k8s versions
+          # Test with modern python and older k8s versions
           - python: "3.12"
             k3s: v1.28
 
           # Test with latest python and latest kubernetes
           - python: 3.x
             k3s: latest
-
-          # Test with latest python and newer kubernetes to see where it fails
-          - python: "3.12"
-            k3s: v1.32
 
           # Test with specific python, kubernetes and latest jupyterhub
           - python: "3.11"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,8 +54,32 @@ jobs:
             k3s: v1.28
 
           # Test with latest python and latest kubernetes
-          - python: "3.12"
+          - python: latest
             k3s: latest
+
+          # Test with latest python and newer kubernetes to see where it fails
+          - python: latest
+            k3s: 1.30
+
+          # Test with latest python and newer kubernetes to see where it fails
+          - python: latest
+            k3s: 1.31
+
+          # Test with latest python and newer kubernetes to see where it fails
+          - python: latest
+            k3s: 1.32
+
+          # Test with latest python and newer kubernetes to see where it fails
+          - python: latest
+            k3s: 1.33
+
+          # Test with latest python and newer kubernetes to see where it fails
+          - python: latest
+            k3s: 1.34
+
+          # Test with latest python and newer kubernetes to see where it fails
+          - python: latest
+            k3s: 1.35
 
           # Test with specific python, kubernetes and latest jupyterhub
           - python: "3.11"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
             k3s: v1.28
 
           # Test with latest python and latest kubernetes
-          - python: latest
+          - python: 3.x
             k3s: latest
 
           # Test with latest python and newer kubernetes to see where it fails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,9 +55,13 @@ jobs:
           - python: "3.12"
             k3s: v1.28
 
-          # Test with latest python and JupyterHub in main branch
+          # Test with latest python and latest kubernetes
           - python: "3.X"
             k3s: latest
+
+          # Test with specific python, kubernetes and latest jupyterhub
+          - python: "3.12"
+            k3s: v1.28
             test_dependencies: git+https://github.com/jupyterhub/jupyterhub
 
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,14 @@ async def _delete_namespace(client, namespace):
         else:
             print("waiting for %s to delete" % namespace)
             await asyncio.sleep(1)
+    import subprocess
+    subprocess.check_call([
+        "kubectl", "-n", namespace,
+        "get", "all"
+    ])
+    subprocess.check_call([
+        "kubectl", "describe", "namespace", namespace
+    ])
     raise Exception(f"Namespace {namespace} not deleted after 20 s")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,7 +252,7 @@ async def _delete_namespace(client, namespace):
     import subprocess
     subprocess.check_call([
         "kubectl", "-n", namespace,
-        "get", "all"
+        "get", "pvc"
     ])
     subprocess.check_call([
         "kubectl", "describe", "namespace", namespace

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,13 +251,7 @@ async def _delete_namespace(client, namespace):
             await asyncio.sleep(1)
     import subprocess
 
-    print("debug info")
-    subprocess.check_call(["kubectl", "-n", namespace, "get", "pvc", "-oyaml", "-A"])
-    subprocess.check_call(["kubectl", "-n", namespace, "get", "pv", "-oyaml", "-A"])
-    subprocess.check_call(["kubectl", "-n", namespace, "get", "pod", "-oyaml", "-A"])
-    subprocess.check_call(["kubectl", "get", "namespace", "-oyaml"])
-    subprocess.check_call(["kubectl", "describe", "namespace", namespace])
-    raise Exception(f"Namespace {namespace} not deleted after 20 s")
+    raise Exception(f"Namespace {namespace} not deleted after 60s")
 
 
 @pytest_asyncio.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,6 +254,7 @@ async def _delete_namespace(client, namespace):
     print("debug info")
     subprocess.check_call(["kubectl", "-n", namespace, "get", "pvc", "-oyaml", "-A"])
     subprocess.check_call(["kubectl", "-n", namespace, "get", "pv", "-oyaml", "-A"])
+    subprocess.check_call(["kubectl", "get", "namespace", "-oyaml"])
     subprocess.check_call(["kubectl", "describe", "namespace", namespace])
     raise Exception(f"Namespace {namespace} not deleted after 20 s")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,7 @@ async def _delete_namespace(client, namespace):
 
     print("debug info")
     subprocess.check_call(["kubectl", "-n", namespace, "get", "pvc", "-oyaml", "-A"])
+    subprocess.check_call(["kubectl", "-n", namespace, "get", "pv", "-oyaml", "-A"])
     subprocess.check_call(["kubectl", "describe", "namespace", namespace])
     raise Exception(f"Namespace {namespace} not deleted after 20 s")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,7 +249,6 @@ async def _delete_namespace(client, namespace):
         else:
             print("waiting for %s to delete" % namespace)
             await asyncio.sleep(1)
-    import subprocess
 
     raise Exception(f"Namespace {namespace} not deleted after 60s")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,14 +250,10 @@ async def _delete_namespace(client, namespace):
             print("waiting for %s to delete" % namespace)
             await asyncio.sleep(1)
     import subprocess
+
     print("debug info")
-    subprocess.check_call([
-        "kubectl", "-n", namespace,
-        "get", "pvc", "-oyaml", "-A"
-    ])
-    subprocess.check_call([
-        "kubectl", "describe", "namespace", namespace
-    ])
+    subprocess.check_call(["kubectl", "-n", namespace, "get", "pvc", "-oyaml", "-A"])
+    subprocess.check_call(["kubectl", "describe", "namespace", namespace])
     raise Exception(f"Namespace {namespace} not deleted after 20 s")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,6 +254,7 @@ async def _delete_namespace(client, namespace):
     print("debug info")
     subprocess.check_call(["kubectl", "-n", namespace, "get", "pvc", "-oyaml", "-A"])
     subprocess.check_call(["kubectl", "-n", namespace, "get", "pv", "-oyaml", "-A"])
+    subprocess.check_call(["kubectl", "-n", namespace, "get", "pod", "-oyaml", "-A"])
     subprocess.check_call(["kubectl", "get", "namespace", "-oyaml"])
     subprocess.check_call(["kubectl", "describe", "namespace", namespace])
     raise Exception(f"Namespace {namespace} not deleted after 20 s")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,9 +250,10 @@ async def _delete_namespace(client, namespace):
             print("waiting for %s to delete" % namespace)
             await asyncio.sleep(1)
     import subprocess
+    print("debug info")
     subprocess.check_call([
         "kubectl", "-n", namespace,
-        "get", "pvc"
+        "get", "pvc", "-oyaml", "-A"
     ])
     subprocess.check_call([
         "kubectl", "describe", "namespace", namespace

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,7 +238,7 @@ async def watch_kubernetes(kube_client, kube_ns):
 
 async def _delete_namespace(client, namespace):
     await client.delete_namespace(namespace, body={}, grace_period_seconds=0)
-    for _ in range(20):  # Usually finishes a good deal faster
+    for _ in range(60):  # Usually finishes a good deal faster
         try:
             await client.read_namespace(namespace)
         except ApiException as e:

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1,8 +1,8 @@
 import asyncio
 import base64
 import json
-import re
 import os
+import re
 from functools import partial
 from unittest.mock import Mock
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -659,7 +659,7 @@ async def test_spawn_progress(kube_ns, kube_client, config, hub_pod, hub):
         with open(os.devnull, "w") as devnull:
             json.dump(progress, devnull)
     # This message varies by version
-    assert re.match(r'Started container|Container started', '\n'.join(messages))
+    assert re.search(r'Started container|Container started', '\n'.join(messages))
 
     await start_future
     # stop the pod

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import re
 import os
 from functools import partial
 from unittest.mock import Mock
@@ -657,7 +658,8 @@ async def test_spawn_progress(kube_ns, kube_client, config, hub_pod, hub):
         # ensure we can serialize whatever we return
         with open(os.devnull, "w") as devnull:
             json.dump(progress, devnull)
-    assert 'Started container' in '\n'.join(messages)
+    # This message varies by version
+    assert re.match(r'Started container|Container started', '\n'.join(messages))
 
     await start_future
     # stop the pod


### PR DESCRIPTION
- Fix failing test due to changed structure of event description on latest k8s
- Seperate out 'test on latest k3s' and 'test on latest jupyterhub main' so it's easier to  
   tell what fails. Remove an earlier redundant lower version python test combo so we don't
  explode our CI time
- Increase the timeout for deleting namespaces, as it seems to take >20s for all finalizers to
  settle on k8s / k3s 1.32+