### PR TITLE
Support nested profile_options in profile choices

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -149,13 +149,17 @@ c.KubeSpawner.profile_list = [
                                                         'display_name': 'Exclusive',
                                                         'default': True,
                                                         'kubespawner_override': {
-                                                            'environment': {'DEMO_GPU_SHARING': 'exclusive'},
+                                                            'environment': {
+                                                                'DEMO_GPU_SHARING': 'exclusive'
+                                                            },
                                                         },
                                                     },
                                                     'mig': {
                                                         'display_name': 'MIG slice',
                                                         'kubespawner_override': {
-                                                            'environment': {'DEMO_GPU_SHARING': 'mig'},
+                                                            'environment': {
+                                                                'DEMO_GPU_SHARING': 'mig'
+                                                            },
                                                         },
                                                     },
                                                 },

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -79,4 +79,101 @@ c.KubeSpawner.profile_list = [
             'extra_resource_guarantees': {"nvidia.com/gpu": "1"},
         },
     },
+    {
+        # Demonstrates nested profile_options: choices can declare their own
+        # profile_options, shown only while that choice is selected. Overrides
+        # here only set environment variables so the pod stays schedulable on
+        # a local cluster and the result is observable with `env | grep DEMO_`
+        # in the spawned server's terminal.
+        'display_name': 'Demo - nested profile options',
+        'slug': 'demo-nested',
+        'profile_options': {
+            'gpu': {
+                'display_name': 'GPU setup',
+                'choices': {
+                    'none': {
+                        'display_name': 'No GPU',
+                        'default': True,
+                        'kubespawner_override': {
+                            'environment': {'DEMO_GPU_SETUP': 'none'},
+                        },
+                    },
+                    'nvidia': {
+                        'display_name': 'NVIDIA',
+                        'kubespawner_override': {
+                            'environment': {'DEMO_GPU_SETUP': 'nvidia'},
+                        },
+                        'profile_options': {
+                            'type': {
+                                'display_name': 'GPU type',
+                                'choices': {
+                                    't4': {
+                                        'display_name': 'T4',
+                                        'default': True,
+                                        'kubespawner_override': {
+                                            'environment': {'DEMO_GPU_TYPE': 't4'},
+                                        },
+                                    },
+                                    'a100': {
+                                        'display_name': 'A100',
+                                        'kubespawner_override': {
+                                            'environment': {'DEMO_GPU_TYPE': 'a100'},
+                                        },
+                                    },
+                                },
+                                'unlisted_choice': {
+                                    'enabled': True,
+                                    'display_name': 'Custom GPU type',
+                                    'validation_regex': '^[a-z0-9-]+$',
+                                    'validation_message': 'Lowercase letters, digits and dashes only',
+                                    'kubespawner_override': {
+                                        'environment': {'DEMO_GPU_TYPE': '{value}'},
+                                    },
+                                },
+                            },
+                            'count': {
+                                'display_name': 'GPU count',
+                                'choices': {
+                                    'one': {
+                                        'display_name': '1',
+                                        'default': True,
+                                        'kubespawner_override': {
+                                            'environment': {'DEMO_GPU_COUNT': '1'},
+                                        },
+                                        # A second level of nesting to exercise recursion
+                                        'profile_options': {
+                                            'sharing': {
+                                                'display_name': 'GPU sharing',
+                                                'choices': {
+                                                    'exclusive': {
+                                                        'display_name': 'Exclusive',
+                                                        'default': True,
+                                                        'kubespawner_override': {
+                                                            'environment': {'DEMO_GPU_SHARING': 'exclusive'},
+                                                        },
+                                                    },
+                                                    'mig': {
+                                                        'display_name': 'MIG slice',
+                                                        'kubespawner_override': {
+                                                            'environment': {'DEMO_GPU_SHARING': 'mig'},
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                    'two': {
+                                        'display_name': '2',
+                                        'kubespawner_override': {
+                                            'environment': {'DEMO_GPU_COUNT': '2'},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
 ]

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3530,6 +3530,51 @@ class KubeSpawner(Spawner):
 
         return user_options
 
+    def _validate_profile_options(self, profile_options, key_prefix=""):
+        """
+        Validates user_options entries corresponding to a profile_options dict,
+        recursively validating nested profile_options for the active choice.
+
+        key_prefix mirrors the same path convention used by
+        _apply_profile_options_overrides.
+        """
+        for option_name, option in profile_options.items():
+            option_key = (
+                f"{key_prefix}--{option_name}" if key_prefix else option_name
+            )
+            unlisted_choice_key = f"{option_key}--unlisted-choice"
+            unlisted_choice_value = self.user_options.get(unlisted_choice_key)
+            choice_key = self.user_options.get(option_key)
+
+            if not (unlisted_choice_value or choice_key):
+                # no user_options was passed for this profile option, the
+                # profile option's default value can be used
+                continue
+
+            if unlisted_choice_value:
+                # we have been passed a value for the profile option's
+                # unlisted_choice, it must be enabled and the provided value
+                # must validate against the validation_regex if configured
+                if not option.get("unlisted_choice", {}).get("enabled"):
+                    raise ValueError(
+                        f"Received unlisted_choice for {option_key} without being enabled."
+                    )
+                validation_regex = option["unlisted_choice"].get("validation_regex")
+                if validation_regex and not re.match(
+                    validation_regex, unlisted_choice_value
+                ):
+                    raise ValueError(
+                        f"Received unlisted_choice for {option_key} that failed validation regex."
+                    )
+            elif choice_key in option.get("choices", {}):
+                # Validate nested profile_options for the active choice
+                choice = option["choices"][choice_key]
+                if choice.get("profile_options"):
+                    nested_prefix = f"{option_key}--{choice_key}"
+                    self._validate_profile_options(
+                        choice["profile_options"], key_prefix=nested_prefix
+                    )
+
     def _validate_user_options(self, profile_list):
         """
         Validate `user_options` using an initialized `profile_list` by raising
@@ -3566,28 +3611,8 @@ class KubeSpawner(Spawner):
         profile = self._get_profile(profile_slug, profile_list)
 
         # Ensure user_options related to the profile's profile_options are valid
-        for option_name, option in profile.get('profile_options', {}).items():
-            unlisted_choice_key = f"{option_name}--unlisted-choice"
-            unlisted_choice = self.user_options.get(unlisted_choice_key)
-            choice = self.user_options.get(option_name)
-            if not (unlisted_choice or choice):
-                # no user_options was passed for this profile option, the
-                # profile option's default value can be used
-                continue
-            if unlisted_choice:
-                # we have been passed a value for the profile option's
-                # unlisted_choice, it must be enabled and the provided value
-                # must validate against the validation_regex if configured
-                if not option.get("unlisted_choice", {}).get("enabled"):
-                    raise ValueError(
-                        f"Received unlisted_choice for {option_name} without being enabled."
-                    )
-
-                validation_regex = option["unlisted_choice"].get("validation_regex")
-                if validation_regex and not re.match(validation_regex, unlisted_choice):
-                    raise ValueError(
-                        f"Received unlisted_choice for {option_name} that failed validation regex."
-                    )
+        # (recursively including nested profile_options)
+        self._validate_profile_options(profile.get('profile_options', {}))
 
     def _get_profile(self, slug: Optional[str], profile_list: list):
         """
@@ -3640,11 +3665,70 @@ class KubeSpawner(Spawner):
             else:
                 setattr(self, k, v)
 
+    def _apply_profile_options_overrides(self, profile_options, key_prefix=""):
+        """
+        Applies kubespawner_override from each active profile option choice,
+        recursively processing any nested profile_options in the selected choice.
+
+        key_prefix is a "--"-delimited path used to look up user_options keys
+        for nested options. For top-level options it is empty; for options
+        nested under choice "testing" of option "image" it would be
+        "image--testing".
+        """
+        for option_name, option in profile_options.items():
+            option_key = (
+                f"{key_prefix}--{option_name}" if key_prefix else option_name
+            )
+            unlisted_choice_key = f"{option_key}--unlisted-choice"
+            unlisted_choice_value = self.user_options.get(unlisted_choice_key)
+            choice_key = self.user_options.get(option_key)
+
+            if unlisted_choice_value:
+                # An unlisted_choice value was passed; render its overrides
+                option_overrides = option["unlisted_choice"].get(
+                    "kubespawner_override", {}
+                )
+                for k, v in option_overrides.items():
+                    option_overrides[k] = recursive_format(
+                        v, value=unlisted_choice_value
+                    )
+                selected_choice_key = None
+                selected_choice = None
+            elif choice_key:
+                # A pre-defined choice was selected
+                selected_choice = option["choices"][choice_key]
+                selected_choice_key = choice_key
+                option_overrides = selected_choice.get("kubespawner_override", {})
+            else:
+                # Determine the default choice
+                if not option.get("choices"):
+                    # if the option only defined unlisted_choice, we can't
+                    # determine a default choice or associated overrides
+                    raise ValueError(
+                        f"Unable to determine a default choice for {option_key}."
+                    )
+                selected_choice_key, selected_choice = next(
+                    (k, c)
+                    for k, c in option["choices"].items()
+                    if c.get("default")
+                )
+                option_overrides = selected_choice.get("kubespawner_override", {})
+
+            self._apply_overrides(option_overrides)
+
+            # Recurse into nested profile_options of the selected choice
+            if selected_choice and selected_choice.get("profile_options"):
+                nested_prefix = f"{option_key}--{selected_choice_key}"
+                self._apply_profile_options_overrides(
+                    selected_choice["profile_options"],
+                    key_prefix=nested_prefix,
+                )
+
     def _load_profile(self, slug, profile_list):
         """
         Applies configured overrides for a selected or default profile,
         including the selected or default overrides for the profile's
-        profile_options.
+        profile_options (recursively, including any nested profile_options).
 
         Called by `load_user_options` after validation of user_options has been
         done with the initialized profile_list.
@@ -3659,40 +3743,33 @@ class KubeSpawner(Spawner):
         self._apply_overrides(profile.get("kubespawner_override", {}))
 
         # Apply overrides for the profile_options's choices or defaults
-        profile_options = profile.get("profile_options", {})
-        for option_name, option in profile_options.items():
-            unlisted_choice_key = f"{option_name}--unlisted-choice"
-            unlisted_choice = self.user_options.get(unlisted_choice_key)
-            choice = self.user_options.get(option_name)
+        self._apply_profile_options_overrides(profile.get("profile_options", {}))
 
-            if unlisted_choice:
-                # An unlisted_choice value was passed, its kubespawner_override
-                # needs to be rendered using the value
-                option_overrides = option["unlisted_choice"].get(
-                    "kubespawner_override", {}
-                )
-                for k, v in option_overrides.items():
-                    option_overrides[k] = recursive_format(v, value=unlisted_choice)
-            elif choice:
-                # A pre-defined choice was selected
-                option_overrides = option["choices"][choice].get(
-                    "kubespawner_override", {}
-                )
-            else:
-                # A default choice for the option needs to be determined
-                if not option.get("choices"):
-                    # if the option only defined unlisted_choice, we can't
-                    # determine a default choice or associated overrides
-                    raise ValueError(
-                        f"Unable to determine a default choice for {option_name}."
-                    )
+    @staticmethod
+    def _init_profile_option_configs(option_configs: dict):
+        """
+        Initializes a profile_options dict in-place, recursively including any
+        nested profile_options found inside choices.
 
-                default_choice = next(
-                    c for c in option["choices"].values() if c.get("default")
-                )
-                option_overrides = default_choice.get("kubespawner_override", {})
-
-            self._apply_overrides(option_overrides)
+        - If choices exist but no choice is marked as default, the first choice
+          is set as the default.
+        - Each option's unlisted_choice dict is populated with default values.
+        """
+        for option_config in option_configs.values():
+            if option_config.get('choices') and not any(
+                c.get('default') for c in option_config['choices'].values()
+            ):
+                # pre-defined choices were provided without a default choice
+                default_choice = list(option_config['choices'].keys())[0]
+                option_config['choices'][default_choice]["default"] = True
+            unlisted_choice = option_config.setdefault("unlisted_choice", {})
+            unlisted_choice.setdefault("enabled", False)
+            if unlisted_choice["enabled"]:
+                unlisted_choice.setdefault("display_name_in_choices", "Other...")
+            # Recurse into nested profile_options inside each choice
+            for choice in option_config.get('choices', {}).values():
+                if choice.get('profile_options'):
+                    KubeSpawner._init_profile_option_configs(choice['profile_options'])
 
     def _get_initialized_profile_list(self, profile_list: list):
         """
@@ -3703,6 +3780,8 @@ class KubeSpawner(Spawner):
           as the default, the first choice is set to be the default.
         - If no default profile is set, the first profile is set to be the
           default
+        - Nested profile_options inside choices are also initialized
+          recursively.
         """
         profile_list = copy.deepcopy(profile_list)
 
@@ -3717,18 +3796,9 @@ class KubeSpawner(Spawner):
 
             # ensure each option in profile_options has a default choice if
             # pre-defined choices are available, and initialize an
-            # unlisted_choice dictionary
-            for option_config in profile.get('profile_options', {}).values():
-                if option_config.get('choices') and not any(
-                    c.get('default') for c in option_config['choices'].values()
-                ):
-                    # pre-defined choices were provided without a default choice
-                    default_choice = list(option_config['choices'].keys())[0]
-                    option_config['choices'][default_choice]["default"] = True
-                unlisted_choice = option_config.setdefault("unlisted_choice", {})
-                unlisted_choice.setdefault("enabled", False)
-                if unlisted_choice["enabled"]:
-                    unlisted_choice.setdefault("display_name_in_choices", "Other...")
+            # unlisted_choice dictionary (recursively for nested options)
+            self._init_profile_option_configs(profile.get('profile_options', {}))
+
         # ensure there is one default profile
         if not any(p.get("default") for p in profile_list):
             profile_list[0]["default"] = True

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3539,9 +3539,7 @@ class KubeSpawner(Spawner):
         _apply_profile_options_overrides.
         """
         for option_name, option in profile_options.items():
-            option_key = (
-                f"{key_prefix}--{option_name}" if key_prefix else option_name
-            )
+            option_key = f"{key_prefix}--{option_name}" if key_prefix else option_name
             unlisted_choice_key = f"{option_key}--unlisted-choice"
             unlisted_choice_value = self.user_options.get(unlisted_choice_key)
             choice_key = self.user_options.get(option_key)
@@ -3676,9 +3674,7 @@ class KubeSpawner(Spawner):
         "image--testing".
         """
         for option_name, option in profile_options.items():
-            option_key = (
-                f"{key_prefix}--{option_name}" if key_prefix else option_name
-            )
+            option_key = f"{key_prefix}--{option_name}" if key_prefix else option_name
             unlisted_choice_key = f"{option_key}--unlisted-choice"
             unlisted_choice_value = self.user_options.get(unlisted_choice_key)
             choice_key = self.user_options.get(option_key)
@@ -3708,9 +3704,7 @@ class KubeSpawner(Spawner):
                         f"Unable to determine a default choice for {option_key}."
                     )
                 selected_choice_key, selected_choice = next(
-                    (k, c)
-                    for k, c in option["choices"].items()
-                    if c.get("default")
+                    (k, c) for k, c in option["choices"].items() if c.get("default")
                 )
                 option_overrides = selected_choice.get("kubespawner_override", {})
 

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -1,4 +1,55 @@
 <style>{% include 'style.css' %}</style>
+
+{#- Macro to render profile_options recursively.
+    profile_slug: the slug of the parent profile (used for form field names)
+    profile_options: the profile_options dict to render
+    key_prefix: "--"-delimited path prefix for nested options (empty at top level)
+#}
+{%- macro render_profile_options(profile_slug, profile_options, key_prefix="") %}
+  {%- for option_name, option in profile_options.items() %}
+    {%- set option_key = (key_prefix ~ "--" ~ option_name) if key_prefix else option_name %}
+    <div class="js-options-container">
+      <div class="option">
+        <label for="profile-option-{{ profile_slug }}--{{ option_key }}"
+               class="js-profile-option-label">{{ option.display_name }}</label>
+        <select data-name="profile-option-{{ profile_slug }}--{{ option_key }}"
+                data-option-key="{{ option_key }}"
+                class="form-control js-profile-option-select">
+          {%- for choice_key, choice in option.get('choices', {}).items() %}
+            <option value="{{ choice_key }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
+          {%- endfor %}
+          {%- if option['unlisted_choice']['enabled'] %}
+            <option value="unlisted-choice">{{ option['unlisted_choice']['display_name_in_choices'] }}</option>
+          {%- endif %}
+        </select>
+      </div>
+      {%- if option['unlisted_choice']['enabled'] %}
+        <div class="option hidden js-other-input-container">
+          <label for="profile-option-{{ profile_slug }}--{{ option_key }}--unlisted-choice">
+            {{ option['unlisted_choice']['display_name'] }}
+          </label>
+          <input data-name="profile-option-{{ profile_slug }}--{{ option_key }}--unlisted-choice"
+                 {%- if option['unlisted_choice']['validation_regex'] %}
+                 pattern="{{ option['unlisted_choice']['validation_regex'] }}"
+                 {%- endif %}
+                 title="{{ option['unlisted_choice']['validation_message'] }}"
+                 class="form-control js-other-input" />
+        </div>
+      {%- endif %}
+      {#- Render nested profile_options for each choice, all initially hidden #}
+      {%- for choice_key, choice in option.get('choices', {}).items() %}
+        {%- if choice.get('profile_options') %}
+          <div class="hidden js-nested-options"
+               data-parent-option="{{ option_key }}"
+               data-parent-choice="{{ choice_key }}">
+            {{ render_profile_options(profile_slug, choice['profile_options'], option_key ~ "--" ~ choice_key) }}
+          </div>
+        {%- endif %}
+      {%- endfor %}
+    </div>
+  {%- endfor %}
+{%- endmacro %}
+
 <div class="form-group" id="kubespawner-profiles-list">
   {%- for profile in profile_list %}
     {#- Wrap everything in a label tag so clicking anywhere selects the option #}
@@ -16,36 +67,7 @@
         {%- if profile.description %}<p>{{ profile.description }}</p>{%- endif %}
         {%- if profile.profile_options %}
           <div>
-            {%- for k, option in profile.profile_options.items() %}
-              <div class="js-options-container">
-                <div class="option">
-                  <label for="profile-option-{{ profile.slug }}--{{ k }}"
-                         class="js-profile-option-label">{{ option.display_name }}</label>
-                  <select name="profile-option-{{ profile.slug }}--{{ k }}"
-                          class="form-control js-profile-option-select">
-                    {%- for k, choice in option['choices'].items() %}
-                      <option value="{{ k }}" {% if choice.default %}selected{% endif %}>{{ choice.display_name }}</option>
-                    {%- endfor %}
-                    {%- if option['unlisted_choice']['enabled'] %}
-                      <option value="unlisted-choice">{{ option['unlisted_choice']['display_name_in_choices'] }}</option>
-                    {%- endif %}
-                  </select>
-                </div>
-                {%- if option['unlisted_choice']['enabled'] %}
-                  <div class="option hidden js-other-input-container">
-                    <label for="profile-option-{{ profile.slug }}--{{ k }}--unlisted-choice">
-                      {{ option['unlisted_choice']['display_name'] }}
-                    </label>
-                    <input data-name="profile-option-{{ profile.slug }}--{{ k }}--unlisted-choice"
-                           {%- if option['unlisted_choice']['validation_regex'] %}
-                           pattern="{{ option['unlisted_choice']['validation_regex'] }}"
-                           {%- endif %}
-                           title="{{ option['unlisted_choice']['validation_message'] }}"
-                           class="form-control js-other-input" />
-                  </div>
-                {%- endif %}
-              </div>
-            {%- endfor %}
+            {{ render_profile_options(profile.slug, profile.profile_options) }}
           </div>
         {%- endif %}
       </div>
@@ -55,44 +77,69 @@
 <script>
   $('.js-profile-option-select, .js-profile-option-label').click(function() {
     // we need this bit of JS to select the profile when a <select> inside is clicked.
-    $(this).parents('.js-profile-label')
+    $(this).closest('.js-profile-label')
       .find('input[type=radio]')
       .prop('checked', true);
   });
 
-  // If the user selects "Other" in the dropdown, show the free text field
-  $('.js-profile-option-select').change(function() {
-    const selectionValue = $(this).val();
-    const $otherInputContainer = $(this).parents('.js-options-container').find('.js-other-input-container');
-    const $otherInput = $(this).parents('.js-options-container').find('.js-other-input');
-    if (selectionValue === 'unlisted-choice') {
+  function handleProfileOptionSelectChange($select) {
+    var selectedValue = $select.val();
+    var $myContainer = $select.closest('.js-options-container');
 
-      // if the Select box is selected with a value that is not 'unlisted-choice',
-      // we remove the "name" attribute for the unlisted-choice input
-      // and vice-versa, so that we only submit valid form values
-      // and don't leave the complexity of figuring out which value
-      // to use to the back-end.
-
-      // This can probably be done cleaner by completely refactoring
-      // how we send values from the frontend.
-      $(this).data('name', $(this).attr('name'));
-      $(this).removeAttr('name');
+    // If the user selects "Other" in the dropdown, show the free text field.
+    // Remove the "name" attribute from whichever input should not submit,
+    // so that we only submit valid form values.
+    var $otherInputContainer = $myContainer.children('.js-other-input-container');
+    var $otherInput = $otherInputContainer.find('.js-other-input');
+    if (selectedValue === 'unlisted-choice') {
+      $select.removeAttr('name');
       $otherInput.attr('name', $otherInput.data('name'));
       $otherInputContainer.removeClass('hidden');
     } else {
+      $select.attr('name', $select.data('name'));
       $otherInput.removeAttr('name');
-      $(this).attr('name', $(this).data('name'));
       $otherInputContainer.addClass('hidden');
     }
+
+    // Show/hide nested options for the selected choice.
+    var optionKey = $select.data('option-key');
+    var $profileLabel = $select.closest('.js-profile-label');
+
+    // Hide all nested option containers for this parent option and strip
+    // their selects' name attributes so they don't submit.
+    $profileLabel.find('.js-nested-options[data-parent-option="' + optionKey + '"]').each(function() {
+      $(this).addClass('hidden');
+      $(this).find('select.js-profile-option-select').removeAttr('name');
+      $(this).find('input.js-other-input').removeAttr('name');
+    });
+
+    // Show the matching nested container for the selected choice and restore
+    // the name attribute for its direct selects, then trigger their change
+    // events to propagate the show/hide state recursively.
+    $profileLabel.find(
+      '.js-nested-options[data-parent-option="' + optionKey + '"]' +
+      '[data-parent-choice="' + selectedValue + '"]'
+    ).each(function() {
+      $(this).removeClass('hidden');
+      $(this).children('.js-options-container').children('.option').find('> select.js-profile-option-select').each(function() {
+        $(this).attr('name', $(this).data('name'));
+        handleProfileOptionSelectChange($(this));
+      });
+    });
+  }
+
+  $('.js-profile-option-select').change(function() {
+    handleProfileOptionSelectChange($(this));
   });
 
   // wrapping in a document.ready to make clear this is executed once
   // on page load
   $(document).ready(() => {
-    // trigger the `change` event on the select inputs,
-    // so that if "Other" is selected on page load, the corresponding
-    // free-text input shows
-    $('.js-profile-option-select').trigger('change');
+    // Trigger change on the top-level (non-nested) selects for each profile
+    // so that nested options are correctly shown/hidden on load.
+    $('.js-profile-label').each(function() {
+      $(this).find('.js-profile-option-select').not('.js-nested-options .js-profile-option-select').trigger('change');
+    });
   });
 
 </script>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -1,5 +1,4 @@
 <style>{% include 'style.css' %}</style>
-
 {#- Macro to render profile_options recursively.
     profile_slug: the slug of the parent profile (used for form field names)
     profile_options: the profile_options dict to render
@@ -50,7 +49,6 @@
     </div>
   {%- endfor %}
 {%- endmacro %}
-
 <div class="form-group" id="kubespawner-profiles-list">
   {%- for profile in profile_list %}
     {#- Wrap everything in a label tag so clicking anywhere selects the option #}
@@ -67,9 +65,7 @@
         <h3>{{ profile.display_name }}</h3>
         {%- if profile.description %}<p>{{ profile.description }}</p>{%- endif %}
         {%- if profile.profile_options %}
-          <div>
-            {{ render_profile_options(profile.slug, profile.profile_options) }}
-          </div>
+          <div>{{ render_profile_options(profile.slug, profile.profile_options) }}</div>
         {%- endif %}
       </div>
     </label>

--- a/kubespawner/templates/form.html
+++ b/kubespawner/templates/form.html
@@ -12,7 +12,8 @@
       <div class="option">
         <label for="profile-option-{{ profile_slug }}--{{ option_key }}"
                class="js-profile-option-label">{{ option.display_name }}</label>
-        <select data-name="profile-option-{{ profile_slug }}--{{ option_key }}"
+        <select {% if not key_prefix %}name="profile-option-{{ profile_slug }}--{{ option_key }}"{% endif %}
+                data-name="profile-option-{{ profile_slug }}--{{ option_key }}"
                 data-option-key="{{ option_key }}"
                 class="form-control js-profile-option-select">
           {%- for choice_key, choice in option.get('choices', {}).items() %}
@@ -75,8 +76,11 @@
   {%- endfor %}
 </div>
 <script>
-  $('.js-profile-option-select, .js-profile-option-label').click(function() {
-    // we need this bit of JS to select the profile when a <select> inside is clicked.
+  // Use event delegation so handlers work regardless of how/when the form HTML
+  // is injected into the page (e.g. via JupyterHub's dynamic form loading).
+
+  $(document).on('click', '.js-profile-option-select, .js-profile-option-label', function() {
+    // Select the profile radio button when the user clicks a dropdown or label.
     $(this).closest('.js-profile-label')
       .find('input[type=radio]')
       .prop('checked', true);
@@ -87,8 +91,8 @@
     var $myContainer = $select.closest('.js-options-container');
 
     // If the user selects "Other" in the dropdown, show the free text field.
-    // Remove the "name" attribute from whichever input should not submit,
-    // so that we only submit valid form values.
+    // We remove "name" from whichever input should NOT submit so the backend
+    // receives exactly one value per option.
     var $otherInputContainer = $myContainer.children('.js-other-input-container');
     var $otherInput = $otherInputContainer.find('.js-other-input');
     if (selectedValue === 'unlisted-choice') {
@@ -105,40 +109,45 @@
     var optionKey = $select.data('option-key');
     var $profileLabel = $select.closest('.js-profile-label');
 
-    // Hide all nested option containers for this parent option and strip
-    // their selects' name attributes so they don't submit.
+    // Hide all nested containers for this parent option and remove their
+    // selects' name attributes so they don't submit.
     $profileLabel.find('.js-nested-options[data-parent-option="' + optionKey + '"]').each(function() {
       $(this).addClass('hidden');
       $(this).find('select.js-profile-option-select').removeAttr('name');
       $(this).find('input.js-other-input').removeAttr('name');
     });
 
-    // Show the matching nested container for the selected choice and restore
-    // the name attribute for its direct selects, then trigger their change
-    // events to propagate the show/hide state recursively.
+    // Show the matching container for the selected choice, restore name
+    // attributes for its immediate selects, then trigger their change events
+    // so that their own nested options and unlisted-choice fields initialise.
     $profileLabel.find(
       '.js-nested-options[data-parent-option="' + optionKey + '"]' +
       '[data-parent-choice="' + selectedValue + '"]'
     ).each(function() {
       $(this).removeClass('hidden');
-      $(this).children('.js-options-container').children('.option').find('> select.js-profile-option-select').each(function() {
+      // Use chained .children() to find only the direct selects (one level down),
+      // avoiding accidentally matching selects inside deeper nested containers.
+      $(this).children('.js-options-container').children('.option').children('select.js-profile-option-select').each(function() {
         $(this).attr('name', $(this).data('name'));
         handleProfileOptionSelectChange($(this));
       });
     });
   }
 
-  $('.js-profile-option-select').change(function() {
+  $(document).on('change', '.js-profile-option-select', function() {
     handleProfileOptionSelectChange($(this));
   });
 
-  // wrapping in a document.ready to make clear this is executed once
-  // on page load
-  $(document).ready(() => {
-    // Trigger change on the top-level (non-nested) selects for each profile
-    // so that nested options are correctly shown/hidden on load.
+  // Trigger change on top-level selects once the DOM is ready so that:
+  //   1. nested option containers are shown/hidden per the default selection,
+  //   2. unlisted-choice inputs are shown if the default happens to be "Other".
+  // Top-level selects already have their "name" attribute in the HTML, so no
+  // name-restoration is needed here.
+  $(document).ready(function() {
     $('.js-profile-label').each(function() {
-      $(this).find('.js-profile-option-select').not('.js-nested-options .js-profile-option-select').trigger('change');
+      $(this).find('.js-profile-option-select')
+             .not('.js-nested-options .js-profile-option-select')
+             .trigger('change');
     });
   });
 

--- a/kubespawner/templates/style.css
+++ b/kubespawner/templates/style.css
@@ -41,3 +41,18 @@
 #kubespawner-profiles-list .js-other-input-container.hidden {
   display: none;
 }
+
+/*
+    Nested profile options are indented with a guide line, so it is visible
+    that they belong to the choice selected in the option above them.
+    Nesting deeper than one level indents further by the same amount.
+*/
+#kubespawner-profiles-list .profile .js-nested-options {
+  margin: 0 0 12px 8px;
+  padding-left: 16px;
+  border-left: 2px solid #ccc;
+}
+
+#kubespawner-profiles-list .profile .js-nested-options .option:last-child {
+  padding-bottom: 0;
+}

--- a/kubespawner/templates/style.css
+++ b/kubespawner/templates/style.css
@@ -1,4 +1,12 @@
 /*
+    .hidden is used by kubespawner's form JS to show/hide elements.
+    Defined here explicitly so it works regardless of Bootstrap version.
+*/
+.hidden {
+  display: none !important;
+}
+
+/*
     .profile divs holds two div tags: one for a radio button, and one
     for the profile's content.
 */

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -400,3 +400,199 @@ async def test_profile_slug_and_option_slug_mixup(profile_list, formdata):
     assert user_options.get("profile") == "short"
     assert user_options.get("relevant") == "choice-a"
     assert not user_options.get("plus-irrelevant")
+
+
+# Shared profile list with nested profile_options used by several tests below.
+# "image" has two choices: "standard" (no nested options) and "testing" (has a
+# nested "version" option with choices v1/v2).
+NESTED_PROFILE_LIST = [
+    {
+        'display_name': 'Example Profile',
+        'slug': 'example',
+        'profile_options': {
+            'image': {
+                'display_name': 'Image',
+                'choices': {
+                    'standard': {
+                        'display_name': 'Standard Image',
+                        'kubespawner_override': {
+                            'image': 'example_org/standard:latest',
+                        },
+                    },
+                    'testing': {
+                        'display_name': 'Testing Image',
+                        'kubespawner_override': {
+                            'image': 'example_org/testing:default',
+                        },
+                        'profile_options': {
+                            'version': {
+                                'display_name': 'Version',
+                                'choices': {
+                                    'v1': {
+                                        'display_name': 'v1',
+                                        'default': True,
+                                        'kubespawner_override': {
+                                            'image': 'example_org/testing:v1',
+                                        },
+                                    },
+                                    'v2': {
+                                        'display_name': 'v2',
+                                        'kubespawner_override': {
+                                            'image': 'example_org/testing:v2',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+]
+
+
+async def test_nested_profile_options_initialized():
+    """
+    _get_initialized_profile_list should recursively initialize nested
+    profile_options inside choices.
+    """
+    spawner = KubeSpawner(_mock=True)
+    initialized = spawner._get_initialized_profile_list(NESTED_PROFILE_LIST)
+
+    profile = initialized[0]
+    image_option = profile['profile_options']['image']
+
+    # top-level option gets unlisted_choice initialized
+    assert image_option['unlisted_choice'] == {'enabled': False}
+
+    testing_choice = image_option['choices']['testing']
+    version_option = testing_choice['profile_options']['version']
+
+    # nested option also gets unlisted_choice initialized
+    assert version_option['unlisted_choice'] == {'enabled': False}
+    # nested option's default choice is preserved
+    assert version_option['choices']['v1']['default'] is True
+    assert 'default' not in version_option['choices']['v2']
+
+
+async def test_nested_profile_options_default_choice_applied():
+    """
+    When the parent choice ('testing') is selected but no nested choice is
+    explicitly passed, the nested default ('v1') override should be applied.
+    """
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = NESTED_PROFILE_LIST
+    spawner.user_options = {'profile': 'example', 'image': 'testing'}
+
+    await spawner.load_user_options()
+
+    # The nested default v1 image should win over the parent's default image
+    assert spawner.image == 'example_org/testing:v1'
+
+
+async def test_nested_profile_options_explicit_choice_applied():
+    """
+    When an explicit nested choice ('v2') is passed in user_options, its
+    override should be applied.
+    """
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = NESTED_PROFILE_LIST
+    spawner.user_options = {
+        'profile': 'example',
+        'image': 'testing',
+        'image--testing--version': 'v2',
+    }
+
+    await spawner.load_user_options()
+
+    assert spawner.image == 'example_org/testing:v2'
+
+
+async def test_nested_profile_options_inactive_choice_not_applied():
+    """
+    When a parent choice without nested options ('standard') is selected,
+    nested options from other choices must not contribute to the spawner config.
+    """
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = NESTED_PROFILE_LIST
+    # Select 'standard'; also include a stale nested option that must be ignored
+    spawner.user_options = {
+        'profile': 'example',
+        'image': 'standard',
+        'image--testing--version': 'v2',  # stale / inactive, should be ignored
+    }
+
+    await spawner.load_user_options()
+
+    assert spawner.image == 'example_org/standard:latest'
+
+
+async def test_nested_profile_options_form_roundtrip():
+    """
+    Form data with nested option fields should round-trip correctly through
+    _options_from_form into user_options.
+    """
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = NESTED_PROFILE_LIST
+
+    formdata = {
+        'profile': ['example'],
+        'profile-option-example--image': ['testing'],
+        'profile-option-example--image--testing--version': ['v2'],
+    }
+    user_options = spawner.options_from_form(formdata)
+
+    assert user_options == {
+        'profile': 'example',
+        'image': 'testing',
+        'image--testing--version': 'v2',
+    }
+
+
+async def test_nested_unlisted_choice_validation():
+    """
+    An unlisted_choice value for a nested option should be validated against
+    its validation_regex.
+    """
+    profiles = [
+        {
+            'display_name': 'Test',
+            'slug': 'test',
+            'profile_options': {
+                'image': {
+                    'display_name': 'Image',
+                    'choices': {
+                        'custom': {
+                            'display_name': 'Custom',
+                            'kubespawner_override': {},
+                            'profile_options': {
+                                'tag': {
+                                    'display_name': 'Tag',
+                                    'unlisted_choice': {
+                                        'enabled': True,
+                                        'display_name': 'Custom tag',
+                                        'validation_regex': r'^v\d+$',
+                                        'validation_message': 'Must be vN',
+                                        'kubespawner_override': {
+                                            'image': 'example_org/image:{value}',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    ]
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = profiles
+    spawner.user_options = {
+        'profile': 'test',
+        'image': 'custom',
+        'image--custom--tag--unlisted-choice': 'bad-value',
+    }
+
+    with pytest.raises(ValueError, match="failed validation regex"):
+        await spawner.load_user_options()


### PR DESCRIPTION
## What this adds

`profile_options` choices can now declare their own `profile_options`, recursively.
This enables dependent option flows in the spawn form — e.g. a "GPU type" dropdown
that only exists while the "GPU" choice is selected:

```python
c.KubeSpawner.profile_list = [
    {
        "display_name": "Demo",
        "profile_options": {
            "gpu": {
                "display_name": "GPU setup",
                "choices": {
                    "none": {"display_name": "No GPU", "default": True, "kubespawner_override": {}},
                    "nvidia": {
                        "display_name": "NVIDIA",
                        "kubespawner_override": {"extra_resource_limits": {"nvidia.com/gpu": "1"}},
                        "profile_options": {
                            "type": {
                                "display_name": "GPU type",
                                "choices": {
                                    "t4":   {"display_name": "T4", "default": True,
                                             "kubespawner_override": {"node_selector": {"gpu": "t4"}}},
                                    "a100": {"display_name": "A100",
                                             "kubespawner_override": {"node_selector": {"gpu": "a100"}}},
                                },
                            },
                        },
                    },
                },
            },
        },
    },
]
```
<img width="828" height="478" alt="image" src="https://github.com/user-attachments/assets/0e6d33c2-4e0a-4704-99c0-555b9e3930d8" />


Nesting works to arbitrary depth, and unlisted_choice (including
validation_regex and {value} templating) works at every level.

Native implementation of https://github.com/2i2c-org/jupyterhub-fancy-profiles/pull/148