### PR TITLE
display the singleuser server `start_timeout` during slow spawns

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2784,8 +2784,8 @@ class KubeSpawner(Spawner):
             if start_future and start_future.done():
                 break_while_loop = True
 
-            # if the timer is greater than self.server_spawn_launch_timer_threshold
-            # display a message to the user with an incrementing count in seconds
+            # if the timer is greater than self.slow_spawn_message_threshold display
+            # a message to the user with an incrementing count in seconds
             elapsed = time.perf_counter() - start_time
             if (
                 elapsed >= self.slow_spawn_message_threshold

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1967,7 +1967,7 @@ class KubeSpawner(Spawner):
         help="""
         The injected timing message to display to the user. The variable `{seconds}`
         will be replaced by the number of seconds the spawn has currently taken.
-        The variable `{timeout}` will be replaced by the current spawn timeout setting.
+        The variable `{timeout}` will be replaced by the default `start_timeout` setting.
         """,
     )
 

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -1962,11 +1962,12 @@ class KubeSpawner(Spawner):
     )
 
     slow_spawn_message = Unicode(
-        "Server launch is taking longer than expected. Please be patient! Current time spent waiting: {seconds} seconds.",
+        "Server launch is taking longer than expected. Please be patient! Current time spent waiting: {seconds} seconds. Timeout is currently {timeout} seconds.",
         config=True,
         help="""
         The injected timing message to display to the user. The variable `{seconds}`
         will be replaced by the number of seconds the spawn has currently taken.
+        The variable `{timeout}` will be replaced by the current spawn timeout setting.
         """,
     )
 
@@ -2793,7 +2794,9 @@ class KubeSpawner(Spawner):
                 # don't spam the user, so only update the timer message every few seconds
                 if elapsed >= last_message_time + self.slow_spawn_message_frequency:
                     patience_message = textwrap.dedent(self.slow_spawn_message)
-                    patience_message = patience_message.format(seconds=int(elapsed))
+                    patience_message = patience_message.format(
+                        seconds=int(elapsed), timeout=self.start_timeout
+                    )
                     last_message_time = elapsed
                     yield {
                         'message': patience_message,


### PR DESCRIPTION
### Checklist

- [x] I am the author of this work

### What does this PR do?

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other

### Is this PR related to an issue, or is it part of a larger body of work?

no

### Does this PR introduce a breaking change?

no

### How can this PR be tested?

1. spawn a user on to a node pool w/0 nodes
2. wait >60 seconds
3. profit!

### What should a reviewer concentrate their feedback on?

that's up to the reviewer(s)!  ;)

### Other information

i was testing the latest release (7.1.0) that includes the changes i made to display the slow spawn message to users, and i realized that it'd be great to mirror the functionality i added for my deployments that also displays the timeout.  this way users know that they have to wait at least whatever the default `spawn_timeout` is set to for their pod to finish launching.

i did a bunch of testing on my deployments and it's behaving as expected:

https://github.com/cal-icor/cal-icor-hubs/pull/968#issuecomment-5062729809
https://github.com/cal-icor/cal-icor-hubs/pull/968/changes#diff-c7ff155658f0273e3fd2df49dee1551363b934660d0cb6e169938288442eba05R500

i'm not entire sure that this change deserves a fresh release, but it's super useful.  :)

@minrk @manics @GeorgianaElena 